### PR TITLE
Fix C++ compiler warnings

### DIFF
--- a/include/fitpack_core_c.h
+++ b/include/fitpack_core_c.h
@@ -256,7 +256,7 @@ inline vector<FP_REAL> flatten_2d_vector(const vector<fpPoint>& x2d) {
     for (const auto& p : x2d) ndim = std::max(ndim, static_cast<FP_SIZE>(p.size()));
 
     vector<FP_REAL> x(x2d.size() * ndim, 0.0);
-    for (FP_SIZE i = 0; i < x2d.size(); i++)
+    for (FP_SIZE i = 0; i < static_cast<FP_SIZE>(x2d.size()); i++)
         copy(x2d[i].begin(), x2d[i].end(), x.begin() + i * ndim);
 
     return x;

--- a/include/fitpack_core_c.h
+++ b/include/fitpack_core_c.h
@@ -256,7 +256,7 @@ inline vector<FP_REAL> flatten_2d_vector(const vector<fpPoint>& x2d) {
     for (const auto& p : x2d) ndim = std::max(ndim, static_cast<FP_SIZE>(p.size()));
 
     vector<FP_REAL> x(x2d.size() * ndim, 0.0);
-    for (FP_SIZE i = 0; i < static_cast<FP_SIZE>(x2d.size()); i++)
+    for (FP_SIZE i = 0; i < (FP_SIZE)x2d.size(); i++)
         copy(x2d[i].begin(), x2d[i].end(), x.begin() + i * ndim);
 
     return x;

--- a/include/fpClosedCurve.hpp
+++ b/include/fpClosedCurve.hpp
@@ -83,12 +83,12 @@ class fpClosedCurve
         FP_FLAG interpolate()                         { return fitpack_closed_curve_c_interpolating(&cptr); }
 
         // Fit properties
-        const FP_SIZE degree   () { return fitpack_closed_curve_c_degree(&cptr); };
-        const FP_REAL smoothing() { return fitpack_closed_curve_c_smoothing(&cptr); };
-        const FP_REAL mse      () { return fitpack_closed_curve_c_mse(&cptr); };
-        const FP_SIZE ndim     () { return fitpack_closed_curve_c_idim(&cptr); };
-        const FP_REAL ubegin   () { return fitpack_closed_curve_c_ubegin(&cptr); };
-        const FP_REAL uend     () { return fitpack_closed_curve_c_uend(&cptr); };
+        FP_SIZE degree   () { return fitpack_closed_curve_c_degree(&cptr); };
+        FP_REAL smoothing() { return fitpack_closed_curve_c_smoothing(&cptr); };
+        FP_REAL mse      () { return fitpack_closed_curve_c_mse(&cptr); };
+        FP_SIZE ndim     () { return fitpack_closed_curve_c_idim(&cptr); };
+        FP_REAL ubegin   () { return fitpack_closed_curve_c_ubegin(&cptr); };
+        FP_REAL uend     () { return fitpack_closed_curve_c_uend(&cptr); };
 
         // Get value at u
         fpPoint eval(FP_REAL u, FP_FLAG* ierr=nullptr)
@@ -106,7 +106,7 @@ class fpClosedCurve
             fpPoint y1(fitpack_closed_curve_c_idim(&cptr),0.0);
             vector<fpPoint> y(u.size(),y1);
 
-            for (FP_SIZE i=0; i<u.size(); i++)
+            for (FP_SIZE i=0; i<static_cast<FP_SIZE>(u.size()); i++)
             {
                 y[i] = eval(u[i],&ierr0);
                 if (!FITPACK_SUCCESS_c(ierr0)) break;

--- a/include/fpConstrainedCurve.hpp
+++ b/include/fpConstrainedCurve.hpp
@@ -84,12 +84,12 @@ class fpConstrainedCurve
         FP_FLAG interpolate()                         { return fitpack_constrained_curve_c_interpolating(&cptr); }
 
         // Fit properties
-        const FP_SIZE degree   () { return fitpack_constrained_curve_c_degree(&cptr); };
-        const FP_REAL smoothing() { return fitpack_constrained_curve_c_smoothing(&cptr); };
-        const FP_REAL mse      () { return fitpack_constrained_curve_c_mse(&cptr); };
-        const FP_SIZE ndim     () { return fitpack_constrained_curve_c_idim(&cptr); };
-        const FP_REAL ubegin   () { return fitpack_constrained_curve_c_ubegin(&cptr); };
-        const FP_REAL uend     () { return fitpack_constrained_curve_c_uend(&cptr); };
+        FP_SIZE degree   () { return fitpack_constrained_curve_c_degree(&cptr); };
+        FP_REAL smoothing() { return fitpack_constrained_curve_c_smoothing(&cptr); };
+        FP_REAL mse      () { return fitpack_constrained_curve_c_mse(&cptr); };
+        FP_SIZE ndim     () { return fitpack_constrained_curve_c_idim(&cptr); };
+        FP_REAL ubegin   () { return fitpack_constrained_curve_c_ubegin(&cptr); };
+        FP_REAL uend     () { return fitpack_constrained_curve_c_uend(&cptr); };
 
         // Set constraints, begin point only
         FP_FLAG constrain_begin(vector<fpPoint> ddx_begin)
@@ -136,7 +136,7 @@ class fpConstrainedCurve
             fpPoint y1(fitpack_constrained_curve_c_idim(&cptr),0.0);
             vector<fpPoint> y(u.size(),y1);
 
-            for (FP_SIZE i=0; i<u.size(); i++)
+            for (FP_SIZE i=0; i<static_cast<FP_SIZE>(u.size()); i++)
             {
                 y[i] = eval(u[i],&ierr0);
                 if (!FITPACK_SUCCESS_c(ierr0)) break;

--- a/include/fpCurve.hpp
+++ b/include/fpCurve.hpp
@@ -67,9 +67,9 @@ class fpCurve
         FP_FLAG interpolate(FP_SIZE order)            { return fitpack_curve_c_interpolating(&cptr,&order); }        
         
         // Fit properties
-        const FP_SIZE degree   () { return fitpack_curve_c_degree(&cptr); };
-        const FP_REAL smoothing() { return fitpack_curve_c_smoothing(&cptr); };
-        const FP_REAL mse      () { return fitpack_curve_c_mse(&cptr); };
+        FP_SIZE degree   () { return fitpack_curve_c_degree(&cptr); };
+        FP_REAL smoothing() { return fitpack_curve_c_smoothing(&cptr); };
+        FP_REAL mse      () { return fitpack_curve_c_mse(&cptr); };
 
         // Get value at x
         FP_REAL eval(FP_REAL x, FP_SIZE* ierr=nullptr)

--- a/include/fpParametricCurve.hpp
+++ b/include/fpParametricCurve.hpp
@@ -83,12 +83,12 @@ class fpParametricCurve
         FP_FLAG interpolate(FP_SIZE order)            { return fitpack_parametric_curve_c_interpolating(&cptr,nullptr); }
 
         // Fit properties
-        const FP_SIZE degree   () { return fitpack_parametric_curve_c_degree(&cptr); };
-        const FP_REAL smoothing() { return fitpack_parametric_curve_c_smoothing(&cptr); };
-        const FP_REAL mse      () { return fitpack_parametric_curve_c_mse(&cptr); };
-        const FP_SIZE ndim     () { return fitpack_parametric_curve_c_idim(&cptr); };
-        const FP_REAL ubegin   () const { return fitpack_parametric_curve_c_ubegin(&cptr);} ;
-        const FP_REAL uend     () const { return fitpack_parametric_curve_c_uend(&cptr); };
+        FP_SIZE degree   () { return fitpack_parametric_curve_c_degree(&cptr); };
+        FP_REAL smoothing() { return fitpack_parametric_curve_c_smoothing(&cptr); };
+        FP_REAL mse      () { return fitpack_parametric_curve_c_mse(&cptr); };
+        FP_SIZE ndim     () { return fitpack_parametric_curve_c_idim(&cptr); };
+        FP_REAL ubegin   () const { return fitpack_parametric_curve_c_ubegin(&cptr);} ;
+        FP_REAL uend     () const { return fitpack_parametric_curve_c_uend(&cptr); };
         
         FP_REAL&      ubegin() { return *fitpack_parametric_curve_c_ubegin_ref(&cptr); };
         FP_REAL&      uend()   { return *fitpack_parametric_curve_c_uend_ref(&cptr); };
@@ -111,7 +111,7 @@ class fpParametricCurve
             fpPoint y1(fitpack_parametric_curve_c_idim(&cptr),0.0);
             vector<fpPoint> y(u.size(),y1);
 
-            for (FP_SIZE i=0; i<u.size(); i++)
+            for (FP_SIZE i=0; i<static_cast<FP_SIZE>(u.size()); i++)
             {
                 y[i] = eval(u[i],&ierr0);
                 if (!FITPACK_SUCCESS_c(ierr0)) break;

--- a/include/fpPeriodicCurve.hpp
+++ b/include/fpPeriodicCurve.hpp
@@ -66,9 +66,9 @@ class fpPeriodicCurve
         FP_FLAG interpolate()                         { return fitpack_periodic_curve_c_interpolating(&cptr); }        
         
         // Fit properties
-        const FP_SIZE degree   () { return fitpack_periodic_curve_c_degree(&cptr); };
-        const FP_REAL smoothing() { return fitpack_periodic_curve_c_smoothing(&cptr); };
-        const FP_REAL mse      () { return fitpack_periodic_curve_c_mse(&cptr); };
+        FP_SIZE degree   () { return fitpack_periodic_curve_c_degree(&cptr); };
+        FP_REAL smoothing() { return fitpack_periodic_curve_c_smoothing(&cptr); };
+        FP_REAL mse      () { return fitpack_periodic_curve_c_mse(&cptr); };
 
         // Get value at x
         FP_REAL eval(FP_REAL x, FP_SIZE* ierr=nullptr)


### PR DESCRIPTION
This is PR about issue #28
- Fix sign-compare warning with static_cast
- Remove `const` qualifiers from return types