### PR TITLE
Add scattered-point eval to fitpack_grid_surface

### DIFF
--- a/src/fitpack_grid_surfaces.f90
+++ b/src/fitpack_grid_surfaces.f90
@@ -70,12 +70,12 @@ module fitpack_grid_surfaces
            procedure :: least_squares => surface_fit_least_squares
            procedure :: interpolate   => surface_fit_interpolating
 
-           !> Evaluate at scattered (x,y) points
+           !> Evaluate at scattered (x,y) points (bispeu). For gridded output, use eval_ongrid.
            procedure, private :: gridsurf_eval_one
            procedure, private :: gridsurf_eval_many
            generic :: eval => gridsurf_eval_one,gridsurf_eval_many
 
-           !> Evaluate on a grid domain
+           !> Evaluate on a rectangular grid x(:) x y(:) (bispev). Returns f(ny,nx).
            procedure, private :: gridded_eval_one
            procedure, private :: gridded_eval_many
            generic :: eval_ongrid => gridded_eval_one,gridded_eval_many

--- a/test/test.f90
+++ b/test/test.f90
@@ -67,6 +67,7 @@ program test
         call add_test(test_surface_integral())
         call add_test(test_cross_section())
         call add_test(test_derivative_spline())
+        call add_test(test_grid_surface_scattered_eval())
 
     end subroutine run_interface_tests
 


### PR DESCRIPTION
## Summary

- Add `eval(x, y)` and `eval(x(:), y(:))` for scattered-point evaluation on `fitpack_grid_surface` using `bispeu` — no sorting requirement, constant workspace (`kx+ky+2`)
- Rename previous gridded `eval` to `eval_ongrid` for consistency with `fitpack_surface`
- Both surface types now have matching interfaces:
  - `eval` — scattered points via `bispeu`
  - `eval_ongrid` — rectangular grid via `bispev`
- **Breaking change**: existing `fitpack_grid_surface` code using `%eval(x_array, y_array)` for gridded evaluation must change to `%eval_ongrid`

## Test plan

- [x] All 59 tests pass (`fpm test`)
- [x] New `test_grid_surface_scattered_eval` verifies scattered, single-point, and gridded eval on `z = x² + y²`
- [x] Existing `test_gridded_fit` and `test_derivative_spline` updated to use `eval_ongrid`