### PR TITLE
Public API cleanup: umbrella module re-exports and missing methods

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,10 @@
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git checkout:*)",
-      "Bash(git push:*)"
+      "Bash(git push:*)",
+      "Bash(grep:*)",
+      "Bash(fpm build:*)",
+      "Bash(git status:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/fitpack.f90
+++ b/src/fitpack.f90
@@ -32,12 +32,13 @@ module fitpack
    implicit none
    private
 
-   ! Public interface
+   ! Public interface: kind parameters
    public :: FP_REAL
    public :: FP_SIZE
    public :: FP_FLAG
    public :: FP_BOOL
 
+   ! Public interface: types
    public :: fitpack_curve
    public :: fitpack_closed_curve
    public :: fitpack_periodic_curve
@@ -53,6 +54,25 @@ module fitpack
    public :: fitpack_surface
    public :: fitpack_grid_surface
    public :: fitpack_parametric_surface
+
+   ! Public interface: boundary behavior flags
+   public :: OUTSIDE_EXTRAPOLATE, OUTSIDE_ZERO, OUTSIDE_NOT_ALLOWED, OUTSIDE_NEAREST_BND
+
+   ! Public interface: fitting state flags
+   public :: IOPT_NEW_LEASTSQUARES, IOPT_NEW_SMOOTHING, IOPT_OLD_FIT
+
+   ! Public interface: error flags
+   public :: FITPACK_OK, FITPACK_INTERPOLATING_OK, FITPACK_LEASTSQUARES_OK
+   public :: FITPACK_INSUFFICIENT_STORAGE, FITPACK_S_TOO_SMALL, FITPACK_MAXIT
+   public :: FITPACK_TOO_MANY_KNOTS, FITPACK_OVERLAPPING_KNOTS, FITPACK_INVALID_RANGE
+   public :: FITPACK_INPUT_ERROR, FITPACK_TEST_ERROR
+   public :: FITPACK_INVALID_CONSTRAINT, FITPACK_INSUFFICIENT_KNOTS
+
+   ! Public interface: error utility functions
+   public :: FITPACK_SUCCESS, FITPACK_MESSAGE, IOPT_MESSAGE
+
+   ! Public interface: named constants
+   public :: zero, one, half, pi
 
 
 end module fitpack

--- a/src/fitpack_curves.f90
+++ b/src/fitpack_curves.f90
@@ -81,8 +81,9 @@ module fitpack_curves
            procedure :: new_fit
 
            !> Generate/update fitting curve, with optional smoothing
-           procedure :: fit         => curve_fit_automatic_knots
-           procedure :: interpolate => interpolating_curve
+           procedure :: fit           => curve_fit_automatic_knots
+           procedure :: interpolate   => interpolating_curve
+           procedure :: least_squares => curve_fit_least_squares
 
            !> Evaluate curve at given coordinates
            procedure, private :: curve_eval_one
@@ -362,6 +363,13 @@ module fitpack_curves
         ierr = curve_fit_automatic_knots(this,smoothing=zero,order=order)
 
     end function interpolating_curve
+
+    ! Least-squares curve fit with current knots
+    integer(FP_FLAG) function curve_fit_least_squares(this) result(ierr)
+        class(fitpack_curve), intent(inout) :: this
+        this%iopt = IOPT_NEW_LEASTSQUARES
+        ierr = this%fit()
+    end function curve_fit_least_squares
 
     ! Curve fitting driver: automatic number of knots
     integer(FP_FLAG) function curve_fit_automatic_knots(this,smoothing,order) result(ierr)

--- a/src/fitpack_grid_surfaces.f90
+++ b/src/fitpack_grid_surfaces.f90
@@ -92,6 +92,9 @@ module fitpack_grid_surfaces
            generic   :: dfdx => gridded_derivatives_one,gridded_derivatives_many
            generic   :: dfdx_ongrid => gridded_derivatives_gridded
 
+           !> Properties: MSE
+           procedure, non_overridable :: mse => gridsurf_error
+
     end type fitpack_grid_surface
 
     interface fitpack_grid_surface
@@ -457,5 +460,11 @@ module fitpack_grid_surfaces
         f  = z1(1)
 
     end function gridded_derivatives_one
+
+    ! Return fitting MSE
+    elemental real(FP_REAL) function gridsurf_error(this)
+       class(fitpack_grid_surface), intent(in) :: this
+       gridsurf_error = this%fp
+    end function gridsurf_error
 
 end module fitpack_grid_surfaces

--- a/src/fitpack_gridded_polar.f90
+++ b/src/fitpack_gridded_polar.f90
@@ -102,6 +102,9 @@ module fitpack_gridded_polar
            procedure, private :: gridded_eval_many
            generic :: eval => gridded_eval_one,gridded_eval_many
 
+           !> Properties: MSE
+           procedure, non_overridable :: mse => gridpolar_error
+
            !> Write to disk
            procedure :: write => gridded_to_disk
 
@@ -388,5 +391,11 @@ module fitpack_gridded_polar
            end function numbered
 
     end subroutine gridded_to_disk
+
+    ! Return fitting MSE
+    elemental real(FP_REAL) function gridpolar_error(this)
+       class(fitpack_grid_polar), intent(in) :: this
+       gridpolar_error = this%fp
+    end function gridpolar_error
 
 end module fitpack_gridded_polar

--- a/src/fitpack_gridded_sphere.f90
+++ b/src/fitpack_gridded_sphere.f90
@@ -95,6 +95,9 @@ module fitpack_gridded_sphere
            procedure, private :: gridded_eval_many
            generic :: eval => gridded_eval_one,gridded_eval_many
 
+           !> Properties: MSE
+           procedure, non_overridable :: mse => gridsphere_error
+
            !> Write to disk
            procedure :: write => gridded_to_disk
 
@@ -395,5 +398,11 @@ module fitpack_gridded_sphere
            end function numbered
 
     end subroutine gridded_to_disk
+
+    ! Return fitting MSE
+    elemental real(FP_REAL) function gridsphere_error(this)
+       class(fitpack_grid_sphere), intent(in) :: this
+       gridsphere_error = this%fp
+    end function gridsphere_error
 
 end module fitpack_gridded_sphere

--- a/src/fitpack_polar.f90
+++ b/src/fitpack_polar.f90
@@ -103,6 +103,9 @@ module fitpack_polar_domains
            procedure, private :: polr_eval_many
            generic :: eval => polr_eval_one,polr_eval_many
 
+           !> Properties: MSE
+           procedure, non_overridable :: mse => polar_error
+
     end type fitpack_polar
 
     interface fitpack_polar
@@ -341,5 +344,11 @@ module fitpack_polar_domains
         polr_new_fit = this%fit(smoothing)
 
     end function polr_new_fit
+
+    ! Return fitting MSE
+    elemental real(FP_REAL) function polar_error(this)
+       class(fitpack_polar), intent(in) :: this
+       polar_error = this%fp
+    end function polar_error
 
 end module fitpack_polar_domains

--- a/src/fitpack_spheres.f90
+++ b/src/fitpack_spheres.f90
@@ -84,6 +84,9 @@ module fitpack_sphere_domains
            procedure, private :: sphere_eval_many
            generic :: eval => sphere_eval_one,sphere_eval_many
 
+           !> Properties: MSE
+           procedure, non_overridable :: mse => sphere_error
+
     end type fitpack_sphere
 
     interface fitpack_sphere
@@ -301,5 +304,11 @@ module fitpack_sphere_domains
         sphere_new_fit = this%fit(smoothing)
 
     end function sphere_new_fit
+
+    ! Return fitting MSE
+    elemental real(FP_REAL) function sphere_error(this)
+       class(fitpack_sphere), intent(in) :: this
+       sphere_error = this%fp
+    end function sphere_error
 
 end module fitpack_sphere_domains

--- a/test/test.f90
+++ b/test/test.f90
@@ -58,6 +58,7 @@ program test
         call add_test(test_parametric_surface())
         call add_test(test_fpknot_crash())
         call add_test(test_curve_comm_roundtrip())
+        call add_test(test_umbrella_api())
 
     end subroutine run_interface_tests
 


### PR DESCRIPTION
## Summary

- Re-export constants, error flags, fitting flags, and utility functions from the `fitpack` umbrella module so users only need `use fitpack`
- Add `eval`/`eval_ongrid` to `fitpack_surface` (scattered via `bispeu`, grid via `bispev`)
- Add `interpolate`/`least_squares` to `fitpack_surface` and `least_squares` to `fitpack_curve`
- Add `mse` to all 6 surface/polar/sphere types that were missing it

## Test plan

- [x] `fpm build` compiles cleanly
- [x] `fpm test` — all 50 tests pass (16 interface + 29 legacy + 5 C++)
- [x] New `test_umbrella_api` verifies constants, eval, eval_ongrid, mse, interpolate, least_squares all work through `use fitpack`