### PR TITLE
Workaround for GCC 15 bug #120163 with abstract interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        toolchain: 
+        toolchain:
           - {compiler: gcc, version: 9}
           - {compiler: gcc, version: 10}
           - {compiler: gcc, version: 11}
           - {compiler: gcc, version: 12}
           - {compiler: gcc, version: 13}
           - {compiler: gcc, version: 14}
+          # - {compiler: gcc, version: 15}  # Not yet available on ubuntu-latest
           - {compiler: intel, version: '2023.2'}
           - {compiler: intel, version: '2024.0'}
           - {compiler: intel, version: '2025.0'}          

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -166,7 +166,7 @@ module fitpack_core
 
     abstract interface
        ! Function defining the boundary of the curve approximation domain
-       pure real(FP_REAL) function fitpack_polar_boundary(theta) result(rad)
+       pure real(FP_REAL) function fitpack_polar_boundary(theta)
           import FP_REAL
           real(FP_REAL), intent(in) :: theta
        end function fitpack_polar_boundary
@@ -2018,7 +2018,17 @@ module fitpack_core
       !  ..array arguments..
       real(FP_REAL),    intent(in) :: tu(nu),tv(nv),c((nu-4)*(nv-4))
       !  ..user specified function
+#if defined(__GFORTRAN__) && __GNUC__ == 15
+      ! GCC 15 bug #120163: use inline interface instead of procedure(fitpack_polar_boundary)
+      interface
+         pure real(FP_REAL) function rad(theta)
+            import FP_REAL
+            real(FP_REAL), intent(in) :: theta
+         end function rad
+      end interface
+#else
       procedure(fitpack_polar_boundary) :: rad
+#endif
 
       !  ..local scalars..
       integer(FP_FLAG) :: ier
@@ -10131,7 +10141,17 @@ module fitpack_core
                                     cs(nvest),cosi(5,nvest),a(ncc,ib1),q(ncc,ib3),bu(nuest,5),bv(nvest,5),spu(m,4), &
                                     spv(m,4),h(ib3),wrk(lwrk)
       !  ..user supplied function..
+#if defined(__GFORTRAN__) && __GNUC__ == 15
+      ! GCC 15 bug #120163: use inline interface instead of procedure(fitpack_polar_boundary)
+      interface
+         pure real(FP_REAL) function rad(theta)
+            import FP_REAL
+            real(FP_REAL), intent(in) :: theta
+         end function rad
+      end interface
+#else
       procedure(fitpack_polar_boundary) :: rad
+#endif
       !  ..local scalars..
       real(FP_REAL) :: acc,arg,co,c1,c2,c3,c4,dmax,eps,fac,fac1,fac2,fpmax,fpms,f1,f2,f3,huj,p,pinv,piv,p1,p2,p3, &
                      r,ratio,si,sigma,sq,store,uu,u2,u3,wi,zi,rn
@@ -16297,7 +16317,17 @@ module fitpack_core
       integer(FP_SIZE), intent(in)    :: iopt(3)
       integer(FP_SIZE), intent(inout) :: iwrk(kwrk)
       !  ..user specified function
+#if defined(__GFORTRAN__) && __GNUC__ == 15
+      ! GCC 15 bug #120163: use inline interface instead of procedure(fitpack_polar_boundary)
+      interface
+         pure real(FP_REAL) function rad(theta)
+            import FP_REAL
+            real(FP_REAL), intent(in) :: theta
+         end function rad
+      end interface
+#else
       procedure(fitpack_polar_boundary) :: rad
+#endif
       !  ..local scalars..
       real(FP_REAL) :: dist,r
       integer(FP_SIZE) :: i,ib1,ib3,ki,kn,kwest,la,lbu,lcc,lcs,lro,lbv,lco,lf,lff,lfp,lh,lq,lsu,lsv,lwest,&

--- a/src/fitpack_core_c.f90
+++ b/src/fitpack_core_c.f90
@@ -277,8 +277,15 @@ module fitpack_core_c
           integer(FP_SIZE), intent(in)        :: iopt(3)
           integer(FP_SIZE), intent(inout)     :: iwrk(kwrk)
           procedure(fitpack_polar_boundary), pointer :: frad
-          
+
           call c_f_procpointer(rad,frad)
+
+          ! Check for null function pointer
+          if (.not.associated(frad)) then
+              ier = FITPACK_INPUT_ERROR
+              return
+          end if
+
           call polar(iopt,m,x,y,z,w,frad,s,nuest,nvest,eps,nu,tu,nv,tv,u,v,c,&
                               fp,wrk1,lwrk1,wrk2,lwrk2,iwrk,kwrk,ier)
 

--- a/test/test.f90
+++ b/test/test.f90
@@ -49,6 +49,7 @@ program test
         call add_test(test_parametric_fit())
         call add_test(test_closed_fit())
         call add_test(test_polar_fit())
+        call add_test(test_polar_boundary())
         call add_test(test_sphere_fit())
         call add_test(test_constrained_curve())
         call add_test(test_gridded_fit())


### PR DESCRIPTION
## Summary

- GCC 15 incorrectly validates pure function dummy procedure arguments when using `procedure(abstract_interface)` syntax, causing: `Argument '_formal_N' of pure function 'rad' must be INTENT(IN) or VALUE`
- Use preprocessor guards (`#if defined(__GFORTRAN__) && __GNUC__ == 15`) to conditionally replace `procedure(fitpack_polar_boundary) :: rad` with inline interface blocks in `evapol`, `fppola`, and `polar` routines
- Add null pointer check in `polar_c` for C function pointer argument
- Add `test_polar_boundary` with cardioid and rose curve domains to test the abstract interface

## Test plan

- [x] All 49 tests pass with GCC 15.1.0
- [x] New `test_polar_boundary` exercises the abstract interface with custom boundary functions

## References

- [GCC Bug #120163](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120163): [15/16 Regression] Cannot import module containing call to pure routine via abstract interface