### PR TITLE
Core refactoring #2: fp_rotate_row_vec for Variant B sites

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,12 @@
   "permissions": {
     "allow": [
       "Bash(git branch:*)",
-      "Bash(git mv:*)"
+      "Bash(git mv:*)",
+      "Bash(fpm test:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git push:*)"
     ],
     "deny": [],
     "ask": []

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 build/*
 project/bin/*
 project/obj/*
+docs/book
+docs/papers
 exact_grid
 loop_1
 loop_2


### PR DESCRIPTION
## Summary

- Add `fp_rotate_row_vec` subroutine for vector-RHS Givens rotations, using explicit-shape arrays `h(band)`, `a(nest,*)`, `xi(idim)`, `z(n,idim)`
- Replace 3 standard Variant B call sites in `fpclos`, `fpcons`, `fppara`
- Remove unused variables `i1`, `i3` from `fpcons` and `fppara`
- Update refactoring plan: mark PRs 3-5 complete, renumber remaining PRs

## Test plan

- [x] `fpm build --flag "-Wall"` — clean, no warnings
- [x] `fpm test` — 49 passed, 0 failed

## Deferred

4 shifting-pivot Variant B/C sites (different pattern) are left for a future PR.