### PR TITLE
Surface derivative

### DIFF
--- a/src/fitpack.f90
+++ b/src/fitpack.f90
@@ -52,6 +52,7 @@ module fitpack
 
    public :: fitpack_surface
    public :: fitpack_grid_surface
+   public :: fitpack_grid_result
    public :: fitpack_parametric_surface
 
 

--- a/src/fitpack_core.f90
+++ b/src/fitpack_core.f90
@@ -78,6 +78,7 @@ module fitpack_core
     public :: fitpack_argsort
     public :: fitpack_error_handling
     public :: get_smoothing
+    public :: resize_if_less_than
 
     ! Spline behavior for points not in the support
     integer(FP_FLAG), parameter,  public :: OUTSIDE_EXTRAPOLATE = 0 ! extrapolated from the end spans
@@ -162,12 +163,39 @@ module fitpack_core
        end function fitpack_polar_boundary
     end interface
 
+    interface resize_if_less_than
+       module procedure resize_if_less_than_double
+       module procedure resize_if_less_than_integer
+    end interface
+
     interface fitpack_swap
         module procedure swap_data
         module procedure swap_size
     end interface fitpack_swap
 
     contains
+
+      ! routines to get enough working space
+      ! for real and integers
+      subroutine resize_if_less_than_double(v, n)
+         real(FP_REAL), allocatable, intent(inout) :: v(:)
+         integer(FP_SIZE), intent(in) :: n
+         if (allocated(v)) then
+            if (size(v) >= n) return 
+            deallocate(v)
+         endif
+         allocate(v(n))
+      end subroutine
+
+      subroutine resize_if_less_than_integer(v, n)
+         integer(FP_SIZE), allocatable, intent(inout) :: v(:)
+         integer(FP_SIZE), intent(in) :: n
+         if (allocated(v)) then
+            if (size(v) >= n) return 
+            deallocate(v)
+         endif
+         allocate(v(n))
+      end subroutine
 
       ! Flow control: on output flag present, return it;
       ! otherwise, halt on error
@@ -2609,7 +2637,7 @@ module fitpack_core
       !  ..local variables..
       integer(FP_SIZE) :: kx1,ky1,l,l1,m,nkx1,nky1,i,i1,j
       real(FP_REAL) :: arg,sp,tb,te,h(MAX_ORDER+1)
-
+      
       ! X
       kx1  = kx+1
       nkx1 = nx-kx1
@@ -15500,7 +15528,7 @@ module fitpack_core
       end subroutine percur
 
 
-       subroutine pogrid(iopt,ider,mu,u,mv,v,z,z0,r,s, &
+      pure subroutine pogrid(iopt,ider,mu,u,mv,v,z,z0,r,s, &
                              nuest,nvest,nu,tu,nv,tv,c,fp,wrk,lwrk,iwrk,kwrk,ier)
 
       !  subroutine pogrid fits a function f(x,y) to a set of data points

--- a/src/fitpack_core.f90
+++ b/src/fitpack_core.f90
@@ -63,7 +63,7 @@ module fitpack_core
     public :: bispev ! * Evaluation of a bivariate spline function
     public :: parder ! Partial derivatives of a bivariate spline
     public :: pardeu ! Partial derivatives of a bivariate spline
-    public :: pardtc ! Create partial derivative splane of a bivariate spline
+    public :: pardtc ! Create partial derivative spline of a bivariate spline
     public :: dblint ! Integration of a bivariate spline
     public :: profil ! Cross-section of a bivariate spline
     public :: evapol ! * Evaluation of a polar spline

--- a/src/fitpack_gridded_polar.f90
+++ b/src/fitpack_gridded_polar.f90
@@ -18,7 +18,9 @@
 !
 ! **************************************************************************************************
 module fitpack_gridded_polar
-    use fitpack_core
+    use fitpack_core, only: FP_REAL, zero, OUTSIDE_EXTRAPOLATE, IOPT_NEW_SMOOTHING, IOPT_OLD_FIT
+    use fitpack_core, only: IOPT_NEW_LEASTSQUARES, fitpack_error_handling, FITPACK_SUCCESS
+    use fitpack_core, only: bispev,  get_smoothing, pogrid
     implicit none
     private
 

--- a/src/fitpack_gridded_sphere.f90
+++ b/src/fitpack_gridded_sphere.f90
@@ -18,7 +18,9 @@
 !
 ! **************************************************************************************************
 module fitpack_gridded_sphere
-    use fitpack_core
+    use fitpack_core, only: FP_REAL, IOPT_NEW_LEASTSQUARES, zero,  IOPT_NEW_SMOOTHING, IOPT_OLD_FIT
+    use fitpack_core, only: fitpack_error_handling, FITPACK_SUCCESS
+    use fitpack_core, only: bispev, get_smoothing, spgrid
     implicit none
     private
 

--- a/src/fitpack_polar.f90
+++ b/src/fitpack_polar.f90
@@ -18,7 +18,9 @@
 !
 ! **************************************************************************************************
 module fitpack_polar_domains
-    use fitpack_core
+    use fitpack_core, only: FP_REAL, zero, OUTSIDE_EXTRAPOLATE, IOPT_NEW_SMOOTHING, fitpack_error_handling
+    use fitpack_core, only: FITPACK_OK, IOPT_OLD_FIT, IOPT_NEW_LEASTSQUARES, FITPACK_SUCCESS, half, one
+    use fitpack_core, only: fitpack_polar_boundary, get_smoothing, polar, evapol
     implicit none
     private
 

--- a/test/fitpack_test_data.f90
+++ b/test/fitpack_test_data.f90
@@ -172,8 +172,10 @@ module fitpack_test_data
 
 
     ! Regrid test: x,y grid coordinates
-    real(FP_REAL), parameter :: daregr_x(*) = [real(FP_REAL) :: -1.5,-1.2,-0.9,-0.6,-0.3,0.0,0.3,0.6,0.9,1.2,1.5]
-    real(FP_REAL), parameter :: daregr_y(*) = [real(FP_REAL) :: -1.5,-1.2,-0.9,-0.6,-0.3,0.0,0.3,0.6,0.9,1.2,1.5]
+    real(FP_REAL), parameter :: daregr_x(*) = [real(FP_REAL) :: -1.5d0,-1.2d0,-0.9d0,-0.6d0,-0.3d0,0.0,&
+                                   0.3d0,0.6d0,0.9d0,1.2d0,1.5d0]
+    real(FP_REAL), parameter :: daregr_y(*) = [real(FP_REAL) :: -1.5d0,-1.2d0,-0.9d0,-0.6d0,-0.3d0,0.0,&
+                                   0.3d0,0.6d0,0.9d0,1.2d0,1.5d0]
 
     ! Regrid: function values at the grid points
     real(FP_REAL), parameter :: daregr_z(*,*) = reshape([real(FP_REAL) :: &

--- a/test/fitpack_tests.f90
+++ b/test/fitpack_tests.f90
@@ -2904,7 +2904,9 @@ module fitpack_tests
                      nc = (nu-4)*(nv-4)
 
                      ! we calculate the function values at the different points.
-                     forall(i=1:m) f(i) = evapol(tu,nu,tv,nv,c,rad1,x(i),y(i))
+                     do i=1, m 
+                        f(i) = evapol(tu,nu,tv,nv,c,rad1,x(i),y(i))
+                     enddo
                      write(useUnit,925) s
 
                  case (4,5)
@@ -2919,8 +2921,9 @@ module fitpack_tests
                      c = c+0.4
 
                      !  we calculate the function values at the different points.
-                     forall(i=1:m)  f(i) = evapol(tu,nu,tv,nv,c,rad2,x(i),y(i))
-
+                     do i=1,m  
+                        f(i) = evapol(tu,nu,tv,nv,c,rad2,x(i),y(i))
+                     enddo
                      if (iopt(1)<0) then
                         write(useUnit,935)
                      else

--- a/test/test.f90
+++ b/test/test.f90
@@ -55,6 +55,7 @@ program test
         call add_test(test_gridded_polar())
         call add_test(test_gridded_sphere())
         call add_test(test_parametric_surface())
+        call add_test(test_gradient_surface())
 
     end subroutine run_interface_tests
 


### PR DESCRIPTION
I added the possibility to create a derivative of a fitpack_grid_surface. In order to do that I decided to split the original fitpack_grid_surface in two different user defined type, one the original but having eliminated from it the information about the knots. The other one contains the results of the fit or of the interpolation. 
This was necessary because it would be senseless to fit again with the method **fit** or the method **interpolate** the derivative of a spline. 
I think the code is better this way with two separate class, one that is basically a fitter and the other one the is the resulting spline.
We may think of other method that can be applied to a resulting spline. But let's see.
In the way I corrected a bug. The original sizes of the work arrays were calculated in advance and depended on the size of the arrays used in the fitting. But when evaluating a 2D spline the sizes of the work arrays should depend on the size of the x and y arrays where one want the spline calculated. For example if one use to fit a spline with array long NX and NY but want the resulting spline on array long 10*NX and 10*NY, well, the size of the pre-calculated work array is not enough.
So while I keep the work arrays in the fitpack_grid_surface I added other work arrays in fitpack_grid_result. 
I also added some procedure to increase the size of the work arrays when needed.
The could be other things that may be done, like returning the variable ier in the fitpack_grid_result, or change its name or apply the same concept to the other surface splines.
So it is still a work in progress. But I would like your comments.
Cheers  