### PR TITLE
Add least_squares, reset_knots, keep_knots across all fitter types

### DIFF
--- a/docs/refactoring/04_oop_interface_analysis.md
+++ b/docs/refactoring/04_oop_interface_analysis.md
@@ -223,7 +223,7 @@ that serializes all allocatable components).
 
 # PR Plans
 
-## PR A: Public API Cleanup & Umbrella Module
+## PR A: Public API Cleanup & Umbrella Module (DONE)
 
 **Goal**: Make the `fitpack` umbrella module self-sufficient — users should never need
 `use fitpack_core` directly.
@@ -270,9 +270,9 @@ A user writing `curve%bc = OUTSIDE_EXTRAPOLATE` must also `use fitpack_core`. Si
 
 ---
 
-## PR B: Abstract Base Type
+## PR B: Abstract Base Type (DONE — PR #41)
 
-**Goal**: Extract shared state and logic into an abstract `fitpack_spline` base type that
+**Goal**: Extract shared state and logic into an abstract `fitpack_fitter` base type that
 all 9 concrete types extend.
 
 ### Design

--- a/project/fitpack.cbp
+++ b/project/fitpack.cbp
@@ -90,6 +90,7 @@
 		<Unit filename="../src/fitpack_constrained_c.f90">
 			<Option weight="0" />
 		</Unit>
+		<Unit filename="../src/fitpack_core.F90" />
 		<Unit filename="../src/fitpack_core.f90">
 			<Option weight="0" />
 		</Unit>
@@ -102,6 +103,7 @@
 		<Unit filename="../src/fitpack_curves_c.f90">
 			<Option weight="0" />
 		</Unit>
+		<Unit filename="../src/fitpack_fitters.f90" />
 		<Unit filename="../src/fitpack_grid_surfaces.f90">
 			<Option weight="0" />
 		</Unit>

--- a/src/fitpack_grid_surfaces.f90
+++ b/src/fitpack_grid_surfaces.f90
@@ -94,8 +94,20 @@ module fitpack_grid_surfaces
     contains
 
     ! Fit a surface to least squares of the current knots
-    integer function surface_fit_least_squares(this) result(ierr)
+    integer function surface_fit_least_squares(this,smoothing,reset_knots) result(ierr)
        class(fitpack_grid_surface), intent(inout) :: this
+       real(FP_REAL), optional, intent(in) :: smoothing
+       logical, optional, intent(in) :: reset_knots
+
+       logical :: do_reset
+
+       ! Optionally recompute knots via a smoothing fit first
+       do_reset = .false.; if (present(reset_knots)) do_reset = reset_knots
+       if (do_reset) then
+           this%iopt = IOPT_NEW_SMOOTHING
+           ierr = this%fit(smoothing)
+           if (.not.FITPACK_SUCCESS(ierr)) return
+       end if
 
        this%iopt = IOPT_NEW_LEASTSQUARES
        ierr = this%fit()
@@ -103,28 +115,35 @@ module fitpack_grid_surfaces
     end function surface_fit_least_squares
 
     ! Find interpolating surface
-    integer function surface_fit_interpolating(this) result(ierr)
+    integer function surface_fit_interpolating(this,reset_knots) result(ierr)
         class(fitpack_grid_surface), intent(inout) :: this
+        logical, optional, intent(in) :: reset_knots
 
-        ! Set zero smoothing
-        ierr = surface_fit_automatic_knots(this,smoothing=zero)
+        logical :: do_reset
+
+        do_reset = .true.; if (present(reset_knots)) do_reset = reset_knots
+        if (do_reset) this%iopt = IOPT_NEW_SMOOTHING
+        ierr = surface_fit_automatic_knots(this,smoothing=zero,keep_knots=.not.do_reset)
 
     end function surface_fit_interpolating
 
 
     ! Fit a surface z = s(x,y) defined on a meshgrid: x[1:n], y[1:m]
-    integer(FP_FLAG) function surface_fit_automatic_knots(this,smoothing,order) result(ierr)
+    integer(FP_FLAG) function surface_fit_automatic_knots(this,smoothing,order,keep_knots) result(ierr)
         class(fitpack_grid_surface), intent(inout) :: this
         real(FP_REAL), optional, intent(in) :: smoothing
         integer, optional, intent(in) :: order
+        logical, optional, intent(in) :: keep_knots
 
         integer(FP_SIZE) :: loop,nit
         real(FP_REAL) :: smooth_now(3)
+        logical :: do_guard
 
         call get_smoothing(this%smoothing,smoothing,nit,smooth_now)
 
-        !> Ensure we start with new knots
-        if (this%iopt==IOPT_OLD_FIT) this%iopt = IOPT_NEW_SMOOTHING
+        !> Ensure we start with new knots (unless caller wants to keep them)
+        do_guard = .true.; if (present(keep_knots)) do_guard = .not.keep_knots
+        if (do_guard .and. this%iopt==IOPT_OLD_FIT) this%iopt = IOPT_NEW_SMOOTHING
 
         ! User may want to change the order for both x and y
         if (present(order)) this%order = order

--- a/src/fitpack_gridded_polar.f90
+++ b/src/fitpack_gridded_polar.f90
@@ -106,8 +106,20 @@ module fitpack_gridded_polar
     contains
 
     ! Fit a surface to least squares of the current knots
-    integer function polr_fit_least_squares(this) result(ierr)
+    integer function polr_fit_least_squares(this,smoothing,reset_knots) result(ierr)
        class(fitpack_grid_polar), intent(inout) :: this
+       real(FP_REAL), optional, intent(in) :: smoothing
+       logical, optional, intent(in) :: reset_knots
+
+       logical :: do_reset
+
+       ! Optionally recompute knots via a smoothing fit first
+       do_reset = .false.; if (present(reset_knots)) do_reset = reset_knots
+       if (do_reset) then
+           this%iopt = IOPT_NEW_SMOOTHING
+           ierr = this%fit(smoothing)
+           if (.not.FITPACK_SUCCESS(ierr)) return
+       end if
 
        this%iopt = IOPT_NEW_LEASTSQUARES
        ierr = this%fit()
@@ -115,27 +127,34 @@ module fitpack_gridded_polar
     end function polr_fit_least_squares
 
     ! Find interpolating surface
-    integer function polr_fit_interpolating(this) result(ierr)
+    integer function polr_fit_interpolating(this,reset_knots) result(ierr)
         class(fitpack_grid_polar), intent(inout) :: this
+        logical, optional, intent(in) :: reset_knots
 
-        ! Set zero smoothing
-        ierr = polr_fit_automatic_knots(this,smoothing=zero)
+        logical :: do_reset
+
+        do_reset = .true.; if (present(reset_knots)) do_reset = reset_knots
+        if (do_reset) this%iopt = IOPT_NEW_SMOOTHING
+        ierr = polr_fit_automatic_knots(this,smoothing=zero,keep_knots=.not.do_reset)
 
     end function polr_fit_interpolating
 
 
     ! Fit a surface z = s(x,y) defined on a meshgrid: x[1:n], y[1:m]
-    integer function polr_fit_automatic_knots(this,smoothing) result(ierr)
+    integer function polr_fit_automatic_knots(this,smoothing,keep_knots) result(ierr)
         class(fitpack_grid_polar), intent(inout) :: this
         real(FP_REAL), optional, intent(in) :: smoothing
+        logical, optional, intent(in) :: keep_knots
 
         integer :: loop,nit,iopt(3),ider(2)
         real(FP_REAL) :: smooth_now(3)
+        logical :: do_guard
 
         call get_smoothing(this%smoothing,smoothing,nit,smooth_now)
 
-        !> Ensure we start with new knots
-        if (this%iopt==IOPT_OLD_FIT) this%iopt = IOPT_NEW_SMOOTHING
+        !> Ensure we start with new knots (unless caller wants to keep them)
+        do_guard = .true.; if (present(keep_knots)) do_guard = .not.keep_knots
+        if (do_guard .and. this%iopt==IOPT_OLD_FIT) this%iopt = IOPT_NEW_SMOOTHING
 
         do loop=1,nit
 

--- a/src/fitpack_polar.f90
+++ b/src/fitpack_polar.f90
@@ -105,8 +105,20 @@ module fitpack_polar_domains
     contains
 
     ! Fit a surface to least squares of the current knots
-    integer function surface_fit_least_squares(this) result(ierr)
+    integer function surface_fit_least_squares(this,smoothing,reset_knots) result(ierr)
        class(fitpack_polar), intent(inout) :: this
+       real(FP_REAL), optional, intent(in) :: smoothing
+       logical, optional, intent(in) :: reset_knots
+
+       logical :: do_reset
+
+       ! Optionally recompute knots via a smoothing fit first
+       do_reset = .false.; if (present(reset_knots)) do_reset = reset_knots
+       if (do_reset) then
+           this%iopt = IOPT_NEW_SMOOTHING
+           ierr = this%fit(smoothing)
+           if (.not.FITPACK_SUCCESS(ierr)) return
+       end if
 
        this%iopt = IOPT_NEW_LEASTSQUARES
        ierr = this%fit()
@@ -114,26 +126,33 @@ module fitpack_polar_domains
     end function surface_fit_least_squares
 
     ! Find interpolating surface
-    integer function surface_fit_interpolating(this) result(ierr)
+    integer function surface_fit_interpolating(this,reset_knots) result(ierr)
         class(fitpack_polar), intent(inout) :: this
+        logical, optional, intent(in) :: reset_knots
 
-        ! Set zero smoothing
-        ierr = surface_fit_automatic_knots(this,smoothing=zero)
+        logical :: do_reset
+
+        do_reset = .true.; if (present(reset_knots)) do_reset = reset_knots
+        if (do_reset) this%iopt = IOPT_NEW_SMOOTHING
+        ierr = surface_fit_automatic_knots(this,smoothing=zero,keep_knots=.not.do_reset)
 
     end function surface_fit_interpolating
 
     ! Fit a surface z = s(x,y) defined on a meshgrid: x[1:n], y[1:m]
-    integer function surface_fit_automatic_knots(this,smoothing) result(ierr)
+    integer function surface_fit_automatic_knots(this,smoothing,keep_knots) result(ierr)
         class(fitpack_polar), intent(inout) :: this
         real(FP_REAL), optional, intent(in) :: smoothing
+        logical, optional, intent(in) :: keep_knots
 
         integer :: loop,nit,iopt(3)
         real(FP_REAL) :: smooth_now(3)
+        logical :: do_guard
 
         call get_smoothing(this%smoothing,smoothing,nit,smooth_now)
 
-        !> Ensure we start with new knots
-        if (this%iopt==IOPT_OLD_FIT) this%iopt = IOPT_NEW_SMOOTHING
+        !> Ensure we start with new knots (unless caller wants to keep them)
+        do_guard = .true.; if (present(keep_knots)) do_guard = .not.keep_knots
+        if (do_guard .and. this%iopt==IOPT_OLD_FIT) this%iopt = IOPT_NEW_SMOOTHING
 
         do loop=1,nit
 

--- a/src/fitpack_spheres.f90
+++ b/src/fitpack_spheres.f90
@@ -86,8 +86,20 @@ module fitpack_sphere_domains
     contains
 
     ! Fit a surface to least squares of the current knots
-    integer function surface_fit_least_squares(this) result(ierr)
+    integer function surface_fit_least_squares(this,smoothing,reset_knots) result(ierr)
        class(fitpack_sphere), intent(inout) :: this
+       real(FP_REAL), optional, intent(in) :: smoothing
+       logical, optional, intent(in) :: reset_knots
+
+       logical :: do_reset
+
+       ! Optionally recompute knots via a smoothing fit first
+       do_reset = .false.; if (present(reset_knots)) do_reset = reset_knots
+       if (do_reset) then
+           this%iopt = IOPT_NEW_SMOOTHING
+           ierr = this%fit(smoothing)
+           if (.not.FITPACK_SUCCESS(ierr)) return
+       end if
 
        this%iopt = IOPT_NEW_LEASTSQUARES
        ierr = this%fit()
@@ -95,26 +107,33 @@ module fitpack_sphere_domains
     end function surface_fit_least_squares
 
     ! Find interpolating surface
-    integer function surface_fit_interpolating(this) result(ierr)
+    integer function surface_fit_interpolating(this,reset_knots) result(ierr)
         class(fitpack_sphere), intent(inout) :: this
+        logical, optional, intent(in) :: reset_knots
 
-        ! Set zero smoothing
-        ierr = surface_fit_automatic_knots(this,smoothing=zero)
+        logical :: do_reset
+
+        do_reset = .true.; if (present(reset_knots)) do_reset = reset_knots
+        if (do_reset) this%iopt = IOPT_NEW_SMOOTHING
+        ierr = surface_fit_automatic_knots(this,smoothing=zero,keep_knots=.not.do_reset)
 
     end function surface_fit_interpolating
 
     ! Fit a surface z = s(x,y) defined on a meshgrid: x[1:n], y[1:m]
-    integer function surface_fit_automatic_knots(this,smoothing) result(ierr)
+    integer function surface_fit_automatic_knots(this,smoothing,keep_knots) result(ierr)
         class(fitpack_sphere), intent(inout) :: this
         real(FP_REAL), optional, intent(in) :: smoothing
+        logical, optional, intent(in) :: keep_knots
 
         integer :: loop,nit
         real(FP_REAL) :: smooth_now(3)
+        logical :: do_guard
 
         call get_smoothing(this%smoothing,smoothing,nit,smooth_now)
 
-        !> Ensure we start with new knots
-        if (this%iopt==IOPT_OLD_FIT) this%iopt = IOPT_NEW_SMOOTHING
+        !> Ensure we start with new knots (unless caller wants to keep them)
+        do_guard = .true.; if (present(keep_knots)) do_guard = .not.keep_knots
+        if (do_guard .and. this%iopt==IOPT_OLD_FIT) this%iopt = IOPT_NEW_SMOOTHING
 
         do loop=1,nit
 

--- a/src/fitpack_surfaces.f90
+++ b/src/fitpack_surfaces.f90
@@ -100,18 +100,21 @@ module fitpack_surfaces
     contains
 
     ! Fit a surface z = s(x,y) defined on a meshgrid: x[1:n], y[1:m]
-    integer(FP_FLAG) function surface_fit_automatic_knots(this,smoothing,order) result(ierr)
+    integer(FP_FLAG) function surface_fit_automatic_knots(this,smoothing,order,keep_knots) result(ierr)
         class(fitpack_surface), intent(inout) :: this
         real(FP_REAL), optional, intent(in) :: smoothing
         integer, optional, intent(in) :: order
+        logical, optional, intent(in) :: keep_knots
 
         integer :: loop,nit
         real(FP_REAL) :: smooth_now(3)
+        logical :: do_guard
 
         call get_smoothing(this%smoothing,smoothing,nit,smooth_now)
 
-        !> Ensure we start with new knots
-        if (this%iopt==IOPT_OLD_FIT) this%iopt = IOPT_NEW_SMOOTHING
+        !> Ensure we start with new knots (unless caller wants to keep them)
+        do_guard = .true.; if (present(keep_knots)) do_guard = .not.keep_knots
+        if (do_guard .and. this%iopt==IOPT_OLD_FIT) this%iopt = IOPT_NEW_SMOOTHING
 
         ! User may want to change the order for both x and y
         if (present(order)) this%order = order
@@ -149,14 +152,33 @@ module fitpack_surfaces
 
 
     ! Find interpolating surface
-    integer(FP_FLAG) function surface_fit_interpolating(this) result(ierr)
+    integer(FP_FLAG) function surface_fit_interpolating(this,reset_knots) result(ierr)
         class(fitpack_surface), intent(inout) :: this
-        ierr = surface_fit_automatic_knots(this,smoothing=zero)
+        logical, optional, intent(in) :: reset_knots
+
+        logical :: do_reset
+
+        do_reset = .true.; if (present(reset_knots)) do_reset = reset_knots
+        if (do_reset) this%iopt = IOPT_NEW_SMOOTHING
+        ierr = surface_fit_automatic_knots(this,smoothing=zero,keep_knots=.not.do_reset)
     end function surface_fit_interpolating
 
     ! Fit a surface to least squares of the current knots
-    integer(FP_FLAG) function surface_fit_least_squares(this) result(ierr)
+    integer(FP_FLAG) function surface_fit_least_squares(this,smoothing,reset_knots) result(ierr)
        class(fitpack_surface), intent(inout) :: this
+       real(FP_REAL), optional, intent(in) :: smoothing
+       logical, optional, intent(in) :: reset_knots
+
+       logical :: do_reset
+
+       ! Optionally recompute knots via a smoothing fit first
+       do_reset = .false.; if (present(reset_knots)) do_reset = reset_knots
+       if (do_reset) then
+           this%iopt = IOPT_NEW_SMOOTHING
+           ierr = this%fit(smoothing)
+           if (.not.FITPACK_SUCCESS(ierr)) return
+       end if
+
        this%iopt = IOPT_NEW_LEASTSQUARES
        ierr = this%fit()
     end function surface_fit_least_squares


### PR DESCRIPTION
## Summary
- Add `least_squares` to `fitpack_parametric_curve` (inherited by `fitpack_closed_curve` and `fitpack_constrained_curve`), completing consistent API across all 9 fitter types
- Add `reset_knots` optional parameter to `interpolate` on all 9 types — when `.false.`, preserves the current knot set as a starting point instead of recomputing from scratch
- Add `keep_knots` optional parameter to `fit` on all 9 types — bypasses the `iopt` guard so callers (like `interpolate(reset_knots=.false.)`) can continue from the current knot configuration
- Extend `test_umbrella_api` with parametric curve `interpolate`/`least_squares` coverage and `fp` value checks (`fp=0` for interpolation, `fp>0` for least-squares)

## Test plan
- [x] `fpm build` compiles cleanly
- [x] `fpm test` — all 51 tests pass, 0 failures
- [x] New test verifies `interpolate(reset_knots=.false.)` achieves `fp=0`
- [x] New test verifies `least_squares()` after smoothing fit gives `fp>0`