### PR TITLE
 Add spline behavior management to C/C++ APIs

### DIFF
--- a/include/fitpack_curves_c.h
+++ b/include/fitpack_curves_c.h
@@ -59,6 +59,8 @@ FP_FLAG  fitpack_curve_c_all_derivatives(fitpack_curve_c *self, FP_REAL x, FP_RE
 FP_REAL fitpack_curve_c_smoothing      (fitpack_curve_c *self);
 FP_REAL fitpack_curve_c_mse            (fitpack_curve_c *self);
 FP_SIZE  fitpack_curve_c_degree         (fitpack_curve_c *self);
+void    fitpack_curve_c_set_bc         (fitpack_curve_c *self, FP_FLAG bc);
+FP_FLAG fitpack_curve_c_get_bc         (fitpack_curve_c *self);
 
 #ifdef __cplusplus
 }

--- a/include/fpCurve.hpp
+++ b/include/fpCurve.hpp
@@ -133,6 +133,17 @@ class fpCurve
            return fitpack_curve_c_integral(&cptr, from, to);
         }
 
+        // Set or Get extrapolation behavior
+        void set_bc(FP_FLAG bc)
+        {
+           fitpack_curve_c_set_bc(&cptr, bc);
+        }
+
+        FP_FLAG get_bc()
+        {
+           return fitpack_curve_c_get_bc(&cptr);
+        }
+
         // Get fourier coefficients
         FP_FLAG fourier(const vector<FP_REAL> &alpha,
                               vector<FP_REAL> &A, vector<FP_REAL> &B)

--- a/include/fpCurve.hpp
+++ b/include/fpCurve.hpp
@@ -133,12 +133,13 @@ class fpCurve
            return fitpack_curve_c_integral(&cptr, from, to);
         }
 
-        // Set or Get extrapolation behavior
+        // Set spline behavior outside the support
         void set_bc(FP_FLAG bc)
         {
            fitpack_curve_c_set_bc(&cptr, bc);
         }
 
+        // Get spline behavior outside the support
         FP_FLAG get_bc()
         {
            return fitpack_curve_c_get_bc(&cptr);

--- a/src/fitpack_curves_c.f90
+++ b/src/fitpack_curves_c.f90
@@ -361,7 +361,7 @@ module fitpack_curves_c
 
      end function fitpack_curve_c_degree
 
-     !> Set extrapolation behavior outside interpolation domain
+     !> Set spline behavior outside the support
      subroutine fitpack_curve_c_set_bc(this, bc) bind(c,name='fitpack_curve_c_set_bc')
         type(fitpack_curve_c), intent(inout) :: this
         integer(FP_FLAG), intent(in), value :: bc
@@ -379,7 +379,7 @@ module fitpack_curves_c
 
      end subroutine fitpack_curve_c_set_bc
 
-     !> Get extrapolation behavior outside interpolation domain
+     !> Get spline behavior outside the support
      integer(FP_FLAG) function fitpack_curve_c_get_bc(this) bind(c,name='fitpack_curve_c_get_bc')
         type(fitpack_curve_c), intent(inout) :: this
 

--- a/src/fitpack_curves_c.f90
+++ b/src/fitpack_curves_c.f90
@@ -24,7 +24,8 @@
 ! **************************************************************************************************
 module fitpack_curves_c
      use fitpack_curves, only: fitpack_curve
-     use fitpack_core, only: FP_SIZE, FP_REAL, FP_FLAG, FP_BOOL
+     use fitpack_core, only: FP_SIZE, FP_REAL, FP_FLAG, FP_BOOL, &
+                             OUTSIDE_EXTRAPOLATE, OUTSIDE_ZERO, OUTSIDE_NOT_ALLOWED, OUTSIDE_NEAREST_BND
      use, intrinsic :: iso_c_binding
      implicit none
      private
@@ -48,6 +49,8 @@ module fitpack_curves_c
      public :: fitpack_curve_c_smoothing
      public :: fitpack_curve_c_mse
      public :: fitpack_curve_c_degree
+     public :: fitpack_curve_c_set_bc
+     public :: fitpack_curve_c_get_bc
 
      !> Opaque-pointer C derived type
      type, public, bind(C) :: fitpack_curve_c
@@ -357,6 +360,37 @@ module fitpack_curves_c
         fitpack_curve_c_degree = fcurve%order
 
      end function fitpack_curve_c_degree
+
+     !> Set extrapolation behavior outside interpolation domain
+     subroutine fitpack_curve_c_set_bc(this, bc) bind(c,name='fitpack_curve_c_set_bc')
+        type(fitpack_curve_c), intent(inout) :: this
+        integer(FP_FLAG), intent(in), value :: bc
+
+        type(fitpack_curve), pointer :: fcurve
+
+        !> Get object; allocate it in case
+        call fitpack_curve_c_pointer(this,fcurve)
+
+        !> Validate extrapolation behavior value
+        if (bc /= OUTSIDE_EXTRAPOLATE .and. bc /= OUTSIDE_ZERO .and. &
+            bc /= OUTSIDE_NOT_ALLOWED .and. bc /= OUTSIDE_NEAREST_BND) return
+
+        fcurve%bc = bc
+
+     end subroutine fitpack_curve_c_set_bc
+
+     !> Get extrapolation behavior outside interpolation domain
+     integer(FP_FLAG) function fitpack_curve_c_get_bc(this) bind(c,name='fitpack_curve_c_get_bc')
+        type(fitpack_curve_c), intent(inout) :: this
+
+        type(fitpack_curve), pointer :: fcurve
+
+        !> Get object; allocate it in case
+        call fitpack_curve_c_pointer(this,fcurve)
+
+        fitpack_curve_c_get_bc = fcurve%bc
+
+     end function fitpack_curve_c_get_bc
 
 
 end module fitpack_curves_c


### PR DESCRIPTION
# Motivation
Many thanks to the maintainers and contributors for keeping this project active and useful.

I would like to make it possible to modify the `bc` variable of the `fitpack_curve` class from the C/C++ interface.
When using it from Fortran, we can directly update the variable inside the structure, for example:
```fortran
type(fitpack_curve) :: fp_curve
fp_curve%bc = OUTSIDE_EXTRAPOLATE
```
On the other hand, when using the corresponding `fpCurve` class in the C++ header fpCurve.hpp, there currently seems to be no method available to modify the `bc` variable from the C++ side.
Therefore, I implemented the following modification.

# Changes
  - Add fitpack_curve_c_set_bc/get_bc functions to C interface
  - Add set_bc/get_bc methods to C++ wrapper
  - Expose existing Fortran boundary condition controls to C/C++ users

# Verification
I verified the implementation in C++ using include/fpCurve.hpp.
First, I generated 100 sample points in the range −2≤x≤2 from the shape of the original function, and created a cubic spline interpolation curve based on them.
Next, I evaluated the spline function including values of x outside the range −2≤x≤2, and the results are shown in the figure.
It was confirmed that the behavior changes depending on the value of the `bc` variable.

<img width="1775" height="1173" alt="image" src="https://github.com/user-attachments/assets/bcf06a24-3861-402a-b374-bc2dd0cf141a" />

## Test code
The following C++ test code was used to generate the attached figure.
```c++
#include "../include/fitpack.hpp"
#include <cmath>
#include <vector>
#include <iostream>
#include <fstream>
#include <string>

int main(void)
{
    static const int N = 101;
    FP_FLAG ierr = FITPACK_OK;

    // Create test data - cubic function
    vector<FP_REAL> x; x.reserve(N);
    vector<FP_REAL> y; y.reserve(N);
    for (int i = 0; i < N; i++)
    {
        x.push_back(static_cast<FP_REAL>(i) / (N-1) * 4.0 - 2.0); // [-2, 2]
        y.push_back(x[i]*x[i]*x[i] - 2*x[i]*x[i] + x[i] + 1); // cubic function
    }

    // Test different extrapolation behaviors outside domain
    vector<FP_FLAG> bc_values = {OUTSIDE_EXTRAPOLATE, OUTSIDE_ZERO, OUTSIDE_NOT_ALLOWED, OUTSIDE_NEAREST_BND};
    vector<std::string> bc_names = {"extrapolate", "zero", "not_allowed", "nearest_boundary"};

    // Output file for Python plotting
    std::ofstream outfile("boundary_test_results.csv");
    outfile << "x,y_original";
    for (size_t bc_idx = 0; bc_idx < bc_values.size(); bc_idx++) {
        outfile << ",y_bc" << bc_values[bc_idx];
    }
    outfile << "\n";

    // Generate evaluation points including outside domain [-2, 2] -> [-3, 3]
    vector<FP_REAL> x_eval;
    const int N_eval = 400;
    for (int i = 0; i < N_eval; i++) {
        x_eval.push_back(-3.0 + static_cast<FP_REAL>(i) / (N_eval-1) * 6.0); // [-3, 3]
    }

    // Store results for each boundary condition
    vector<vector<FP_REAL>> results;

    for (size_t bc_idx = 0; bc_idx < bc_values.size(); bc_idx++) {
        std::cout << "Testing extrapolation behavior: " << bc_names[bc_idx]
                  << " (value=" << bc_values[bc_idx] << ")" << std::endl;

        // Create curve with smoothing
        fpCurve curve;
        ierr = curve.new_fit(x, y, 100.0); // Some smoothing
        if (!FITPACK_SUCCESS_c(ierr)) {
            std::cout << "Error creating curve: " << ierr << std::endl;
            continue;
        }
        // Verify extrapolation condition was set
        FP_FLAG retrieved_bc = curve.get_bc();
        std::cout << "Set BC: " << bc_values[bc_idx] << ", Retrieved BC: " << retrieved_bc << std::endl;

        // Set extrapolation behavior after fitting
        curve.set_bc(bc_values[bc_idx]);

        curve.interpolate();

        // Evaluate curve
        vector<FP_REAL> y_eval = curve.eval(x_eval);
        results.push_back(y_eval);

        std::cout << "Curve properties - Degree: " << curve.degree()
                  << ", MSE: " << curve.mse()
                  << ", BC : " << curve.get_bc()
                  << ", Smoothing: " << curve.smoothing() << std::endl;
    }

    // Write results to CSV
    for (int i = 0; i < N_eval; i++) {
        outfile << x_eval[i] << "," << (x_eval[i]*x_eval[i]*x_eval[i] - 2*x_eval[i]*x_eval[i] + x_eval[i] + 1);
        for (size_t bc_idx = 0; bc_idx < results.size(); bc_idx++) {
            outfile << "," << results[bc_idx][i];
        }
        outfile << "\n";
    }

    outfile.close();
    std::cout << "Results written to boundary_test_results.csv" << std::endl;

    return 0;
}
```