### PR TITLE
Pure evaluation routines and parallel communication support

### DIFF
--- a/src/fitpack_core.f90
+++ b/src/fitpack_core.f90
@@ -19,7 +19,6 @@
 ! **************************************************************************************************
 module fitpack_core
     use iso_c_binding, only: c_double,c_int32_t,c_bool
-    use iso_fortran_env, only: real64, int32
     implicit none
     private
 

--- a/src/fitpack_core.f90
+++ b/src/fitpack_core.f90
@@ -18833,11 +18833,14 @@ module fitpack_core
         real(FP_REAL), allocatable, intent(in) :: array(:,:)
         real(FP_COMM), intent(out) :: buffer(:)
 
-        integer(FP_SIZE) :: bnd(2, 2), ndoubles, d
+        integer(FP_SIZE) :: bnd(2, 2), ndoubles
         integer(FP_SIZE), parameter :: header = 2
 
         if (allocated(array)) then
-            forall (d = 1:2) bnd(:, d) = [lbound(array, d, FP_SIZE), ubound(array, d, FP_SIZE)]
+            bnd(1, 1) = lbound(array, 1, FP_SIZE)
+            bnd(2, 1) = ubound(array, 1, FP_SIZE)
+            bnd(1, 2) = lbound(array, 2, FP_SIZE)
+            bnd(2, 2) = ubound(array, 2, FP_SIZE)
         else
             bnd = FP_NOT_ALLOC
         end if

--- a/src/fitpack_core.f90
+++ b/src/fitpack_core.f90
@@ -18909,7 +18909,7 @@ module fitpack_core
     !> Expand communication buffer into 1D integer(FP_SIZE) allocatable array
     pure subroutine FP_SIZE_COMM_EXPAND_1D(array, buffer)
         integer(FP_SIZE), allocatable, intent(out) :: array(:)
-        real(FP_REAL), intent(in) :: buffer(:)
+        real(FP_COMM), intent(in) :: buffer(:)
 
         integer(FP_SIZE) :: bnd(2), ndoubles
         integer(FP_SIZE), parameter :: header = 1

--- a/src/fitpack_curves.f90
+++ b/src/fitpack_curves.f90
@@ -651,18 +651,18 @@ module fitpack_curves
     !> Pack curve data into communication buffer
     pure subroutine curve_comm_pack(this, buffer)
         class(fitpack_curve), intent(in) :: this
-        real(FP_REAL), intent(out) :: buffer(:)
+        real(FP_COMM), intent(out) :: buffer(:)
 
         integer(FP_SIZE) :: pos, n
 
         ! Pack scalar integers as reals
-        buffer(1)  = real(this%m, FP_REAL)
-        buffer(2)  = real(this%order, FP_REAL)
-        buffer(3)  = real(this%knots, FP_REAL)
-        buffer(4)  = real(this%bc, FP_REAL)
-        buffer(5)  = real(this%iopt, FP_REAL)
-        buffer(6)  = real(this%nest, FP_REAL)
-        buffer(7)  = real(this%lwrk, FP_REAL)
+        buffer(1)  = real(this%m, FP_COMM)
+        buffer(2)  = real(this%order, FP_COMM)
+        buffer(3)  = real(this%knots, FP_COMM)
+        buffer(4)  = real(this%bc, FP_COMM)
+        buffer(5)  = real(this%iopt, FP_COMM)
+        buffer(6)  = real(this%nest, FP_COMM)
+        buffer(7)  = real(this%lwrk, FP_COMM)
         buffer(8)  = this%xleft
         buffer(9)  = this%xright
         buffer(10) = this%smoothing
@@ -685,7 +685,7 @@ module fitpack_curves
     !> Expand curve data from communication buffer
     pure subroutine curve_comm_expand(this, buffer)
         class(fitpack_curve), intent(inout) :: this
-        real(FP_REAL), intent(in) :: buffer(:)
+        real(FP_COMM), intent(in) :: buffer(:)
 
         integer(FP_SIZE) :: pos
 

--- a/test/test.f90
+++ b/test/test.f90
@@ -56,6 +56,7 @@ program test
         call add_test(test_gridded_sphere())
         call add_test(test_parametric_surface())
         call add_test(test_fpknot_crash())
+        call add_test(test_curve_comm_roundtrip())
 
     end subroutine run_interface_tests
 


### PR DESCRIPTION
## Summary

- Add `pure` curve evaluation routines that return NaN on error instead of using error handling, enabling use in parallel contexts
- Make `dfdx_all` (all derivatives) routine `pure` with the same NaN-on-error approach
- Implement parallel communication utilities (`comm_size`, `comm_pack`, `comm_expand`) for serializing/deserializing curve objects into MPI-compatible buffers

## Test plan

- [x] Build with fpm and run existing tests
- [x] Test pack/expand round-trip preserves curve data
