### PR TITLE
Add Doxygen + MathJax documentation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,43 @@
+# Deploy documentation to gh-pages
+name: Deploy Doxygen Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      DOXYGEN_VERSION: '1.13.2'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install graphviz -y
+
+      - name: Install Doxygen v${{ env.DOXYGEN_VERSION }}
+        run: |
+          transformed_version=$(echo "${{ env.DOXYGEN_VERSION }}" | tr '.' '_')
+          wget https://github.com/doxygen/doxygen/releases/download/Release_${transformed_version}/doxygen-${{ env.DOXYGEN_VERSION }}.linux.bin.tar.gz
+          tar -xzf doxygen-${{ env.DOXYGEN_VERSION }}.linux.bin.tar.gz
+          sudo mv doxygen-${{ env.DOXYGEN_VERSION }}/bin/doxygen /usr/local/bin/doxygen
+
+      - name: Generate Doxygen Documentation
+        run: cd project/doxygen && doxygen
+
+      - name: Create .nojekyll file
+        run: echo "" > ./project/doxygen/html/.nojekyll
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./project/doxygen/html

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ loop_2
 loop_3
 polar_grid.dat
 project/fitpack.dylib
+project/doxygen/html/

--- a/doc/book_reference.md
+++ b/doc/book_reference.md
@@ -1,0 +1,79 @@
+# Book Reference Index {#book_reference}
+
+Quick-reference table mapping FITPACK routines to chapters, sections, and equations
+in the primary reference:
+
+> P. Dierckx, *Curve and Surface Fitting with Splines*,
+> Oxford University Press, 1993.
+
+## Core Algorithms
+
+| Routine | Book Reference | Description |
+|---------|---------------|-------------|
+| `fpbspl` | Ch. 1, Eq. 1.11 | B-spline basis evaluation (de Boor&ndash;Cox recurrence) |
+| `fprati` | Ch. 5, &sect;5.2.4 | Rational interpolation for smoothing parameter update |
+| `fpdisc` | Ch. 4, &sect;4.3 | Discontinuity jumps of B-spline derivatives at knots |
+| `fpgivs` | Ch. 4, &sect;4.2 | Givens rotation computation |
+| `fprota` | Ch. 4, &sect;4.2 | Apply Givens rotation to matrix rows |
+| `fpback` | Ch. 4, &sect;4.2 | Back-substitution for upper triangular systems |
+| `fprank` | Ch. 4, &sect;4.3 | Rank-deficient least-squares via Householder |
+| `fporde` | Ch. 5, &sect;5.3 | Assign scattered data to knot intervals |
+| `fpchec` | Ch. 4, &sect;4.1 | Check knot sequence validity |
+| `fpchep` | Ch. 4, &sect;4.1 | Check periodic knot sequence |
+| `fppara` | Ch. 9, &sect;9.1 | Compute chord-length parameterization |
+
+## Curve Fitting (1D)
+
+| Routine | Book Reference | Description |
+|---------|---------------|-------------|
+| `curfit` | Ch. 5, &sect;5.2 (pp. 67&ndash;84) | Automatic-knot curve fitting |
+| `percur` | Ch. 6, &sect;6.1 (pp. 105&ndash;114) | Periodic curve fitting |
+| `parcur` | Ch. 9, &sect;9.1 (pp. 199&ndash;212) | Open parametric curve fitting |
+| `clocur` | Ch. 9, &sect;9.2 (pp. 213&ndash;216) | Closed parametric curve fitting |
+| `concur` | Ch. 9, &sect;9.3 (pp. 217&ndash;228) | Constrained parametric curve fitting |
+| `concon` | Ch. 8, &sect;8.3 (pp. 173&ndash;188) | Convexity-constrained fitting (auto knots) |
+| `cocosp` | Ch. 8, &sect;8.4 (pp. 189&ndash;196) | Convexity-constrained fitting (given knots) |
+| `insert` | Ch. 6, &sect;6.2 (pp. 114&ndash;118) | Knot insertion (Oslo algorithm) |
+
+## Curve Evaluation
+
+| Routine | Book Reference | Description |
+|---------|---------------|-------------|
+| `splev` | Ch. 1, Eq. 1.11 | Evaluate spline at given points |
+| `splder` | Ch. 1, &sect;1.3 | Evaluate spline derivatives |
+| `splint` | Ch. 1, &sect;1.4 | Definite integral of spline |
+| `sproot` | Ch. 6, &sect;6.3 (pp. 118&ndash;123) | Zeros of a cubic spline |
+| `fourco` | Ch. 7, &sect;7.3 (pp. 153&ndash;165) | Fourier coefficients of spline |
+| `curev` | Ch. 9 | Evaluate parametric spline curve |
+| `cualde` | Ch. 9 | All derivatives of parametric curve |
+
+## Surface Fitting (2D)
+
+| Routine | Book Reference | Description |
+|---------|---------------|-------------|
+| `surfit` | Ch. 5, &sect;5.3 (pp. 85&ndash;98) | Scattered bivariate fitting |
+| `regrid` | Ch. 5, &sect;5.4 (pp. 98&ndash;103) | Gridded bivariate fitting |
+| `parsur` | Ch. 10, &sect;10.2 (pp. 241&ndash;254) | Parametric surface fitting |
+
+## Surface Evaluation
+
+| Routine | Book Reference | Description |
+|---------|---------------|-------------|
+| `bispev` | Ch. 1, &sect;1.5 | Evaluate bivariate spline on grid |
+| `bispeu` | Ch. 1, &sect;1.5 | Evaluate bivariate spline at scattered points |
+| `parder` | Ch. 1, &sect;1.5 | Partial derivatives on grid |
+| `pardeu` | Ch. 1, &sect;1.5 | Partial derivatives at scattered points |
+| `pardtc` | &mdash; | Transform coefficients for derivative spline |
+| `dblint` | Ch. 1, &sect;1.5 | Double integral over rectangle |
+| `profil` | &mdash; | Cross-section at fixed x or y |
+| `surev`  | Ch. 10 | Evaluate parametric surface on grid |
+| `evapol` | &mdash; | Evaluate polar-domain spline |
+
+## Polar and Spherical Domains
+
+| Routine | Book Reference | Description |
+|---------|---------------|-------------|
+| `polar` | Ch. 11, &sect;11.1 (pp. 255&ndash;263) | Scattered polar fitting |
+| `pogrid` | Ch. 11, &sect;11.1 (pp. 255&ndash;263) | Gridded polar fitting |
+| `sphere` | Ch. 11, &sect;11.2 (pp. 263&ndash;269) | Scattered spherical fitting |
+| `spgrid` | Ch. 11, &sect;11.2 (pp. 263&ndash;269) | Gridded spherical fitting |

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -76,6 +76,13 @@ fpm build          # build the library
 fpm test           # run all tests
 ```
 
+## Tutorials
+
+- @ref tutorial_curves — Smoothing, interpolation, derivatives, roots, periodic and parametric curves
+- @ref tutorial_surfaces — Scattered and gridded surface fitting, cross-sections, integration
+- @ref tutorial_special — Polar and spherical domains, pole boundary conditions
+- @ref book_reference — Quick-reference table mapping routines to book chapters and equations
+
 ## Reference
 
 The algorithms are described in:

--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -1,0 +1,87 @@
+# fitpack — Modern Fortran Spline Fitting {#mainpage}
+
+**fitpack** is a Modern Fortran (2008+) library for curve and surface fitting with splines,
+based on the FITPACK package by Paul Dierckx.
+
+It provides an object-oriented API with derived types for all major fitting tasks:
+smoothing, interpolation, least-squares approximation, and constrained fitting.
+All routines support spline degrees 1 through 5 (cubic by default) and return
+B-spline representations that can be evaluated, differentiated, integrated, and
+root-found efficiently.
+
+## Type Hierarchy
+
+All fitter types extend the abstract base `fitpack_fitter`:
+
+```
+fitpack_fitter (abstract base)
+├── fitpack_curve                   — 1D spline: y = s(x)
+│   ├── fitpack_periodic_curve      — periodic boundary conditions
+│   └── fitpack_convex_curve        — convexity-constrained fitting
+├── fitpack_parametric_curve        — parametric curves: x_i = s_i(u)
+│   ├── fitpack_closed_curve        — closed parametric curves
+│   └── fitpack_constrained_curve   — endpoint derivative constraints
+├── fitpack_surface                 — 2D spline from scattered data
+├── fitpack_grid_surface            — 2D spline from gridded data
+├── fitpack_parametric_surface      — parametric surfaces
+├── fitpack_polar                   — polar-domain fitting (scattered)
+├── fitpack_grid_polar              — polar-domain fitting (gridded)
+├── fitpack_sphere                  — spherical-domain fitting (scattered)
+└── fitpack_grid_sphere             — spherical-domain fitting (gridded)
+```
+
+## Quick Start
+
+### Fit a curve
+
+```fortran
+use fitpack, only: fitpack_curve
+
+type(fitpack_curve) :: curve
+integer :: ierr
+
+! Create a smoothing spline from data
+curve = fitpack_curve(x, y, ierr=ierr)
+
+! Evaluate at new points
+y_new = curve%eval(x_new, ierr)
+
+! Compute derivative, integral, zeros
+dydx  = curve%dfdx(x_new, ierr)
+area  = curve%integral(x(1), x(size(x)), ierr)
+roots = curve%zeros(ierr)
+```
+
+### Fit a surface
+
+```fortran
+use fitpack, only: fitpack_grid_surface
+
+type(fitpack_grid_surface) :: surf
+integer :: ierr
+
+! Create a smoothing spline from gridded data
+surf = fitpack_grid_surface(x, y, z, ierr=ierr)
+
+! Evaluate on a new grid
+z_new = surf%eval(x_new, y_new, ierr)
+```
+
+## Building
+
+fitpack uses [fpm](https://fpm.fortran-lang.org/) (Fortran Package Manager):
+
+```bash
+fpm build          # build the library
+fpm test           # run all tests
+```
+
+## Reference
+
+The algorithms are described in:
+
+> P. Dierckx, *Curve and Surface Fitting with Splines*,
+> Oxford University Press, 1993.
+
+Each routine's documentation references the relevant book chapter, section,
+and equation numbers.

--- a/doc/tutorial_curves.md
+++ b/doc/tutorial_curves.md
@@ -1,0 +1,182 @@
+# Curve Fitting Tutorial {#tutorial_curves}
+
+This tutorial covers one-dimensional spline fitting with FITPACK: constructing
+a B-spline \f$ y = s(x) \f$ from data, controlling smoothness, and evaluating
+derived quantities (derivatives, integrals, roots).
+
+## Basic Workflow
+
+```fortran
+use fitpack, only: fitpack_curve, FP_REAL, FITPACK_OK
+
+real(FP_REAL) :: x(20), y(20)
+type(fitpack_curve) :: curve
+integer :: ierr
+
+! 1. Prepare data (must be sorted by x)
+x = [...]
+y = [...]
+
+! 2. Construct a smoothing spline (automatic knots)
+curve = fitpack_curve(x, y, ierr=ierr)
+
+! 3. Evaluate at new points
+y_new = curve%eval(x_new, ierr)
+
+! 4. Clean up
+call curve%destroy()
+```
+
+The constructor calls `curfit` internally, which selects knots automatically
+to balance closeness of fit against smoothness.
+
+## Smoothing Parameter
+
+The smoothing parameter \f$ s \f$ controls the trade-off between fidelity and
+smoothness. Specifically, the fitted spline minimizes a roughness measure
+subject to:
+
+\f[
+    \sum_{i=1}^{m} \left( w_i \, (y_i - s(x_i)) \right)^2 \leq s
+\f]
+
+- **\f$ s = 0 \f$**: Interpolation — the spline passes through every data point.
+  Use `curve%interpolate()` or set `smoothing=0`.
+- **Small \f$ s \f$**: Close to the data but may oscillate.
+- **Large \f$ s \f$**: Very smooth but may miss data features.
+- **Default**: The constructor uses \f$ s = 1000 \f$; call `curve%fit(smoothing=s)`
+  to adjust.
+
+A practical starting point is \f$ s = m \f$ (the number of data points) when weights
+are unity, since the expected sum of squared residuals for a good fit is
+\f$ \mathcal{O}(m) \f$.
+
+@see Dierckx, Ch. 5, &sect;5.2.4 (pp. 78&ndash;84)
+
+## Fitting Modes
+
+FITPACK offers three fitting strategies:
+
+| Method | Call | Description |
+|--------|------|-------------|
+| Automatic knots | `curve%fit(smoothing=s)` | Knots chosen to satisfy the smoothing constraint |
+| Interpolation | `curve%interpolate()` | Passes through all data points (\f$ s = 0 \f$) |
+| Least-squares | `curve%least_squares(knots)` | User-supplied knots, no smoothing constraint |
+
+After any fit, `curve%mse()` returns the weighted sum of squared residuals \f$ f_p \f$.
+
+## Spline Degree
+
+The default spline degree is \f$ k = 3 \f$ (cubic). Degrees 1 through 5 are supported.
+Set the degree at construction:
+
+```fortran
+curve = fitpack_curve(x, y, k=5, ierr=ierr)   ! quintic
+```
+
+## Weights
+
+Optional per-point weights emphasize certain data points:
+
+```fortran
+curve = fitpack_curve(x, y, w=weights, ierr=ierr)
+```
+
+Points with larger weights are fitted more closely.
+
+## Evaluation, Derivatives, and Integration
+
+Once fitted, the spline supports several operations:
+
+```fortran
+! Evaluate at one or many points
+y_val  = curve%eval(x_val, ierr)
+
+! First derivative dy/dx
+dydx   = curve%dfdx(x_val, order=1, ierr=ierr)
+
+! n-th derivative (up to order k)
+d2ydx2 = curve%dfdx(x_val, order=2, ierr=ierr)
+
+! Definite integral over [a, b]
+area   = curve%integral(a, b, ierr)
+
+! All zeros (roots) in the data range
+roots  = curve%zeros(ierr)
+```
+
+## Periodic Curves
+
+For data with periodic boundary conditions — e.g. \f$ y(x_1) = y(x_m) \f$ — use
+`fitpack_periodic_curve`:
+
+```fortran
+use fitpack, only: fitpack_periodic_curve
+
+type(fitpack_periodic_curve) :: pcurve
+pcurve = fitpack_periodic_curve(x, y, ierr=ierr)
+```
+
+The periodic variant enforces \f$ s^{(j)}(x_1) = s^{(j)}(x_m) \f$ for
+\f$ j = 0, 1, \ldots, k-1 \f$.
+
+## Parametric Curves
+
+To fit a curve through points in \f$ \mathbb{R}^d \f$ (e.g. a 2D trajectory),
+use `fitpack_parametric_curve`:
+
+```fortran
+use fitpack, only: fitpack_parametric_curve
+
+real(FP_REAL) :: pts(2, 50)   ! 2D points
+type(fitpack_parametric_curve) :: pcurve
+
+pcurve = fitpack_parametric_curve(pts, ierr=ierr)
+```
+
+Each component \f$ s_j(u) \f$ shares a common knot vector. Parameter values
+are computed automatically from cumulative chord lengths unless explicitly supplied.
+
+Closed parametric curves use `fitpack_closed_curve`; curves with prescribed
+endpoint derivatives use `fitpack_constrained_curve`.
+
+@see @ref fitpack_parametric_curves, Dierckx Ch. 9 (pp. 199&ndash;228)
+
+## Convexity-Constrained Curves
+
+When the spline must be locally convex or concave, use `fitpack_convex_curve`:
+
+```fortran
+use fitpack, only: fitpack_convex_curve
+
+type(fitpack_convex_curve) :: ccurve
+ccurve = fitpack_convex_curve(x, y, ierr=ierr)
+
+! Set per-point convexity flags: 1 = concave, -1 = convex, 0 = free
+call ccurve%set_convexity(v)
+call ccurve%fit(smoothing=s, ierr=ierr)
+```
+
+@see @ref fitpack_convex_curves, Dierckx Ch. 8, &sect;8.3&ndash;8.4 (pp. 173&ndash;196)
+
+## Error Handling
+
+All routines return an `integer(FP_FLAG)` error code:
+
+```fortran
+use fitpack, only: FITPACK_OK, FITPACK_SUCCESS, FITPACK_MESSAGE
+
+if (.not. FITPACK_SUCCESS(ierr)) then
+    print *, 'Error: ', FITPACK_MESSAGE(ierr)
+end if
+```
+
+Common return values:
+
+| Flag | Meaning |
+|------|---------|
+| `FITPACK_OK` (0) | Success |
+| `FITPACK_INTERPOLATING_OK` (-1) | Interpolating spline returned |
+| `FITPACK_S_TOO_SMALL` (1) | Smoothing parameter too small for the requested knot budget |
+| `FITPACK_MAXIT` (2) | Maximum iterations reached |
+| `FITPACK_INPUT_ERROR` (10) | Invalid input data |

--- a/doc/tutorial_special.md
+++ b/doc/tutorial_special.md
@@ -1,0 +1,133 @@
+# Polar and Spherical Domains {#tutorial_special}
+
+This tutorial covers spline fitting on non-rectangular domains: polar coordinates
+(disc-shaped regions) and spherical coordinates (the unit sphere).
+
+## Polar Domain — Scattered Data
+
+`fitpack_polar` fits a bicubic spline to data scattered over a general polar domain
+\f$ x^2 + y^2 \leq r(\theta)^2 \f$, where \f$ r(\theta) \f$ is a user-supplied
+boundary function.
+
+The Cartesian coordinates are internally transformed to normalized polar
+coordinates:
+
+\f[
+    x = u \, r(v) \cos v, \quad y = u \, r(v) \sin v, \quad
+    0 \leq u \leq 1, \; -\pi \leq v \leq \pi
+\f]
+
+```fortran
+use fitpack, only: fitpack_polar
+
+type(fitpack_polar) :: pol
+integer :: ierr
+
+! rad_func is a function: real(FP_REAL) function rad_func(theta) result(r)
+pol = fitpack_polar(x, y, z, rad_func, ierr=ierr)
+
+! Evaluate
+z_val = pol%eval(x_val, y_val, ierr)
+```
+
+### Continuity at the Origin
+
+The continuity order at \f$ u = 0 \f$ (the origin) is configurable:
+
+| `bc_continuity_origin` | Meaning |
+|------------------------|---------|
+| 0 | \f$ C^0 \f$ continuity |
+| 1 | \f$ C^1 \f$ continuity |
+| 2 | \f$ C^2 \f$ continuity (default) |
+
+@see Dierckx, Ch. 11, &sect;11.1 (pp. 255&ndash;263)
+
+## Polar Domain — Gridded Data
+
+`fitpack_grid_polar` fits a bicubic spline to data on a polar grid with a
+**constant** boundary radius \f$ r \f$:
+
+```fortran
+use fitpack, only: fitpack_grid_polar
+
+type(fitpack_grid_polar) :: gpol
+integer :: ierr
+
+gpol = fitpack_grid_polar(u, v, z, r, ierr=ierr)
+```
+
+Additional options:
+- **Origin value**: Set `z0` to prescribe the function value at the origin,
+  with optional exact interpolation (`z0_exact = .true.`).
+- **Zero gradient**: Set `z0_zero_gradient = .true.` to enforce
+  \f$ \nabla s(0,0) = 0 \f$.
+
+@see pogrid
+
+## Spherical Domain — Scattered Data
+
+`fitpack_sphere` fits a bicubic spline to data scattered on the unit sphere,
+parameterized by colatitude \f$ \theta \in [0, \pi] \f$ and longitude
+\f$ \phi \in [0, 2\pi] \f$:
+
+\f[
+    r = s(\theta, \phi)
+\f]
+
+```fortran
+use fitpack, only: fitpack_sphere
+
+type(fitpack_sphere) :: sph
+integer :: ierr
+
+sph = fitpack_sphere(theta, phi, r, ierr=ierr)
+
+! Evaluate at new locations
+r_val = sph%eval(theta_new, phi_new, ierr)
+```
+
+The fitted spline automatically satisfies pole constraints to ensure smoothness
+at \f$ \theta = 0 \f$ (north pole) and \f$ \theta = \pi \f$ (south pole).
+
+@see Dierckx, Ch. 11, &sect;11.2 (pp. 263&ndash;269)
+
+## Spherical Domain — Gridded Data
+
+`fitpack_grid_sphere` fits a bicubic spline to data on a latitude-longitude grid:
+
+```fortran
+use fitpack, only: fitpack_grid_sphere
+
+type(fitpack_grid_sphere) :: gsph
+integer :: ierr
+
+gsph = fitpack_grid_sphere(u, v, z, ierr=ierr)
+```
+
+### Pole Boundary Conditions
+
+Each pole (north and south) has independently configurable boundary conditions:
+
+```fortran
+! North pole: prescribed value z0 = 1.0, exact, with C1 continuity
+call gsph%BC_north_pole(z0=1.0_FP_REAL, exact=.true., continuity=1)
+
+! South pole: prescribed value z0 = -1.0, approximate
+call gsph%BC_south_pole(z0=-1.0_FP_REAL, exact=.false.)
+```
+
+| Setting | Description |
+|---------|-------------|
+| `z0` | Function value at the pole |
+| `exact` | If `.true.`, the spline passes exactly through `z0` |
+| `continuity` | Continuity order at the pole (0 = \f$ C^0 \f$, 1 = \f$ C^1 \f$) |
+| `zero_gradient` | If `.true.`, enforce vanishing gradient at the pole |
+
+@see spgrid
+
+## Summary
+
+| Domain | Scattered | Gridded |
+|--------|-----------|---------|
+| Polar disc | `fitpack_polar` (polar) | `fitpack_grid_polar` (pogrid) |
+| Sphere | `fitpack_sphere` (sphere) | `fitpack_grid_sphere` (spgrid) |

--- a/doc/tutorial_surfaces.md
+++ b/doc/tutorial_surfaces.md
@@ -1,0 +1,151 @@
+# Surface Fitting Tutorial {#tutorial_surfaces}
+
+This tutorial covers bivariate spline fitting with FITPACK: constructing a
+tensor-product B-spline \f$ z = s(x, y) \f$ from data and evaluating derived
+quantities (partial derivatives, integrals, cross-sections).
+
+## Scattered vs Gridded Data
+
+FITPACK provides two surface types, selected by input data structure:
+
+| Type | Input | Core routine | Efficiency |
+|------|-------|-------------|------------|
+| `fitpack_surface` | Scattered \f$ (x_i, y_i, z_i) \f$ | `surfit` | General |
+| `fitpack_grid_surface` | Grid \f$ z(y_j, x_i) \f$ | `regrid` | Faster for gridded data |
+
+**Always prefer `fitpack_grid_surface` when data lies on a rectangular grid** —
+the `regrid` algorithm exploits the grid structure and is significantly more
+efficient than `surfit`.
+
+## Scattered Data
+
+```fortran
+use fitpack, only: fitpack_surface
+
+real(FP_REAL) :: x(100), y(100), z(100)
+type(fitpack_surface) :: surf
+integer :: ierr
+
+surf = fitpack_surface(x, y, z, ierr=ierr)
+```
+
+@see Dierckx, Ch. 5, &sect;5.3 (pp. 85&ndash;98)
+
+## Gridded Data
+
+```fortran
+use fitpack, only: fitpack_grid_surface
+
+real(FP_REAL) :: xg(20), yg(30), zg(30, 20)
+type(fitpack_grid_surface) :: gsurf
+integer :: ierr
+
+gsurf = fitpack_grid_surface(xg, yg, zg, ierr=ierr)
+```
+
+Note that `zg` has shape `(size(yg), size(xg))` — the first index corresponds to
+the \f$ y \f$-direction.
+
+@see Dierckx, Ch. 5, &sect;5.4 (pp. 98&ndash;103)
+
+## Smoothing, Interpolation, Least-Squares
+
+The same three fitting modes are available as for curves:
+
+```fortran
+! Automatic knot placement with smoothing
+call surf%fit(smoothing=s, ierr=ierr)
+
+! Interpolation (s = 0)
+call surf%interpolate(ierr=ierr)
+
+! Least-squares with user-supplied knots
+call surf%least_squares(tx, ty, ierr=ierr)
+```
+
+## Evaluation
+
+Evaluate the fitted spline at scattered points or on a grid:
+
+```fortran
+! Single point
+z_val = surf%eval(x_val, y_val, ierr)
+
+! Array of scattered points
+z_arr = surf%eval(x_arr, y_arr, ierr)
+
+! Rectangular output grid
+z_grid = surf%eval(x_new, y_new, ierr)  ! for fitpack_grid_surface
+```
+
+## Partial Derivatives
+
+Compute partial derivatives \f$ \partial^{n_x+n_y} s / \partial x^{n_x} \partial y^{n_y} \f$:
+
+```fortran
+! Derivatives on a grid (for fitpack_grid_surface)
+dz = gsurf%dfdx(x_eval, y_eval, order=[1, 0], ierr=ierr)   ! ds/dx
+dz = gsurf%dfdx(x_eval, y_eval, order=[0, 1], ierr=ierr)   ! ds/dy
+dz = gsurf%dfdx(x_eval, y_eval, order=[1, 1], ierr=ierr)   ! d2s/dxdy
+```
+
+## Integration
+
+Compute the integral over a rectangular sub-domain:
+
+\f[
+    \iint_{[x_1, x_2] \times [y_1, y_2]} s(x, y) \, dx \, dy
+\f]
+
+```fortran
+area = gsurf%integral(x1, x2, y1, y2, ierr)
+```
+
+## Cross-Sections
+
+Extract a 1D profile (cross-section) at a fixed \f$ x \f$ or \f$ y \f$ value:
+
+```fortran
+type(fitpack_curve) :: profile
+
+! Profile at fixed y = y0
+profile = gsurf%cross_section(y0, axis=2, ierr=ierr)
+
+! Evaluate the 1D profile
+z_line = profile%eval(x_eval, ierr)
+```
+
+The returned `fitpack_curve` is a full 1D spline that can be evaluated,
+differentiated, and integrated independently.
+
+## Derivative Splines
+
+Transform the B-spline coefficients to obtain a new surface whose evaluation
+gives the partial derivative:
+
+```fortran
+type(fitpack_grid_surface) :: dsdx_surf
+
+dsdx_surf = gsurf%derivative_spline(order=[1, 0], ierr=ierr)
+```
+
+This creates a new surface object whose `eval` method returns
+\f$ \partial s / \partial x \f$.
+
+## Parametric Surfaces
+
+For surfaces in \f$ \mathbb{R}^d \f$ parameterized by \f$ (u, v) \f$, use
+`fitpack_parametric_surface`:
+
+```fortran
+use fitpack, only: fitpack_parametric_surface
+
+type(fitpack_parametric_surface) :: psurf
+
+! z has shape [size(v), size(u), idim]
+psurf = fitpack_parametric_surface(u, v, z, ierr=ierr)
+```
+
+Each dimension supports optional periodicity in \f$ u \f$ and/or \f$ v \f$.
+
+@see Dierckx, Ch. 10, &sect;10.2 (pp. 241&ndash;254); parsur, surev

--- a/docs/refactoring/09_doxygen_mathjax_plan.md
+++ b/docs/refactoring/09_doxygen_mathjax_plan.md
@@ -1,0 +1,358 @@
+# PR 9: Doxygen + MathJax Documentation
+
+## Context
+
+All 8 code refactoring PRs are complete. The next step per `docs/refactoring/00_refactoring_summary.md`
+is to add structured Doxygen documentation to the entire library. The documentation convention is
+defined in `docs/refactoring/03_doxygen_convention.md`. The goal is a professional GitHub Pages site
+(like [fortran-lapack](https://perazz.github.io/fortran-lapack/)) with dark mode, MathJax equations,
+and cross-referenced API docs.
+
+This is a large PR — it touches every source file. The plan breaks it into sequential,
+independently-testable steps.
+
+---
+
+## Phase A: Infrastructure Setup
+
+### A1. Create `project/doxygen/` directory with theme files
+
+Copy from `~/code/fortran-lapack/project/doxygen/`:
+- `Doxyfile` — adapt for fitpack (project name, input paths, warn log path)
+- `header.html` — unchanged (dark mode toggle init)
+- `doxygen-awesome.css` — unchanged (2,681 lines)
+- `doxygen-awesome-darkmode-toggle.js` — unchanged (258 lines)
+
+Key Doxyfile changes from fortran-lapack:
+```
+PROJECT_NAME           = fitpack
+INPUT                  = "../../src/"
+INPUT                 += "../../doc/mainpage.md"
+USE_MDFILE_AS_MAINPAGE = "../../doc/mainpage.md"
+EXTENSION_MAPPING      = .F90=FortranFree
+EXAMPLE_PATH           = "../../example/"
+WARN_LOGFILE           = ""
+EXTRACT_PRIVATE        = NO
+CALL_GRAPH             = YES
+CALLER_GRAPH           = NO
+```
+
+### A2. Create `doc/mainpage.md` — Doxygen landing page
+
+High-level overview page (NOT the README — Doxygen main page is separate):
+- Project description and purpose
+- Links to type hierarchy overview
+- Quick-start code examples
+- Links to book reference
+
+### A3. Create `.github/workflows/deploy-docs.yml`
+
+Copy from fortran-lapack, same structure:
+- Trigger on push to `main`
+- Install doxygen 1.13.2, texlive-full, ghostscript, graphviz
+- Run `cd project/doxygen && doxygen`
+- Create `.nojekyll`
+- Deploy to `gh-pages` via `peaceiris/actions-gh-pages@v3`
+
+### A4. Add `project/doxygen/html/` to `.gitignore`
+
+### A5. Verify: run `doxygen` locally, open HTML, confirm theme renders
+
+---
+
+## Phase B: Core Routine Documentation (`fitpack_core.F90`)
+
+Each routine gets a new Doxygen comment block placed **immediately before** the
+`subroutine`/`function` statement. The existing F77-style comments inside the routine body
+are left as-is (they serve as inline implementation notes). The new Doxygen block provides:
+
+1. `@brief` — one-line summary
+2. **Description** — what the routine computes, written clearly with MathJax equations from the book
+3. `@param` — all parameters with `[in]`/`[out]`/`[in,out]` direction
+4. **Error flags** — for public API routines
+5. **Usage guidance** — for public API routines (from original F77 comment blocks)
+6. `@see` — book chapter, section, page range, equation numbers
+
+Math syntax: `\f$ inline \f$`, `\f[ display \f]`, `\tag{N.M}` for book equation numbers.
+
+### B1. Low-level utilities (10 routines)
+
+Small, self-contained routines — good warm-up, establish the pattern.
+
+| Routine | Line | Book ref | Key equations |
+|---------|------|----------|---------------|
+| `fpgivs` | 5500 | §4.1.2, pp.55-58 | 4.15, 4.16 |
+| `fprota` | 11402 | §4.1.2, pp.55-58 | 4.15 |
+| `fpback` | 2368 | §4.1.2, pp.55-58 | 4.14 |
+| `fpbacp` | 2406 | §6.1, pp.95-100 | 6.6 |
+| `fpbspl` | 2721 | §1.3, pp.8-11 | 1.22, 1.30 |
+| `fpdisc` | 5356 | §5.2.2, pp.76-79 | 5.5, 5.6 |
+| `fprati` | 10973 | §5.2.4, pp.83-86 | 5.30-5.32 |
+| `fpchec` | (in fpcons area) | §4.1.1, pp.53-55 | 4.5, 4.17 |
+| `fpbisp` | 2648 | §2.1.2, pp.28-30 | 2.14-2.17 |
+| `fporde` | 8121 | §9.1, pp.147-150 | — |
+
+### B2. Refactored Givens rotation helpers (9 routines)
+
+These already have Doxygen comments — review and enhance with book refs:
+
+| Routine | Line | Book ref |
+|---------|------|----------|
+| `fp_rotate_row` | 5537 | §4.1.2, Eq.4.15 |
+| `fp_rotate_row_vec` | 5569 | §4.1.2, Eq.4.15 |
+| `fp_rotate_shifted` | 5608 | §5.2.2, Eq.5.15 |
+| `fp_rotate_shifted_vec` | 5642 | §5.2.2, Eq.5.15 |
+| `fp_rotate_row_2mat_vec` | 5675 | §6.1, Eq.6.4 |
+| `fp_rotate_row_2mat` | 5716 | §6.1, Eq.6.4 |
+| `fp_rotate_row_block` | 5758 | §10.2, Eq.10.4-10.8 |
+| `fp_rotate_row_stride` | 5783 | §10.2, Eq.10.8 |
+| `fp_rotate_2mat_stride` | 5808 | §10.2, Eq.10.8 |
+
+### B3. Knot/tree/polynomial utilities (9 routines)
+
+| Routine | Line | Book ref | Key equations |
+|---------|------|----------|---------------|
+| `fpknot` | 7632 | §5.3, pp.87-94 | 5.37-5.43 |
+| `fprank` | 10738 | §9.1.2, pp.150-152 | 9.8-9.10 |
+| `fpinst` | 7426 | §4.2, pp.63-65 | — |
+| `fpintb` | 7494 | §3.2, pp.44-46 | 3.8-3.10 |
+| `fpadno` | 2229 | §7.2, pp.125-130 | — |
+| `fpdeno` | 5266 | §7.2, pp.125-130 | — |
+| `fpfrno` | 5405 | §7.2, pp.125-130 | — |
+| `fpseno` | 11560 | §7.2, pp.125-130 | — |
+| `fpcuro` | 5071 | — | cubic polynomial roots |
+
+### B4. Cyclic/polynomial helpers (5 routines)
+
+| Routine | Line | Book ref |
+|---------|------|----------|
+| `fpcyt1` | 5183 | §6.1, pp.95-100, Eq.6.5-6.6 |
+| `fpcyt2` | 5232 | §6.1, pp.95-100 |
+| `fppocu` | 9478 | §7.1, pp.115-120 |
+| `fpcoco` | 3670 | §7.2, pp.125-130 |
+| `fpcosp` | 4275 | §7.1, pp.115-120 |
+
+### B5. Core fitting algorithms (9 routines)
+
+The big ones — these need the most detailed documentation with full equation chains.
+
+| Routine | Line | Book ref | Key equations |
+|---------|------|----------|---------------|
+| `fpcurf` | 4717 | §4.1-5.3, pp.53-94 | 4.12, 5.10, 5.37 |
+| `fpcons` | 3864 | §8.2, pp.141-146 | — |
+| `fpclos` | 3031 | §6.1-6.2, pp.95-112 | 6.1-6.8 |
+| `fppara` | 8156 | §6.3, pp.112-114 | 6.9 |
+| `fpperi` | 8906 | §6.1-6.2, pp.95-112 | 6.1-6.8 |
+| `fpsurf` | 12808 | §9.1-9.2, pp.147-167 | 9.2-9.6 |
+| `fppola` | 9954 | §11.1, pp.197-205 | 11.1-11.9 |
+| `fpsphe` | 12044 | §11.2, pp.205-213 | 11.12-11.16 |
+| `fppasu` | 8514 | §10.3, pp.173-178 | 10.9-10.12 |
+
+### B6. Grid fitting algorithms (6 routines)
+
+| Routine | Line | Book ref | Key equations |
+|---------|------|----------|---------------|
+| `fpgrre` | 6655 | §10.2, pp.170-172 | 10.4-10.8 |
+| `fpgrdi` | 5844 | §10.2, pp.170-172 | 10.4-10.8 |
+| `fptrnp` | 13488 | §10.2, pp.170-172 | 10.8 |
+| `fptrpe` | 13574 | §10.2, pp.170-172 | 10.8 (periodic) |
+| `fpgrsp` | 6913 | §11.2, pp.205-213 | — |
+| `fpgrpa` | 6316 | §10.3, pp.173-178 | — |
+
+### B7. Specialized helpers (7 routines)
+
+| Routine | Line | Book ref |
+|---------|------|----------|
+| `fpcsin` | 4664 | §3.3, Fourier integrals |
+| `fpbfou` | 2469 | §3.3, Fourier coefficients |
+| `fpadpo` | 2301 | §7.1, polynomial spline |
+| `fprppo` | 11423 | §11.1, polar representation |
+| `fprpsp` | 11498 | §11.2, spherical representation |
+| `fpopdi` | 7740 | §11.1, polar derivatives |
+| `fpopsp` | 7890 | §11.2, spherical operations |
+| `fpsysy` | 13429 | — symmetric system solve |
+| `sort_xy` | 13386 | — reorder scattered data |
+| `fppogr` | 9548 | §11.1, polar grid fitting |
+| `fpspgr` | 11596 | §11.2, spherical grid setup |
+| `fpregr` | 11005 | §10.2, regression residuals |
+
+### B8. Public API wrappers (30 routines)
+
+These have the longest existing F77 comment blocks — full conversion to Doxygen format.
+Preserve ALL original content (parameter descriptions, error codes, usage guidance).
+
+**Curve routines:**
+`curfit`, `splev`, `splder`, `splint`, `sproot`, `spalde`, `cualde`, `curev`,
+`percur`, `clocur`, `parcur`, `concur`, `fourco`, `insert`, `insert_inplace`,
+`cocosp`, `concon`
+
+**Surface routines:**
+`surfit`, `bispev`, `bispeu`, `parder`, `pardeu`, `pardtc`, `dblint`, `profil`,
+`regrid`, `parsur`, `surev`
+
+**Polar/sphere routines:**
+`polar`, `pogrid`, `sphere`, `spgrid`, `evapol`
+
+### B9. Utility/error/comm routines (~15 routines)
+
+| Routine | Line | Notes |
+|---------|------|-------|
+| `fitpack_error_handling` | 214 | Error handler |
+| `FITPACK_MESSAGE` | 228 | Error code → string |
+| `FITPACK_SUCCESS` | 292 | Check success |
+| `get_smoothing` | 258 | Smoothing parameter logic |
+| `IOPT_MESSAGE` | 280 | iopt → string |
+| `fp_knot_interval` | 2756 | Already has Doxygen — review |
+| `fitpack_argsort` | 18151 | Index sort |
+| `equal`, `not_equal` | 18294 | Float comparison |
+| `swap_data`, `swap_size` | 18255 | Element swap |
+| `FP_*_COMM_*` | 18308+ | Already have Doxygen — review |
+
+---
+
+## Phase C: OOP API Documentation
+
+Each OOP type gets a Doxygen comment block on the `type` declaration and on each
+public method. These reference the book but focus on **usage**: what the type represents,
+how to use each method, what the parameters mean.
+
+### C1. Abstract base: `fitpack_fitter` (`src/fitpack_fitters.f90`)
+
+Document: type overview, `mse()`, `fitting_status()`, `destroy_base()`, comm interfaces.
+
+### C2. Curve types (`src/fitpack_curves.f90`)
+
+- `fitpack_curve` — full documentation: constructor, `new_fit`, `fit`, `interpolate`,
+  `least_squares`, `eval`, `dfdx`, `dfdx_all`, `integral`, `zeros`,
+  `fourier_coefficients`, `insert_knot`, `destroy`, comm methods
+- `fitpack_periodic_curve` — brief (marker type, inherits everything)
+
+### C3. Convex curve (`src/fitpack_convex_curves.f90`)
+
+- `fitpack_convex_curve` — `set_convexity`, `fit` (concon), `least_squares` (cocosp)
+
+### C4. Parametric curves (`src/fitpack_parametric_curves.f90`)
+
+- `fitpack_parametric_curve` — constructor, `eval` (returns multi-dim), `dfdx`, `dfdx_all`
+- `fitpack_closed_curve` — brief
+- `fitpack_constrained_curve` — `set_constraints`, derivative boundary conditions
+
+### C5. Surface types (`src/fitpack_surfaces.f90`, `src/fitpack_grid_surfaces.f90`)
+
+- `fitpack_surface` — full: `eval` (scattered, bispeu), `eval_ongrid` (grid, bispev),
+  `dfdx`, `dfdx_ongrid`, `integral`, `cross_section`, `derivative_spline`
+- `fitpack_grid_surface` — same methods, note eval/eval_ongrid distinction
+
+### C6. Parametric surface (`src/fitpack_parametric_surfaces.f90`)
+
+- `fitpack_parametric_surface` — `eval`, periodicity, `idim`
+
+### C7. Polar types (`src/fitpack_polar.f90`, `src/fitpack_gridded_polar.f90`)
+
+- `fitpack_polar` — boundary function pointer, origin continuity, eval in Cartesian
+- `fitpack_grid_polar` — origin BC, grid structure
+
+### C8. Sphere types (`src/fitpack_spheres.f90`, `src/fitpack_gridded_sphere.f90`)
+
+- `fitpack_sphere` — theta/phi coordinates, pole handling
+- `fitpack_grid_sphere` — pole BC, grid structure
+
+### C9. Umbrella module (`src/fitpack.f90`)
+
+Document the module itself: what it exports, how to use it.
+
+---
+
+## Phase D: Tutorial / Guide Pages
+
+### D1. `doc/mainpage.md` — Landing page (created in A2)
+
+- What is FITPACK?
+- Type hierarchy diagram (text-based)
+- Quick-start: fit a curve in 5 lines
+- Link to tutorials below
+
+### D2. `doc/tutorial_curves.md` — Curve fitting tutorial
+
+- Basic curve fitting workflow
+- Smoothing parameter guidance (from book §5.2.4)
+- Periodic curves
+- Parametric curves
+- Convexity constraints
+- Evaluation, derivatives, integration, roots
+
+### D3. `doc/tutorial_surfaces.md` — Surface fitting tutorial
+
+- Scattered vs gridded data
+- Smoothing, interpolation, least-squares
+- Evaluation (scattered vs grid)
+- Cross-sections, integration, derivative splines
+
+### D4. `doc/tutorial_special.md` — Polar & spherical domains
+
+- Polar coordinates, boundary functions
+- Spherical coordinates, pole handling
+- Grid vs scattered variants
+
+### D5. `doc/book_reference.md` — Book equation index
+
+Quick-reference table mapping FITPACK routines to book chapters/equations.
+
+---
+
+## Phase E: Verification
+
+1. `fpm build && fpm test` — all 59 tests pass (no code changes, only comments)
+2. `cd project/doxygen && doxygen` — builds without errors/warnings
+3. Open `project/doxygen/html/index.html` — verify:
+   - Dark mode toggle works
+   - MathJax equations render
+   - Type hierarchy visible
+   - Cross-references link correctly
+   - Tutorial pages accessible
+4. Push to branch, verify GitHub Actions deploys to gh-pages
+
+---
+
+## Files Created
+
+| File | Description |
+|------|-------------|
+| `project/doxygen/Doxyfile` | Doxygen configuration |
+| `project/doxygen/header.html` | Custom HTML header (dark mode) |
+| `project/doxygen/doxygen-awesome.css` | Theme CSS |
+| `project/doxygen/doxygen-awesome-darkmode-toggle.js` | Dark mode JS |
+| `.github/workflows/deploy-docs.yml` | GitHub Pages deployment |
+| `doc/mainpage.md` | Landing page |
+| `doc/tutorial_curves.md` | Curve fitting guide |
+| `doc/tutorial_surfaces.md` | Surface fitting guide |
+| `doc/tutorial_special.md` | Polar/sphere guide |
+| `doc/book_reference.md` | Book equation index |
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `src/fitpack_core.F90` | Add Doxygen blocks to ~112 routines |
+| `src/fitpack.f90` | Add module-level Doxygen comment |
+| `src/fitpack_fitters.f90` | Add type/method Doxygen comments |
+| `src/fitpack_curves.f90` | Add type/method Doxygen comments |
+| `src/fitpack_convex_curves.f90` | Add type/method Doxygen comments |
+| `src/fitpack_parametric_curves.f90` | Add type/method Doxygen comments |
+| `src/fitpack_surfaces.f90` | Add type/method Doxygen comments |
+| `src/fitpack_grid_surfaces.f90` | Add type/method Doxygen comments |
+| `src/fitpack_parametric_surfaces.f90` | Add type/method Doxygen comments |
+| `src/fitpack_polar.f90` | Add type/method Doxygen comments |
+| `src/fitpack_gridded_polar.f90` | Add type/method Doxygen comments |
+| `src/fitpack_spheres.f90` | Add type/method Doxygen comments |
+| `src/fitpack_gridded_sphere.f90` | Add type/method Doxygen comments |
+| `.gitignore` | Add `project/doxygen/html/` |
+
+## Execution Order
+
+Phases A → B → C → D → E. Within Phase B, steps B1-B9 are sequential (each
+establishes patterns the next follows). Phase C can partially overlap with late
+Phase B. Phase D can be written in parallel with Phase C.
+
+Given the size (~112 core routines + 13 OOP types + 5 guide pages), this will
+be split into multiple sub-PRs or done as one large documentation PR.

--- a/project/doxygen/Doxyfile
+++ b/project/doxygen/Doxyfile
@@ -1,0 +1,302 @@
+#******************************************************************************
+# Doxygen configuration for fitpack
+# Adapted from fortran-lapack Doxygen setup
+#******************************************************************************
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = fitpack
+PROJECT_NUMBER         =
+PROJECT_BRIEF          = "Modern Fortran library for curve and surface fitting with splines"
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       =
+CREATE_SUBDIRS         = NO
+OUTPUT_LANGUAGE        = English
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
+
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+
+ALWAYS_DETAILED_SEC    = YES
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = NO
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = NO
+QT_AUTOBRIEF           = NO
+MULTILINE_CPP_IS_BRIEF = NO
+PYTHON_DOCSTRING       = YES
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 4
+ALIASES                =
+OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = YES
+OPTIMIZE_OUTPUT_VHDL   = NO
+
+EXTENSION_MAPPING      = .F90=FortranFree
+EXTENSION_MAPPING     += .f90=FortranFree
+
+MARKDOWN_SUPPORT       = YES
+
+USE_MDFILE_AS_MAINPAGE = "../../doc/mainpage.md"
+
+TOC_INCLUDE_HEADINGS   = 5
+AUTOLINK_SUPPORT       = YES
+BUILTIN_STL_SUPPORT    = YES
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
+DISTRIBUTE_GROUP_DOC   = NO
+SUBGROUPING            = YES
+TYPEDEF_HIDES_STRUCT   = NO
+
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = YES
+EXTRACT_PACKAGE        = YES
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = YES
+EXTRACT_ANON_NSPACES   = NO
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = NO
+HIDE_SCOPE_NAMES       = NO
+SHOW_INCLUDE_FILES     = YES
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = YES
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = NO
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = YES
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           =
+
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = "../../src/"
+INPUT                 += "../../doc/mainpage.md"
+
+INPUT_ENCODING         = UTF-8
+
+FILE_PATTERNS          = *.F90 \
+                         *.f90 \
+                         *.f95 \
+                         *.f03 \
+                         *.f08 \
+                         *.f18 \
+                         *.f \
+                         *.for \
+                         *.md
+
+RECURSIVE              = YES
+EXCLUDE                =
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
+EXAMPLE_PATTERNS       =
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = NO
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = NO
+REFERENCES_RELATION    = NO
+REFERENCES_LINK_SOURCE = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+IGNORE_PREFIX          =
+
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            = header.html
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_COLORSTYLE        = LIGHT
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_DYNAMIC_MENUS     = YES
+HTML_DYNAMIC_SECTIONS  = NO
+HTML_EXTRA_FILES       = doxygen-awesome-darkmode-toggle.js
+HTML_EXTRA_STYLESHEET  = doxygen-awesome.css
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
+CHM_FILE               =
+HHC_LOCATION           =
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
+DISABLE_INDEX          = NO
+ENUM_VALUES_PER_LINE   = 4
+GENERATE_TREEVIEW      = YES
+FULL_SIDEBAR           = NO
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+FORMULA_FONTSIZE       = 16
+USE_MATHJAX            = YES
+MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/
+SEARCHENGINE           = YES
+SERVER_BASED_SEARCH    = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         = latex
+MAKEINDEX_CMD_NAME     = makeindex
+COMPACT_LATEX          = NO
+PAPER_TYPE             = a4
+EXTRA_PACKAGES         = {amsmath}
+EXTRA_PACKAGES        += {amssymb}
+LATEX_HEADER           =
+PDF_HYPERLINKS         = YES
+USE_PDFLATEX           = YES
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
+SKIP_FUNCTION_MACROS   = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+TEMPLATE_RELATIONS     = NO
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = YES
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = png
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES

--- a/project/doxygen/Doxyfile
+++ b/project/doxygen/Doxyfile
@@ -119,6 +119,10 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 INPUT                  = "../../src/"
 INPUT                 += "../../doc/mainpage.md"
+INPUT                 += "../../doc/tutorial_curves.md"
+INPUT                 += "../../doc/tutorial_surfaces.md"
+INPUT                 += "../../doc/tutorial_special.md"
+INPUT                 += "../../doc/book_reference.md"
 
 INPUT_ENCODING         = UTF-8
 

--- a/project/doxygen/Doxyfile
+++ b/project/doxygen/Doxyfile
@@ -69,7 +69,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # Build related configuration options
 #---------------------------------------------------------------------------
 EXTRACT_ALL            = YES
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 EXTRACT_STATIC         = YES
 EXTRACT_PACKAGE        = YES
 EXTRACT_LOCAL_CLASSES  = YES

--- a/project/doxygen/doxygen-awesome-darkmode-toggle.js
+++ b/project/doxygen/doxygen-awesome-darkmode-toggle.js
@@ -1,0 +1,157 @@
+/**
+
+Doxygen Awesome
+https://github.com/jothepro/doxygen-awesome-css
+
+MIT License
+
+Copyright (c) 2021 - 2023 jothepro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+class DoxygenAwesomeDarkModeToggle extends HTMLElement {
+    // SVG icons from https://fonts.google.com/icons
+    // Licensed under the Apache 2.0 license:
+    // https://www.apache.org/licenses/LICENSE-2.0.html
+    static lightModeIcon = `<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#FCBF00"><rect fill="none" height="24" width="24"/><circle cx="12" cy="12" opacity=".3" r="3"/><path d="M12,9c1.65,0,3,1.35,3,3s-1.35,3-3,3s-3-1.35-3-3S10.35,9,12,9 M12,7c-2.76,0-5,2.24-5,5s2.24,5,5,5s5-2.24,5-5 S14.76,7,12,7L12,7z M2,13l2,0c0.55,0,1-0.45,1-1s-0.45-1-1-1l-2,0c-0.55,0-1,0.45-1,1S1.45,13,2,13z M20,13l2,0c0.55,0,1-0.45,1-1 s-0.45-1-1-1l-2,0c-0.55,0-1,0.45-1,1S19.45,13,20,13z M11,2v2c0,0.55,0.45,1,1,1s1-0.45,1-1V2c0-0.55-0.45-1-1-1S11,1.45,11,2z M11,20v2c0,0.55,0.45,1,1,1s1-0.45,1-1v-2c0-0.55-0.45-1-1-1C11.45,19,11,19.45,11,20z M5.99,4.58c-0.39-0.39-1.03-0.39-1.41,0 c-0.39,0.39-0.39,1.03,0,1.41l1.06,1.06c0.39,0.39,1.03,0.39,1.41,0s0.39-1.03,0-1.41L5.99,4.58z M18.36,16.95 c-0.39-0.39-1.03-0.39-1.41,0c-0.39,0.39-0.39,1.03,0,1.41l1.06,1.06c0.39,0.39,1.03,0.39,1.41,0c0.39-0.39,0.39-1.03,0-1.41 L18.36,16.95z M19.42,5.99c0.39-0.39,0.39-1.03,0-1.41c-0.39-0.39-1.03-0.39-1.41,0l-1.06,1.06c-0.39,0.39-0.39,1.03,0,1.41 s1.03,0.39,1.41,0L19.42,5.99z M7.05,18.36c0.39-0.39,0.39-1.03,0-1.41c-0.39-0.39-1.03-0.39-1.41,0l-1.06,1.06 c-0.39,0.39-0.39,1.03,0,1.41s1.03,0.39,1.41,0L7.05,18.36z"/></svg>`
+    static darkModeIcon = `<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#FE9700"><rect fill="none" height="24" width="24"/><path d="M9.37,5.51C9.19,6.15,9.1,6.82,9.1,7.5c0,4.08,3.32,7.4,7.4,7.4c0.68,0,1.35-0.09,1.99-0.27 C17.45,17.19,14.93,19,12,19c-3.86,0-7-3.14-7-7C5,9.07,6.81,6.55,9.37,5.51z" opacity=".3"/><path d="M9.37,5.51C9.19,6.15,9.1,6.82,9.1,7.5c0,4.08,3.32,7.4,7.4,7.4c0.68,0,1.35-0.09,1.99-0.27C17.45,17.19,14.93,19,12,19 c-3.86,0-7-3.14-7-7C5,9.07,6.81,6.55,9.37,5.51z M12,3c-4.97,0-9,4.03-9,9s4.03,9,9,9s9-4.03,9-9c0-0.46-0.04-0.92-0.1-1.36 c-0.98,1.37-2.58,2.26-4.4,2.26c-2.98,0-5.4-2.42-5.4-5.4c0-1.81,0.89-3.42,2.26-4.4C12.92,3.04,12.46,3,12,3L12,3z"/></svg>`
+    static title = "Toggle Light/Dark Mode"
+
+    static prefersLightModeInDarkModeKey = "prefers-light-mode-in-dark-mode"
+    static prefersDarkModeInLightModeKey = "prefers-dark-mode-in-light-mode"
+
+    static _staticConstructor = function() {
+        DoxygenAwesomeDarkModeToggle.enableDarkMode(DoxygenAwesomeDarkModeToggle.userPreference)
+        // Update the color scheme when the browsers preference changes
+        // without user interaction on the website.
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+            DoxygenAwesomeDarkModeToggle.onSystemPreferenceChanged()
+        })
+        // Update the color scheme when the tab is made visible again.
+        // It is possible that the appearance was changed in another tab 
+        // while this tab was in the background.
+        document.addEventListener("visibilitychange", visibilityState => {
+            if (document.visibilityState === 'visible') {
+                DoxygenAwesomeDarkModeToggle.onSystemPreferenceChanged()
+            }
+        });
+    }()
+
+    static init() {
+        $(function() {
+            $(document).ready(function() {
+                const toggleButton = document.createElement('doxygen-awesome-dark-mode-toggle')
+                toggleButton.title = DoxygenAwesomeDarkModeToggle.title
+                toggleButton.updateIcon()
+
+                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+                    toggleButton.updateIcon()
+                })
+                document.addEventListener("visibilitychange", visibilityState => {
+                    if (document.visibilityState === 'visible') {
+                        toggleButton.updateIcon()
+                    }
+                });
+
+                $(document).ready(function(){
+                    document.getElementById("MSearchBox").parentNode.appendChild(toggleButton)
+                })
+                $(window).resize(function(){
+                    document.getElementById("MSearchBox").parentNode.appendChild(toggleButton)
+                })
+            })
+        })
+    }
+
+    constructor() {
+        super();
+        this.onclick=this.toggleDarkMode
+    }
+
+    /**
+     * @returns `true` for dark-mode, `false` for light-mode system preference
+     */
+    static get systemPreference() {
+        return window.matchMedia('(prefers-color-scheme: dark)').matches
+    }
+
+    /**
+     * @returns `true` for dark-mode, `false` for light-mode user preference
+     */
+    static get userPreference() {
+        return (!DoxygenAwesomeDarkModeToggle.systemPreference && localStorage.getItem(DoxygenAwesomeDarkModeToggle.prefersDarkModeInLightModeKey)) || 
+        (DoxygenAwesomeDarkModeToggle.systemPreference && !localStorage.getItem(DoxygenAwesomeDarkModeToggle.prefersLightModeInDarkModeKey))
+    }
+
+    static set userPreference(userPreference) {
+        DoxygenAwesomeDarkModeToggle.darkModeEnabled = userPreference
+        if(!userPreference) {
+            if(DoxygenAwesomeDarkModeToggle.systemPreference) {
+                localStorage.setItem(DoxygenAwesomeDarkModeToggle.prefersLightModeInDarkModeKey, true)
+            } else {
+                localStorage.removeItem(DoxygenAwesomeDarkModeToggle.prefersDarkModeInLightModeKey)
+            }
+        } else {
+            if(!DoxygenAwesomeDarkModeToggle.systemPreference) {
+                localStorage.setItem(DoxygenAwesomeDarkModeToggle.prefersDarkModeInLightModeKey, true)
+            } else {
+                localStorage.removeItem(DoxygenAwesomeDarkModeToggle.prefersLightModeInDarkModeKey)
+            }
+        }
+        DoxygenAwesomeDarkModeToggle.onUserPreferenceChanged()
+    }
+
+    static enableDarkMode(enable) {
+        if(enable) {
+            DoxygenAwesomeDarkModeToggle.darkModeEnabled = true
+            document.documentElement.classList.add("dark-mode")
+            document.documentElement.classList.remove("light-mode")
+        } else {
+            DoxygenAwesomeDarkModeToggle.darkModeEnabled = false
+            document.documentElement.classList.remove("dark-mode")
+            document.documentElement.classList.add("light-mode")
+        }
+    }
+
+    static onSystemPreferenceChanged() {
+        DoxygenAwesomeDarkModeToggle.darkModeEnabled = DoxygenAwesomeDarkModeToggle.userPreference
+        DoxygenAwesomeDarkModeToggle.enableDarkMode(DoxygenAwesomeDarkModeToggle.darkModeEnabled)
+    }
+
+    static onUserPreferenceChanged() {
+        DoxygenAwesomeDarkModeToggle.enableDarkMode(DoxygenAwesomeDarkModeToggle.darkModeEnabled)
+    }
+
+    toggleDarkMode() {
+        DoxygenAwesomeDarkModeToggle.userPreference = !DoxygenAwesomeDarkModeToggle.userPreference
+        this.updateIcon()
+    }
+
+    updateIcon() {
+        if(DoxygenAwesomeDarkModeToggle.darkModeEnabled) {
+            this.innerHTML = DoxygenAwesomeDarkModeToggle.darkModeIcon
+        } else {
+            this.innerHTML = DoxygenAwesomeDarkModeToggle.lightModeIcon
+        }
+    }
+}
+
+customElements.define("doxygen-awesome-dark-mode-toggle", DoxygenAwesomeDarkModeToggle);

--- a/project/doxygen/doxygen-awesome.css
+++ b/project/doxygen/doxygen-awesome.css
@@ -1,0 +1,2681 @@
+/**
+
+Doxygen Awesome
+https://github.com/jothepro/doxygen-awesome-css
+
+MIT License
+
+Copyright (c) 2021 - 2023 jothepro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+html {
+    /* primary theme color. This will affect the entire websites color scheme: links, arrows, labels, ... */
+    --primary-color: #1779c4;
+    --primary-dark-color: #335c80;
+    --primary-light-color: #70b1e9;
+
+    /* page base colors */
+    --page-background-color: #ffffff;
+    --page-foreground-color: #2f4153;
+    --page-secondary-foreground-color: #6f7e8e;
+
+    /* color for all separators on the website: hr, borders, ... */
+    --separator-color: #dedede;
+
+    /* border radius for all rounded components. Will affect many components, like dropdowns, memitems, codeblocks, ... */
+    --border-radius-large: 8px;
+    --border-radius-small: 4px;
+    --border-radius-medium: 6px;
+
+    /* default spacings. Most components reference these values for spacing, to provide uniform spacing on the page. */
+    --spacing-small: 5px;
+    --spacing-medium: 10px;
+    --spacing-large: 16px;
+
+    /* default box shadow used for raising an element above the normal content. Used in dropdowns, search result, ... */
+    --box-shadow: 0 2px 8px 0 rgba(0,0,0,.075);
+
+    --odd-color: rgba(0,0,0,.028);
+
+    /* font-families. will affect all text on the website
+     * font-family: the normal font for text, headlines, menus
+     * font-family-monospace: used for preformatted text in memtitle, code, fragments
+     */
+    --font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    --font-family-monospace: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+
+    /* font sizes */
+    --page-font-size: 15.6px;
+    --navigation-font-size: 14.4px;
+    --toc-font-size: 13.4px;
+    --code-font-size: 14px; /* affects code, fragment */
+    --title-font-size: 22px;
+
+    /* content text properties. These only affect the page content, not the navigation or any other ui elements */
+    --content-line-height: 27px;
+    /* The content is centered and constraint in it's width. To make the content fill the whole page, set the variable to auto.*/
+    --content-maxwidth: 1050px;
+    --table-line-height: 24px;
+    --toc-sticky-top: var(--spacing-medium);
+    --toc-width: 200px;
+    --toc-max-height: calc(100vh - 2 * var(--spacing-medium) - 85px);
+
+    /* colors for various content boxes: @warning, @note, @deprecated @bug */
+    --warning-color: #faf3d8;
+    --warning-color-dark: #f3a600;
+    --warning-color-darker: #5f4204;
+    --note-color: #e4f3ff;
+    --note-color-dark: #1879C4;
+    --note-color-darker: #274a5c;
+    --todo-color: #e4dafd;
+    --todo-color-dark: #5b2bdd;
+    --todo-color-darker: #2a0d72;
+    --deprecated-color: #ecf0f3;
+    --deprecated-color-dark: #5b6269;
+    --deprecated-color-darker: #43454a;
+    --bug-color: #f8d1cc;
+    --bug-color-dark: #b61825;
+    --bug-color-darker: #75070f;
+    --invariant-color: #d8f1e3;
+    --invariant-color-dark: #44b86f;
+    --invariant-color-darker: #265532;
+
+    /* blockquote colors */
+    --blockquote-background: #f8f9fa;
+    --blockquote-foreground: #636568;
+
+    /* table colors */
+    --tablehead-background: #f1f1f1;
+    --tablehead-foreground: var(--page-foreground-color);
+
+    /* menu-display: block | none
+     * Visibility of the top navigation on screens >= 768px. On smaller screen the menu is always visible.
+     * `GENERATE_TREEVIEW` MUST be enabled!
+     */
+    --menu-display: block;
+
+    --menu-focus-foreground: var(--page-background-color);
+    --menu-focus-background: var(--primary-color);
+    --menu-selected-background: rgba(0,0,0,.05);
+
+
+    --header-background: var(--page-background-color);
+    --header-foreground: var(--page-foreground-color);
+
+    /* searchbar colors */
+    --searchbar-background: var(--side-nav-background);
+    --searchbar-foreground: var(--page-foreground-color);
+
+    /* searchbar size
+     * (`searchbar-width` is only applied on screens >= 768px.
+     * on smaller screens the searchbar will always fill the entire screen width) */
+    --searchbar-height: 33px;
+    --searchbar-width: 210px;
+    --searchbar-border-radius: var(--searchbar-height);
+
+    /* code block colors */
+    --code-background: #f5f5f5;
+    --code-foreground: var(--page-foreground-color);
+
+    /* fragment colors */
+    --fragment-background: #F8F9FA;
+    --fragment-foreground: #37474F;
+    --fragment-keyword: #bb6bb2;
+    --fragment-keywordtype: #8258b3;
+    --fragment-keywordflow: #d67c3b;
+    --fragment-token: #438a59;
+    --fragment-comment: #969696;
+    --fragment-link: #5383d6;
+    --fragment-preprocessor: #46aaa5;
+    --fragment-linenumber-color: #797979;
+    --fragment-linenumber-background: #f4f4f5;
+    --fragment-linenumber-border: #e3e5e7;
+    --fragment-lineheight: 20px;
+
+    /* sidebar navigation (treeview) colors */
+    --side-nav-background: #fbfbfb;
+    --side-nav-foreground: var(--page-foreground-color);
+    --side-nav-arrow-opacity: 0;
+    --side-nav-arrow-hover-opacity: 0.9;
+
+    --toc-background: var(--side-nav-background);
+    --toc-foreground: var(--side-nav-foreground);
+
+    /* height of an item in any tree / collapsible table */
+    --tree-item-height: 30px;
+
+    --memname-font-size: var(--code-font-size);
+    --memtitle-font-size: 18px;
+
+    --webkit-scrollbar-size: 7px;
+    --webkit-scrollbar-padding: 4px;
+    --webkit-scrollbar-color: var(--separator-color);
+
+    --animation-duration: .12s
+}
+
+@media screen and (max-width: 767px) {
+    html {
+        --page-font-size: 16px;
+        --navigation-font-size: 16px;
+        --toc-font-size: 15px;
+        --code-font-size: 15px; /* affects code, fragment */
+        --title-font-size: 22px;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not(.light-mode) {
+        color-scheme: dark;
+
+        --primary-color: #1982d2;
+        --primary-dark-color: #86a9c4;
+        --primary-light-color: #4779ac;
+
+        --box-shadow: 0 2px 8px 0 rgba(0,0,0,.35);
+
+        --odd-color: rgba(100,100,100,.06);
+
+        --menu-selected-background: rgba(0,0,0,.4);
+
+        --page-background-color: #1C1D1F;
+        --page-foreground-color: #d2dbde;
+        --page-secondary-foreground-color: #859399;
+        --separator-color: #38393b;
+        --side-nav-background: #252628;
+
+        --code-background: #2a2c2f;
+
+        --tablehead-background: #2a2c2f;
+    
+        --blockquote-background: #222325;
+        --blockquote-foreground: #7e8c92;
+
+        --warning-color: #3b2e04;
+        --warning-color-dark: #f1b602;
+        --warning-color-darker: #ceb670;
+        --note-color: #163750;
+        --note-color-dark: #1982D2;
+        --note-color-darker: #dcf0fa;
+        --todo-color: #2a2536;
+        --todo-color-dark: #7661b3;
+        --todo-color-darker: #ae9ed6;
+        --deprecated-color: #2e323b;
+        --deprecated-color-dark: #738396;
+        --deprecated-color-darker: #abb0bd;
+        --bug-color: #2e1917;
+        --bug-color-dark: #ad2617;
+        --bug-color-darker: #f5b1aa;
+        --invariant-color: #303a35;
+        --invariant-color-dark: #76ce96;
+        --invariant-color-darker: #cceed5;
+
+        --fragment-background: #282c34;
+        --fragment-foreground: #dbe4eb;
+        --fragment-keyword: #cc99cd;
+        --fragment-keywordtype: #ab99cd;
+        --fragment-keywordflow: #e08000;
+        --fragment-token: #7ec699;
+        --fragment-comment: #999999;
+        --fragment-link: #98c0e3;
+        --fragment-preprocessor: #65cabe;
+        --fragment-linenumber-color: #cccccc;
+        --fragment-linenumber-background: #35393c;
+        --fragment-linenumber-border: #1f1f1f;
+    }
+}
+
+/* dark mode variables are defined twice, to support both the dark-mode without and with doxygen-awesome-darkmode-toggle.js */
+html.dark-mode {
+    color-scheme: dark;
+
+    --primary-color: #1982d2;
+    --primary-dark-color: #86a9c4;
+    --primary-light-color: #4779ac;
+
+    --box-shadow: 0 2px 8px 0 rgba(0,0,0,.30);
+
+    --odd-color: rgba(100,100,100,.06);
+
+    --menu-selected-background: rgba(0,0,0,.4);
+
+    --page-background-color: #1C1D1F;
+    --page-foreground-color: #d2dbde;
+    --page-secondary-foreground-color: #859399;
+    --separator-color: #38393b;
+    --side-nav-background: #252628;
+
+    --code-background: #2a2c2f;
+
+    --tablehead-background: #2a2c2f;
+
+    --blockquote-background: #222325;
+    --blockquote-foreground: #7e8c92;
+
+    --warning-color: #3b2e04;
+    --warning-color-dark: #f1b602;
+    --warning-color-darker: #ceb670;
+    --note-color: #163750;
+    --note-color-dark: #1982D2;
+    --note-color-darker: #dcf0fa;
+    --todo-color: #2a2536;
+    --todo-color-dark: #7661b3;
+    --todo-color-darker: #ae9ed6;
+    --deprecated-color: #2e323b;
+    --deprecated-color-dark: #738396;
+    --deprecated-color-darker: #abb0bd;
+    --bug-color: #2e1917;
+    --bug-color-dark: #ad2617;
+    --bug-color-darker: #f5b1aa;
+    --invariant-color: #303a35;
+    --invariant-color-dark: #76ce96;
+    --invariant-color-darker: #cceed5;
+
+    --fragment-background: #282c34;
+    --fragment-foreground: #dbe4eb;
+    --fragment-keyword: #cc99cd;
+    --fragment-keywordtype: #ab99cd;
+    --fragment-keywordflow: #e08000;
+    --fragment-token: #7ec699;
+    --fragment-comment: #999999;
+    --fragment-link: #98c0e3;
+    --fragment-preprocessor: #65cabe;
+    --fragment-linenumber-color: #cccccc;
+    --fragment-linenumber-background: #35393c;
+    --fragment-linenumber-border: #1f1f1f;
+}
+
+body {
+    color: var(--page-foreground-color);
+    background-color: var(--page-background-color);
+    font-size: var(--page-font-size);
+}
+
+body, table, div, p, dl, #nav-tree .label, .title,
+.sm-dox a, .sm-dox a:hover, .sm-dox a:focus, #projectname,
+.SelectItem, #MSearchField, .navpath li.navelem a,
+.navpath li.navelem a:hover, p.reference, p.definition, div.toc li, div.toc h3 {
+    font-family: var(--font-family);
+}
+
+h1, h2, h3, h4, h5 {
+    margin-top: 1em;
+    font-weight: 600;
+    line-height: initial;
+}
+
+p, div, table, dl, p.reference, p.definition {
+    font-size: var(--page-font-size);
+}
+
+p.reference, p.definition {
+    color: var(--page-secondary-foreground-color);
+}
+
+a:link, a:visited, a:hover, a:focus, a:active {
+    color: var(--primary-color) !important;
+    font-weight: 500;
+    background: none;
+}
+
+a.anchor {
+    scroll-margin-top: var(--spacing-large);
+    display: block;
+}
+
+/*
+ Title and top navigation
+ */
+
+#top {
+    background: var(--header-background);
+    border-bottom: 1px solid var(--separator-color);
+}
+
+@media screen and (min-width: 768px) {
+    #top {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: center;
+    }
+}
+
+#main-nav {
+    flex-grow: 5;
+    padding: var(--spacing-small) var(--spacing-medium);
+}
+
+#titlearea {
+    width: auto;
+    padding: var(--spacing-medium) var(--spacing-large);
+    background: none;
+    color: var(--header-foreground);
+    border-bottom: none;
+}
+
+@media screen and (max-width: 767px) {
+    #titlearea {
+        padding-bottom: var(--spacing-small);
+    }
+}
+
+#titlearea table tbody tr {
+    height: auto !important;
+}
+
+#projectname {
+    font-size: var(--title-font-size);
+    font-weight: 600;
+}
+
+#projectnumber {
+    font-family: inherit;
+    font-size: 60%;
+}
+
+#projectbrief {
+    font-family: inherit;
+    font-size: 80%;
+}
+
+#projectlogo {
+    vertical-align: middle;
+}
+
+#projectlogo img {
+    max-height: calc(var(--title-font-size) * 2);
+    margin-right: var(--spacing-small);
+}
+
+.sm-dox, .tabs, .tabs2, .tabs3 {
+    background: none;
+    padding: 0;
+}
+
+.tabs, .tabs2, .tabs3 {
+    border-bottom: 1px solid var(--separator-color);
+    margin-bottom: -1px;
+}
+
+.main-menu-btn-icon, .main-menu-btn-icon:before, .main-menu-btn-icon:after {
+    background: var(--page-secondary-foreground-color);
+}
+
+@media screen and (max-width: 767px) {
+    .sm-dox a span.sub-arrow {
+        background: var(--code-background);
+    }
+
+    #main-menu a.has-submenu span.sub-arrow {
+        color: var(--page-secondary-foreground-color);
+        border-radius: var(--border-radius-medium);
+    }
+
+    #main-menu a.has-submenu:hover span.sub-arrow {
+        color: var(--page-foreground-color);
+    }
+}
+
+@media screen and (min-width: 768px) {
+    .sm-dox li, .tablist li {
+        display: var(--menu-display);
+    }
+
+    .sm-dox a span.sub-arrow {
+        border-color: var(--header-foreground) transparent transparent transparent;
+    }
+
+    .sm-dox a:hover span.sub-arrow {
+        border-color: var(--menu-focus-foreground) transparent transparent transparent;
+    }
+
+    .sm-dox ul a span.sub-arrow {
+        border-color: transparent transparent transparent var(--page-foreground-color);
+    }
+
+    .sm-dox ul a:hover span.sub-arrow {
+        border-color: transparent transparent transparent var(--menu-focus-foreground);
+    }
+}
+
+.sm-dox ul {
+    background: var(--page-background-color);
+    box-shadow: var(--box-shadow);
+    border: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-medium) !important;
+    padding: var(--spacing-small);
+    animation: ease-out 150ms slideInMenu;
+}
+
+@keyframes slideInMenu {
+    from {
+        opacity: 0;
+        transform: translate(0px, -2px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translate(0px, 0px);
+    }
+}
+
+.sm-dox ul a {
+    color: var(--page-foreground-color) !important;
+    background: var(--page-background-color);
+    font-size: var(--navigation-font-size);
+}
+
+.sm-dox>li>ul:after {
+    border-bottom-color: var(--page-background-color) !important;
+}
+
+.sm-dox>li>ul:before {
+    border-bottom-color: var(--separator-color) !important;
+}
+
+.sm-dox ul a:hover, .sm-dox ul a:active, .sm-dox ul a:focus {
+    font-size: var(--navigation-font-size) !important;
+    color: var(--menu-focus-foreground) !important;
+    text-shadow: none;
+    background-color: var(--menu-focus-background);
+    border-radius: var(--border-radius-small) !important;
+}
+
+.sm-dox a, .sm-dox a:focus, .tablist li, .tablist li a, .tablist li.current a {
+    text-shadow: none;
+    background: transparent;
+    background-image: none !important;
+    color: var(--header-foreground) !important;
+    font-weight: normal;
+    font-size: var(--navigation-font-size);
+    border-radius: var(--border-radius-small) !important;
+}
+
+.sm-dox a:focus {
+    outline: auto;
+}
+
+.sm-dox a:hover, .sm-dox a:active, .tablist li a:hover {
+    text-shadow: none;
+    font-weight: normal;
+    background: var(--menu-focus-background);
+    color: var(--menu-focus-foreground) !important;
+    border-radius: var(--border-radius-small) !important;
+    font-size: var(--navigation-font-size);
+}
+
+.tablist li.current {
+    border-radius: var(--border-radius-small);
+    background: var(--menu-selected-background);
+}
+
+.tablist li {
+    margin: var(--spacing-small) 0 var(--spacing-small) var(--spacing-small);
+}
+
+.tablist a {
+    padding: 0 var(--spacing-large);
+}
+
+
+/*
+ Search box
+ */
+
+#MSearchBox {
+    height: var(--searchbar-height);
+    background: var(--searchbar-background);
+    border-radius: var(--searchbar-border-radius);
+    border: 1px solid var(--separator-color);
+    overflow: hidden;
+    width: var(--searchbar-width);
+    position: relative;
+    box-shadow: none;
+    display: block;
+    margin-top: 0;
+}
+
+/* until Doxygen 1.9.4 */
+.left img#MSearchSelect {
+    left: 0;
+    user-select: none;
+    padding-left: 8px;
+}
+
+/* Doxygen 1.9.5 */
+.left span#MSearchSelect {
+    left: 0;
+    user-select: none;
+    margin-left: 8px;
+    padding: 0;
+}
+
+.left #MSearchSelect[src$=".png"] {
+    padding-left: 0
+}
+
+.SelectionMark {
+    user-select: none;
+}
+
+.tabs .left #MSearchSelect {
+    padding-left: 0;
+}
+
+.tabs #MSearchBox {
+    position: absolute;
+    right: var(--spacing-medium);
+}
+
+@media screen and (max-width: 767px) {
+    .tabs #MSearchBox {
+        position: relative;
+        right: 0;
+        margin-left: var(--spacing-medium);
+        margin-top: 0;
+    }
+}
+
+#MSearchSelectWindow, #MSearchResultsWindow {
+    z-index: 9999;
+}
+
+#MSearchBox.MSearchBoxActive {
+    border-color: var(--primary-color);
+    box-shadow: inset 0 0 0 1px var(--primary-color);
+}
+
+#main-menu > li:last-child {
+    margin-right: 0;
+}
+
+@media screen and (max-width: 767px) {
+    #main-menu > li:last-child {
+        height: 50px;
+    }
+}
+
+#MSearchField {
+    font-size: var(--navigation-font-size);
+    height: calc(var(--searchbar-height) - 2px);
+    background: transparent;
+    width: calc(var(--searchbar-width) - 64px);
+}
+
+.MSearchBoxActive #MSearchField {
+    color: var(--searchbar-foreground);
+}
+
+#MSearchSelect {
+    top: calc(calc(var(--searchbar-height) / 2) - 11px);
+}
+
+#MSearchBox span.left, #MSearchBox span.right {
+    background: none;
+    background-image: none;
+}
+
+#MSearchBox span.right {
+    padding-top: calc(calc(var(--searchbar-height) / 2) - 12px);
+    position: absolute;
+    right: var(--spacing-small);
+}
+
+.tabs #MSearchBox span.right {
+    top: calc(calc(var(--searchbar-height) / 2) - 12px);
+}
+
+@keyframes slideInSearchResults {
+    from {
+        opacity: 0;
+        transform: translate(0, 15px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translate(0, 20px);
+    }
+}
+
+#MSearchResultsWindow {
+    left: auto !important;
+    right: var(--spacing-medium);
+    border-radius: var(--border-radius-large);
+    border: 1px solid var(--separator-color);
+    transform: translate(0, 20px);
+    box-shadow: var(--box-shadow);
+    animation: ease-out 280ms slideInSearchResults;
+    background: var(--page-background-color);
+}
+
+iframe#MSearchResults {
+    margin: 4px;
+}
+
+iframe {
+    color-scheme: normal;
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not(.light-mode) iframe#MSearchResults {
+        filter: invert() hue-rotate(180deg);
+    }
+}
+
+html.dark-mode iframe#MSearchResults {
+    filter: invert() hue-rotate(180deg);
+}
+
+#MSearchResults .SRPage {
+    background-color: transparent;
+}
+
+#MSearchResults .SRPage .SREntry {
+    font-size: 10pt;
+    padding: var(--spacing-small) var(--spacing-medium);
+}
+
+#MSearchSelectWindow {
+    border: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-medium);
+    box-shadow: var(--box-shadow);
+    background: var(--page-background-color);
+    padding-top: var(--spacing-small);
+    padding-bottom: var(--spacing-small);
+}
+
+#MSearchSelectWindow a.SelectItem {
+    font-size: var(--navigation-font-size);
+    line-height: var(--content-line-height);
+    margin: 0 var(--spacing-small);
+    border-radius: var(--border-radius-small);
+    color: var(--page-foreground-color) !important;
+    font-weight: normal;
+}
+
+#MSearchSelectWindow a.SelectItem:hover {
+    background: var(--menu-focus-background);
+    color: var(--menu-focus-foreground) !important;
+}
+
+@media screen and (max-width: 767px) {
+    #MSearchBox {
+        margin-top: var(--spacing-medium);
+        margin-bottom: var(--spacing-medium);
+        width: calc(100vw - 30px);
+    }
+
+    #main-menu > li:last-child {
+        float: none !important;
+    }
+
+    #MSearchField {
+        width: calc(100vw - 110px);
+    }
+
+    @keyframes slideInSearchResultsMobile {
+        from {
+            opacity: 0;
+            transform: translate(0, 15px);
+        }
+
+        to {
+            opacity: 1;
+            transform: translate(0, 20px);
+        }
+    }
+
+    #MSearchResultsWindow {
+        left: var(--spacing-medium) !important;
+        right: var(--spacing-medium);
+        overflow: auto;
+        transform: translate(0, 20px);
+        animation: ease-out 280ms slideInSearchResultsMobile;
+        width: auto !important;
+    }
+
+    /*
+     * Overwrites for fixing the searchbox on mobile in doxygen 1.9.2
+     */
+    label.main-menu-btn ~ #searchBoxPos1 {
+        top: 3px !important;
+        right: 6px !important;
+        left: 45px;
+        display: flex;
+    }
+
+    label.main-menu-btn ~ #searchBoxPos1 > #MSearchBox {
+        margin-top: 0;
+        margin-bottom: 0;
+        flex-grow: 2;
+        float: left;
+    }
+}
+
+/*
+ Tree view
+ */
+
+#side-nav {
+    padding: 0 !important;
+    background: var(--side-nav-background);
+    min-width: 8px;
+    max-width: 50vw;
+}
+
+@media screen and (max-width: 767px) {
+    #side-nav {
+        display: none;
+    }
+
+    #doc-content {
+        margin-left: 0 !important;
+    }
+}
+
+#nav-tree {
+    background: transparent;
+    margin-right: 1px;
+}
+
+#nav-tree .label {
+    font-size: var(--navigation-font-size);
+}
+
+#nav-tree .item {
+    height: var(--tree-item-height);
+    line-height: var(--tree-item-height);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+#nav-tree .item > a:focus {
+    outline: none;
+}
+
+#nav-sync {
+    bottom: 12px;
+    right: 12px;
+    top: auto !important;
+    user-select: none;
+}
+
+#nav-tree .selected {
+    text-shadow: none;
+    background-image: none;
+    background-color: transparent;
+    position: relative;
+    color: var(--primary-color) !important;
+    font-weight: 500;
+}
+
+#nav-tree .selected::after {
+    content: "";
+    position: absolute;
+    top: 1px;
+    bottom: 1px;
+    left: 0;
+    width: 4px;
+    border-radius: 0 var(--border-radius-small) var(--border-radius-small) 0;
+    background: var(--primary-color);
+}
+
+
+#nav-tree a {
+    color: var(--side-nav-foreground) !important;
+    font-weight: normal;
+}
+
+#nav-tree a:focus {
+    outline-style: auto;
+}
+
+#nav-tree .arrow {
+    opacity: var(--side-nav-arrow-opacity);
+    background: none;
+}
+
+.arrow {
+    color: inherit;
+    cursor: pointer;
+    font-size: 45%;
+    vertical-align: middle;
+    margin-right: 2px;
+    font-family: serif;
+    height: auto;
+    text-align: right;
+}
+
+#nav-tree div.item:hover .arrow, #nav-tree a:focus .arrow {
+    opacity: var(--side-nav-arrow-hover-opacity);
+}
+
+#nav-tree .selected a {
+    color: var(--primary-color) !important;
+    font-weight: bolder;
+    font-weight: 600;
+}
+
+.ui-resizable-e {
+    width: 4px;
+    background: transparent;
+    box-shadow: inset -1px 0 0 0 var(--separator-color);
+}
+
+/*
+ Contents
+ */
+
+div.header {
+    border-bottom: 1px solid var(--separator-color);
+    background-color: var(--page-background-color);
+    background-image: none;
+}
+
+@media screen and (min-width: 1000px) {
+    #doc-content > div > div.contents,
+    .PageDoc > div.contents {
+        display: flex;
+        flex-direction: row-reverse;
+        flex-wrap: nowrap;
+        align-items: flex-start;
+    }
+    
+    div.contents .textblock {
+        min-width: 200px;
+        flex-grow: 1;
+    }
+}
+
+div.contents, div.header .title, div.header .summary {
+    max-width: var(--content-maxwidth);
+}
+
+div.contents, div.header .title  {
+    line-height: initial;
+    margin: calc(var(--spacing-medium) + .2em) auto var(--spacing-medium) auto;
+}
+
+div.header .summary {
+    margin: var(--spacing-medium) auto 0 auto;
+}
+
+div.headertitle {
+    padding: 0;
+}
+
+div.header .title {
+    font-weight: 600;
+    font-size: 225%;
+    padding: var(--spacing-medium) var(--spacing-large);
+    word-break: break-word;
+}
+
+div.header .summary {
+    width: auto;
+    display: block;
+    float: none;
+    padding: 0 var(--spacing-large);
+}
+
+td.memSeparator {
+    border-color: var(--separator-color);
+}
+
+span.mlabel {
+    background: var(--primary-color);
+    border: none;
+    padding: 4px 9px;
+    border-radius: 12px;
+    margin-right: var(--spacing-medium);
+}
+
+span.mlabel:last-of-type {
+    margin-right: 2px;
+}
+
+div.contents {
+    padding: 0 var(--spacing-large);
+}
+
+div.contents p, div.contents li {
+    line-height: var(--content-line-height);
+}
+
+div.contents div.dyncontent {
+    margin: var(--spacing-medium) 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not(.light-mode) div.contents div.dyncontent img,
+    html:not(.light-mode) div.contents center img,
+    html:not(.light-mode) div.contents > table img,
+    html:not(.light-mode) div.contents div.dyncontent iframe,
+    html:not(.light-mode) div.contents center iframe,
+    html:not(.light-mode) div.contents table iframe,
+    html:not(.light-mode) div.contents .dotgraph iframe {
+        filter: brightness(89%) hue-rotate(180deg) invert();
+    }
+}
+
+html.dark-mode div.contents div.dyncontent img,
+html.dark-mode div.contents center img,
+html.dark-mode div.contents > table img,
+html.dark-mode div.contents div.dyncontent iframe,
+html.dark-mode div.contents center iframe,
+html.dark-mode div.contents table iframe,
+html.dark-mode div.contents .dotgraph iframe
+ {
+    filter: brightness(89%) hue-rotate(180deg) invert();
+}
+
+h2.groupheader {
+    border-bottom: 0px;
+    color: var(--page-foreground-color);
+    box-shadow: 
+        100px 0 var(--page-background-color), 
+        -100px 0 var(--page-background-color),
+        100px 0.75px var(--separator-color),
+        -100px 0.75px var(--separator-color),
+        500px 0 var(--page-background-color), 
+        -500px 0 var(--page-background-color),
+        500px 0.75px var(--separator-color),
+        -500px 0.75px var(--separator-color),
+        900px 0 var(--page-background-color), 
+        -900px 0 var(--page-background-color),
+        900px 0.75px var(--separator-color),
+        -900px 0.75px var(--separator-color),
+        1400px 0 var(--page-background-color),
+        -1400px 0 var(--page-background-color), 
+        1400px 0.75px var(--separator-color),
+        -1400px 0.75px var(--separator-color),
+        1900px 0 var(--page-background-color),
+        -1900px 0 var(--page-background-color),
+        1900px 0.75px var(--separator-color),
+        -1900px 0.75px var(--separator-color);
+}
+
+blockquote {
+    margin: 0 var(--spacing-medium) 0 var(--spacing-medium);
+    padding: var(--spacing-small) var(--spacing-large);
+    background: var(--blockquote-background);
+    color: var(--blockquote-foreground);
+    border-left: 0;
+    overflow: visible;
+    border-radius: var(--border-radius-medium);
+    overflow: visible;
+    position: relative;
+}
+
+blockquote::before, blockquote::after {
+    font-weight: bold;
+    font-family: serif;
+    font-size: 360%;
+    opacity: .15;
+    position: absolute;
+}
+
+blockquote::before {
+    content: "“";
+    left: -10px;
+    top: 4px;
+}
+
+blockquote::after {
+    content: "”";
+    right: -8px;
+    bottom: -25px;
+}
+
+blockquote p {
+    margin: var(--spacing-small) 0 var(--spacing-medium) 0;
+}
+.paramname, .paramname em {
+    font-weight: 600;
+    color: var(--primary-dark-color);
+}
+
+.paramname > code {
+    border: 0;
+}
+
+table.params .paramname {
+    font-weight: 600;
+    font-family: var(--font-family-monospace);
+    font-size: var(--code-font-size);
+    padding-right: var(--spacing-small);
+    line-height: var(--table-line-height);
+}
+
+h1.glow, h2.glow, h3.glow, h4.glow, h5.glow, h6.glow {
+    text-shadow: 0 0 15px var(--primary-light-color);
+}
+
+.alphachar a {
+    color: var(--page-foreground-color);
+}
+
+.dotgraph {
+    max-width: 100%;
+    overflow-x: scroll;
+}
+
+.dotgraph .caption {
+    position: sticky;
+    left: 0;
+}
+
+/* Wrap Graphviz graphs with the `interactive_dotgraph` class if `INTERACTIVE_SVG = YES` */
+.interactive_dotgraph .dotgraph iframe {
+    max-width: 100%;
+}
+
+/*
+ Table of Contents
+ */
+
+div.contents .toc {
+    max-height: var(--toc-max-height);
+    min-width: var(--toc-width);
+    border: 0;
+    border-left: 1px solid var(--separator-color);
+    border-radius: 0;
+    background-color: var(--page-background-color);
+    box-shadow: none;
+    position: sticky;
+    top: var(--toc-sticky-top);
+    padding: 0 var(--spacing-large);
+    margin: var(--spacing-small) 0 var(--spacing-large) var(--spacing-large);
+}
+
+div.toc h3 {
+    color: var(--toc-foreground);
+    font-size: var(--navigation-font-size);
+    margin: var(--spacing-large) 0 var(--spacing-medium) 0;
+}
+
+div.toc li {
+    padding: 0;
+    background: none;
+    line-height: var(--toc-font-size);
+    margin: var(--toc-font-size) 0 0 0;
+}
+
+div.toc li::before {
+    display: none;
+}
+
+div.toc ul {
+    margin-top: 0
+}
+
+div.toc li a {
+    font-size: var(--toc-font-size);
+    color: var(--page-foreground-color) !important;
+    text-decoration: none;
+}
+
+div.toc li a:hover, div.toc li a.active {
+    color: var(--primary-color) !important;
+}
+
+div.toc li a.aboveActive {
+    color: var(--page-secondary-foreground-color) !important;
+}
+
+
+@media screen and (max-width: 999px) {
+    div.contents .toc {
+        max-height: 45vh;
+        float: none;
+        width: auto;
+        margin: 0 0 var(--spacing-medium) 0;
+        position: relative;
+        top: 0;
+        position: relative;
+        border: 1px solid var(--separator-color);
+        border-radius: var(--border-radius-medium);
+        background-color: var(--toc-background);
+        box-shadow: var(--box-shadow);
+    }
+
+    div.contents .toc.interactive {
+        max-height: calc(var(--navigation-font-size) + 2 * var(--spacing-large));
+        overflow: hidden;
+    }
+
+    div.contents .toc > h3 {
+        -webkit-tap-highlight-color: transparent;
+        cursor: pointer;
+        position: sticky;
+        top: 0;
+        background-color: var(--toc-background);
+        margin: 0;
+        padding: var(--spacing-large) 0;
+        display: block;
+    }
+
+    div.contents .toc.interactive > h3::before {
+        content: "";
+        width: 0; 
+        height: 0; 
+        border-left: 4px solid transparent;
+        border-right: 4px solid transparent;
+        border-top: 5px solid var(--primary-color);
+        display: inline-block;
+        margin-right: var(--spacing-small);
+        margin-bottom: calc(var(--navigation-font-size) / 4);
+        transform: rotate(-90deg);
+        transition: transform var(--animation-duration) ease-out;
+    }
+
+    div.contents .toc.interactive.open > h3::before {
+        transform: rotate(0deg);
+    }
+
+    div.contents .toc.interactive.open {
+        max-height: 45vh;
+        overflow: auto;
+        transition: max-height 0.2s ease-in-out;
+    }
+
+    div.contents .toc a, div.contents .toc a.active {
+        color: var(--primary-color) !important;
+    }
+
+    div.contents .toc a:hover {
+        text-decoration: underline;
+    }
+}
+
+/*
+ Code & Fragments
+ */
+
+code, div.fragment, pre.fragment {
+    border-radius: var(--border-radius-small);
+    border: 1px solid var(--separator-color);
+    overflow: hidden;
+}
+
+code {
+    display: inline;
+    background: var(--code-background);
+    color: var(--code-foreground);
+    padding: 2px 6px;
+}
+
+div.fragment, pre.fragment {
+    margin: var(--spacing-medium) 0;
+    padding: calc(var(--spacing-large) - (var(--spacing-large) / 6)) var(--spacing-large);
+    background: var(--fragment-background);
+    color: var(--fragment-foreground);
+    overflow-x: auto;
+}
+
+@media screen and (max-width: 767px) {
+    div.fragment, pre.fragment {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+        border-right: 0;
+    }
+
+    .contents > div.fragment,
+    .textblock > div.fragment,
+    .textblock > pre.fragment,
+    .textblock > .tabbed > ul > li > div.fragment,
+    .textblock > .tabbed > ul > li > pre.fragment,
+    .contents > .doxygen-awesome-fragment-wrapper > div.fragment,
+    .textblock > .doxygen-awesome-fragment-wrapper > div.fragment,
+    .textblock > .doxygen-awesome-fragment-wrapper > pre.fragment,
+    .textblock > .tabbed > ul > li > .doxygen-awesome-fragment-wrapper > div.fragment,
+    .textblock > .tabbed > ul > li > .doxygen-awesome-fragment-wrapper > pre.fragment {
+        margin: var(--spacing-medium) calc(0px - var(--spacing-large));
+        border-radius: 0;
+        border-left: 0;
+    }
+
+    .textblock li > .fragment,
+    .textblock li > .doxygen-awesome-fragment-wrapper > .fragment {
+        margin: var(--spacing-medium) calc(0px - var(--spacing-large));
+    }
+
+    .memdoc li > .fragment,
+    .memdoc li > .doxygen-awesome-fragment-wrapper > .fragment {
+        margin: var(--spacing-medium) calc(0px - var(--spacing-medium));
+    }
+
+    .textblock ul, .memdoc ul {
+        overflow: initial;
+    }
+
+    .memdoc > div.fragment,
+    .memdoc > pre.fragment,
+    dl dd > div.fragment,
+    dl dd pre.fragment,
+    .memdoc > .doxygen-awesome-fragment-wrapper > div.fragment,
+    .memdoc > .doxygen-awesome-fragment-wrapper > pre.fragment,
+    dl dd > .doxygen-awesome-fragment-wrapper > div.fragment,
+    dl dd .doxygen-awesome-fragment-wrapper > pre.fragment {
+        margin: var(--spacing-medium) calc(0px - var(--spacing-medium));
+        border-radius: 0;
+        border-left: 0;
+    }
+}
+
+code, code a, pre.fragment, div.fragment, div.fragment .line, div.fragment span, div.fragment .line a, div.fragment .line span {
+    font-family: var(--font-family-monospace);
+    font-size: var(--code-font-size) !important;
+}
+
+div.line:after {
+    margin-right: var(--spacing-medium);
+}
+
+div.fragment .line, pre.fragment {
+    white-space: pre;
+    word-wrap: initial;
+    line-height: var(--fragment-lineheight);
+}
+
+div.fragment span.keyword {
+    color: var(--fragment-keyword);
+}
+
+div.fragment span.keywordtype {
+    color: var(--fragment-keywordtype);
+}
+
+div.fragment span.keywordflow {
+    color: var(--fragment-keywordflow);
+}
+
+div.fragment span.stringliteral {
+    color: var(--fragment-token)
+}
+
+div.fragment span.comment {
+    color: var(--fragment-comment);
+}
+
+div.fragment a.code {
+    color: var(--fragment-link) !important;
+}
+
+div.fragment span.preprocessor {
+    color: var(--fragment-preprocessor);
+}
+
+div.fragment span.lineno {
+    display: inline-block;
+    width: 27px;
+    border-right: none;
+    background: var(--fragment-linenumber-background);
+    color: var(--fragment-linenumber-color);
+}
+
+div.fragment span.lineno a {
+    background: none;
+    color: var(--fragment-link) !important;
+}
+
+div.fragment > .line:first-child .lineno {
+    box-shadow: -999999px 0px 0 999999px var(--fragment-linenumber-background), -999998px 0px 0 999999px var(--fragment-linenumber-border);
+    background-color: var(--fragment-linenumber-background) !important;
+}
+
+div.line {
+    border-radius: var(--border-radius-small);
+}
+
+div.line.glow {
+    background-color: var(--primary-light-color);
+    box-shadow: none;
+}
+
+/*
+ dl warning, attention, note, deprecated, bug, ...
+ */
+
+dl.bug dt a, dl.deprecated dt a, dl.todo dt a {
+    font-weight: bold !important;
+}
+
+dl.warning, dl.attention, dl.note, dl.deprecated, dl.bug, dl.invariant, dl.pre, dl.post, dl.todo, dl.remark {
+    padding: var(--spacing-medium);
+    margin: var(--spacing-medium) 0;
+    color: var(--page-background-color);
+    overflow: hidden;
+    margin-left: 0;
+    border-radius: var(--border-radius-small);
+}
+
+dl.section dd {
+    margin-bottom: 2px;
+}
+
+dl.warning, dl.attention {
+    background: var(--warning-color);
+    border-left: 8px solid var(--warning-color-dark);
+    color: var(--warning-color-darker);
+}
+
+dl.warning dt, dl.attention dt {
+    color: var(--warning-color-dark);
+}
+
+dl.note, dl.remark {
+    background: var(--note-color);
+    border-left: 8px solid var(--note-color-dark);
+    color: var(--note-color-darker);
+}
+
+dl.note dt, dl.remark dt {
+    color: var(--note-color-dark);
+}
+
+dl.todo {
+    background: var(--todo-color);
+    border-left: 8px solid var(--todo-color-dark);
+    color: var(--todo-color-darker);
+}
+
+dl.todo dt a {
+    color: var(--todo-color-dark) !important;
+}
+
+dl.bug dt a {
+    color: var(--todo-color-dark) !important;
+}
+
+dl.bug {
+    background: var(--bug-color);
+    border-left: 8px solid var(--bug-color-dark);
+    color: var(--bug-color-darker);
+}
+
+dl.bug dt a {
+    color: var(--bug-color-dark) !important;
+}
+
+dl.deprecated {
+    background: var(--deprecated-color);
+    border-left: 8px solid var(--deprecated-color-dark);
+    color: var(--deprecated-color-darker);
+}
+
+dl.deprecated dt a {
+    color: var(--deprecated-color-dark) !important;
+}
+
+dl.section dd, dl.bug dd, dl.deprecated dd, dl.todo dd {
+    margin-inline-start: 0px;
+}
+
+dl.invariant, dl.pre, dl.post {
+    background: var(--invariant-color);
+    border-left: 8px solid var(--invariant-color-dark);
+    color: var(--invariant-color-darker);
+}
+
+dl.invariant dt, dl.pre dt, dl.post dt {
+    color: var(--invariant-color-dark);
+}
+
+/*
+ memitem
+ */
+
+div.memdoc, div.memproto, h2.memtitle {
+    box-shadow: none;
+    background-image: none;
+    border: none;
+}
+
+div.memdoc {
+    padding: 0 var(--spacing-medium);
+    background: var(--page-background-color);
+}
+
+h2.memtitle, div.memitem {
+    border: 1px solid var(--separator-color);
+    box-shadow: var(--box-shadow);
+}
+
+h2.memtitle {
+    box-shadow: 0px var(--spacing-medium) 0 -1px var(--fragment-background), var(--box-shadow);
+}
+
+div.memitem {
+    transition: none;
+}
+
+div.memproto, h2.memtitle {
+    background: var(--fragment-background);
+}
+
+h2.memtitle {
+    font-weight: 500;
+    font-size: var(--memtitle-font-size);
+    font-family: var(--font-family-monospace);
+    border-bottom: none;
+    border-top-left-radius: var(--border-radius-medium);
+    border-top-right-radius: var(--border-radius-medium);
+    word-break: break-all;
+    position: relative;
+}
+
+h2.memtitle:after {
+    content: "";
+    display: block;
+    background: var(--fragment-background);
+    height: var(--spacing-medium);
+    bottom: calc(0px - var(--spacing-medium));
+    left: 0;
+    right: -14px;
+    position: absolute;
+    border-top-right-radius: var(--border-radius-medium);
+}
+
+h2.memtitle > span.permalink {
+    font-size: inherit;
+}
+
+h2.memtitle > span.permalink > a {
+    text-decoration: none;
+    padding-left: 3px;
+    margin-right: -4px;
+    user-select: none;
+    display: inline-block;
+    margin-top: -6px;
+}
+
+h2.memtitle > span.permalink > a:hover {
+    color: var(--primary-dark-color) !important;
+}
+
+a:target + h2.memtitle, a:target + h2.memtitle + div.memitem {
+    border-color: var(--primary-light-color);
+}
+
+div.memitem {
+    border-top-right-radius: var(--border-radius-medium);
+    border-bottom-right-radius: var(--border-radius-medium);
+    border-bottom-left-radius: var(--border-radius-medium);
+    overflow: hidden;
+    display: block !important;
+}
+
+div.memdoc {
+    border-radius: 0;
+}
+
+div.memproto {
+    border-radius: 0 var(--border-radius-small) 0 0;
+    overflow: auto;
+    border-bottom: 1px solid var(--separator-color);
+    padding: var(--spacing-medium);
+    margin-bottom: -1px;
+}
+
+div.memtitle {
+    border-top-right-radius: var(--border-radius-medium);
+    border-top-left-radius: var(--border-radius-medium);
+}
+
+div.memproto table.memname {
+    font-family: var(--font-family-monospace);
+    color: var(--page-foreground-color);
+    font-size: var(--memname-font-size);
+    text-shadow: none;
+}
+
+div.memproto div.memtemplate {
+    font-family: var(--font-family-monospace);
+    color: var(--primary-dark-color);
+    font-size: var(--memname-font-size);
+    margin-left: 2px;
+    text-shadow: none;
+}
+
+table.mlabels, table.mlabels > tbody {
+    display: block;
+}
+
+td.mlabels-left {
+    width: auto;
+}
+
+td.mlabels-right {
+    margin-top: 3px;
+    position: sticky;
+    left: 0;
+}
+
+table.mlabels > tbody > tr:first-child {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.memname, .memitem span.mlabels {
+    margin: 0
+}
+
+/*
+ reflist
+ */
+
+dl.reflist {
+    box-shadow: var(--box-shadow);
+    border-radius: var(--border-radius-medium);
+    border: 1px solid var(--separator-color);
+    overflow: hidden;
+    padding: 0;
+}
+
+
+dl.reflist dt, dl.reflist dd {
+    box-shadow: none;
+    text-shadow: none;
+    background-image: none;
+    border: none;
+    padding: 12px;
+}
+
+
+dl.reflist dt {
+    font-weight: 500;
+    border-radius: 0;
+    background: var(--code-background);
+    border-bottom: 1px solid var(--separator-color);
+    color: var(--page-foreground-color)
+}
+
+
+dl.reflist dd {
+    background: none;
+}
+
+/*
+ Table
+ */
+
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname),
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody {
+    display: inline-block;
+    max-width: 100%;
+}
+
+.contents > table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname):not(.classindex) {
+    margin-left: calc(0px - var(--spacing-large));
+    margin-right: calc(0px - var(--spacing-large));
+    max-width: calc(100% + 2 * var(--spacing-large));
+}
+
+table.fieldtable,
+table.markdownTable tbody,
+table.doxtable tbody {
+    border: none;
+    margin: var(--spacing-medium) 0;
+    box-shadow: 0 0 0 1px var(--separator-color);
+    border-radius: var(--border-radius-small);
+}
+
+table.markdownTable, table.doxtable, table.fieldtable {
+    padding: 1px;
+}
+
+table.doxtable caption {
+    display: block;
+}
+
+table.fieldtable {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+th.markdownTableHeadLeft,
+th.markdownTableHeadRight,
+th.markdownTableHeadCenter,
+th.markdownTableHeadNone,
+table.doxtable th {
+    background: var(--tablehead-background);
+    color: var(--tablehead-foreground);
+    font-weight: 600;
+    font-size: var(--page-font-size);
+}
+
+th.markdownTableHeadLeft:first-child,
+th.markdownTableHeadRight:first-child,
+th.markdownTableHeadCenter:first-child,
+th.markdownTableHeadNone:first-child,
+table.doxtable tr th:first-child {
+    border-top-left-radius: var(--border-radius-small);
+}
+
+th.markdownTableHeadLeft:last-child,
+th.markdownTableHeadRight:last-child,
+th.markdownTableHeadCenter:last-child,
+th.markdownTableHeadNone:last-child,
+table.doxtable tr th:last-child {
+    border-top-right-radius: var(--border-radius-small);
+}
+
+table.markdownTable td,
+table.markdownTable th,
+table.fieldtable td,
+table.fieldtable th,
+table.doxtable td,
+table.doxtable th {
+    border: 1px solid var(--separator-color);
+    padding: var(--spacing-small) var(--spacing-medium);
+}
+
+table.markdownTable td:last-child,
+table.markdownTable th:last-child,
+table.fieldtable td:last-child,
+table.fieldtable th:last-child,
+table.doxtable td:last-child,
+table.doxtable th:last-child {
+    border-right: none;
+}
+
+table.markdownTable td:first-child,
+table.markdownTable th:first-child,
+table.fieldtable td:first-child,
+table.fieldtable th:first-child,
+table.doxtable td:first-child,
+table.doxtable th:first-child {
+    border-left: none;
+}
+
+table.markdownTable tr:first-child td,
+table.markdownTable tr:first-child th,
+table.fieldtable tr:first-child td,
+table.fieldtable tr:first-child th,
+table.doxtable tr:first-child td,
+table.doxtable tr:first-child th {
+    border-top: none;
+}
+
+table.markdownTable tr:last-child td,
+table.markdownTable tr:last-child th,
+table.fieldtable tr:last-child td,
+table.fieldtable tr:last-child th,
+table.doxtable tr:last-child td,
+table.doxtable tr:last-child th {
+    border-bottom: none;
+}
+
+table.markdownTable tr, table.doxtable tr {
+    border-bottom: 1px solid var(--separator-color);
+}
+
+table.markdownTable tr:last-child, table.doxtable tr:last-child {
+    border-bottom: none;
+}
+
+.full_width_table table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) {
+    display: block;
+}
+
+.full_width_table table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody {
+    display: table;
+    width: 100%;
+}
+
+table.fieldtable th {
+    font-size: var(--page-font-size);
+    font-weight: 600;
+    background-image: none;
+    background-color: var(--tablehead-background);
+    color: var(--tablehead-foreground);
+}
+
+table.fieldtable td.fieldtype, .fieldtable td.fieldname, .fieldtable td.fieldinit, .fieldtable td.fielddoc, .fieldtable th {
+    border-bottom: 1px solid var(--separator-color);
+    border-right: 1px solid var(--separator-color);
+}
+
+table.fieldtable tr:last-child td:first-child {
+    border-bottom-left-radius: var(--border-radius-small);
+}
+
+table.fieldtable tr:last-child td:last-child {
+    border-bottom-right-radius: var(--border-radius-small);
+}
+
+.memberdecls td.glow, .fieldtable tr.glow {
+    background-color: var(--primary-light-color);
+    box-shadow: none;
+}
+
+table.memberdecls {
+    display: block;
+    -webkit-tap-highlight-color: transparent;
+}
+
+table.memberdecls tr[class^='memitem'] {
+    font-family: var(--font-family-monospace);
+    font-size: var(--code-font-size);
+}
+
+table.memberdecls tr[class^='memitem'] .memTemplParams {
+    font-family: var(--font-family-monospace);
+    font-size: var(--code-font-size);
+    color: var(--primary-dark-color);
+    white-space: normal;
+}
+
+table.memberdecls .memItemLeft,
+table.memberdecls .memItemRight,
+table.memberdecls .memTemplItemLeft,
+table.memberdecls .memTemplItemRight,
+table.memberdecls .memTemplParams {
+    transition: none;
+    padding-top: var(--spacing-small);
+    padding-bottom: var(--spacing-small);
+    border-top: 1px solid var(--separator-color);
+    border-bottom: 1px solid var(--separator-color);
+    background-color: var(--fragment-background);
+}
+
+table.memberdecls .memTemplItemLeft,
+table.memberdecls .memTemplItemRight {
+    padding-top: 2px;
+}
+
+table.memberdecls .memTemplParams {
+    border-bottom: 0;
+    border-left: 1px solid var(--separator-color);
+    border-right: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-small) var(--border-radius-small) 0 0;
+    padding-bottom: var(--spacing-small);
+}
+
+table.memberdecls .memTemplItemLeft {
+    border-radius: 0 0 0 var(--border-radius-small);
+    border-left: 1px solid var(--separator-color);
+    border-top: 0;
+}
+
+table.memberdecls .memTemplItemRight {
+    border-radius: 0 0 var(--border-radius-small) 0;
+    border-right: 1px solid var(--separator-color);
+    padding-left: 0;
+    border-top: 0;
+}
+
+table.memberdecls .memItemLeft {
+    border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
+    border-left: 1px solid var(--separator-color);
+    padding-left: var(--spacing-medium);
+    padding-right: 0;
+}
+
+table.memberdecls .memItemRight  {
+    border-radius: 0 var(--border-radius-small) var(--border-radius-small) 0;
+    border-right: 1px solid var(--separator-color);
+    padding-right: var(--spacing-medium);
+    padding-left: 0;
+
+}
+
+table.memberdecls .mdescLeft, table.memberdecls .mdescRight {
+    background: none;
+    color: var(--page-foreground-color);
+    padding: var(--spacing-small) 0;
+}
+
+table.memberdecls .memItemLeft,
+table.memberdecls .memTemplItemLeft {
+    padding-right: var(--spacing-medium);
+}
+
+table.memberdecls .memSeparator {
+    background: var(--page-background-color);
+    height: var(--spacing-large);
+    border: 0;
+    transition: none;
+}
+
+table.memberdecls .groupheader {
+    margin-bottom: var(--spacing-large);
+}
+
+table.memberdecls .inherit_header td {
+    padding: 0 0 var(--spacing-medium) 0;
+    text-indent: -12px;
+    color: var(--page-secondary-foreground-color);
+}
+
+table.memberdecls img[src="closed.png"],
+table.memberdecls img[src="open.png"],
+div.dynheader img[src="open.png"],
+div.dynheader img[src="closed.png"] {
+    width: 0; 
+    height: 0; 
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid var(--primary-color);
+    margin-top: 8px;
+    display: block;
+    float: left;
+    margin-left: -10px;
+    transition: transform var(--animation-duration) ease-out;
+}
+
+table.memberdecls img {
+    margin-right: 10px;
+}
+
+table.memberdecls img[src="closed.png"],
+div.dynheader img[src="closed.png"] {
+    transform: rotate(-90deg);
+    
+}
+
+.compoundTemplParams {
+    font-family: var(--font-family-monospace);
+    color: var(--primary-dark-color);
+    font-size: var(--code-font-size);
+}
+
+@media screen and (max-width: 767px) {
+
+    table.memberdecls .memItemLeft,
+    table.memberdecls .memItemRight,
+    table.memberdecls .mdescLeft,
+    table.memberdecls .mdescRight,
+    table.memberdecls .memTemplItemLeft,
+    table.memberdecls .memTemplItemRight,
+    table.memberdecls .memTemplParams {
+        display: block;
+        text-align: left;
+        padding-left: var(--spacing-large);
+        margin: 0 calc(0px - var(--spacing-large)) 0 calc(0px - var(--spacing-large));
+        border-right: none;
+        border-left: none;
+        border-radius: 0;
+        white-space: normal;
+    }
+
+    table.memberdecls .memItemLeft,
+    table.memberdecls .mdescLeft,
+    table.memberdecls .memTemplItemLeft {
+        border-bottom: 0;
+        padding-bottom: 0;
+    }
+
+    table.memberdecls .memTemplItemLeft {
+        padding-top: 0;
+    }
+
+    table.memberdecls .mdescLeft {
+        margin-bottom: calc(0px - var(--page-font-size));
+    }
+
+    table.memberdecls .memItemRight, 
+    table.memberdecls .mdescRight,
+    table.memberdecls .memTemplItemRight {
+        border-top: 0;
+        padding-top: 0;
+        padding-right: var(--spacing-large);
+        overflow-x: auto;
+    }
+
+    table.memberdecls tr[class^='memitem']:not(.inherit) {
+        display: block;
+        width: calc(100vw - 2 * var(--spacing-large));
+    }
+
+    table.memberdecls .mdescRight {
+        color: var(--page-foreground-color);
+    }
+
+    table.memberdecls tr.inherit {
+        visibility: hidden;
+    }
+
+    table.memberdecls tr[style="display: table-row;"] {
+        display: block !important;
+        visibility: visible;
+        width: calc(100vw - 2 * var(--spacing-large));
+        animation: fade .5s;
+    }
+
+    @keyframes fade {
+        0% {
+            opacity: 0;
+            max-height: 0;
+        }
+
+        100% {
+            opacity: 1;
+            max-height: 200px;
+        }
+    }
+}
+
+
+/*
+ Horizontal Rule
+ */
+
+hr {
+    margin-top: var(--spacing-large);
+    margin-bottom: var(--spacing-large);
+    height: 1px;
+    background-color: var(--separator-color);
+    border: 0;
+}
+
+.contents hr {
+    box-shadow: 100px 0 var(--separator-color),
+                -100px 0 var(--separator-color),
+                500px 0 var(--separator-color),
+                -500px 0 var(--separator-color),
+                900px 0 var(--separator-color),
+                -900px 0 var(--separator-color),
+                1400px 0 var(--separator-color),
+                -1400px 0 var(--separator-color),
+                1900px 0 var(--separator-color),
+                -1900px 0 var(--separator-color);       
+}
+
+.contents img, .contents .center, .contents center, .contents div.image object {
+    max-width: 100%;
+    overflow: auto;
+}
+
+@media screen and (max-width: 767px) {
+    .contents .dyncontent > .center, .contents > center {
+        margin-left: calc(0px - var(--spacing-large));
+        margin-right: calc(0px - var(--spacing-large));
+        max-width: calc(100% + 2 * var(--spacing-large));
+    }
+}
+
+/*
+ Directories
+ */
+div.directory {
+    border-top: 1px solid var(--separator-color);
+    border-bottom: 1px solid var(--separator-color);
+    width: auto;
+}
+
+table.directory {
+    font-family: var(--font-family);
+    font-size: var(--page-font-size);
+    font-weight: normal;
+    width: 100%;
+}
+
+table.directory td.entry, table.directory td.desc {
+    padding: calc(var(--spacing-small) / 2) var(--spacing-small);
+    line-height: var(--table-line-height);
+}
+
+table.directory tr.even td:last-child {
+    border-radius: 0 var(--border-radius-small) var(--border-radius-small) 0;
+}
+
+table.directory tr.even td:first-child {
+    border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
+}
+
+table.directory tr.even:last-child td:last-child {
+    border-radius: 0 var(--border-radius-small) 0 0;
+}
+
+table.directory tr.even:last-child td:first-child {
+    border-radius: var(--border-radius-small) 0 0 0;
+}
+
+table.directory td.desc {
+    min-width: 250px;
+}
+
+table.directory tr.even {
+    background-color: var(--odd-color);
+}
+
+table.directory tr.odd {
+    background-color: transparent;
+}
+
+.icona {
+    width: auto;
+    height: auto;
+    margin: 0 var(--spacing-small);
+}
+
+.icon {
+    background: var(--primary-color);
+    border-radius: var(--border-radius-small);
+    font-size: var(--page-font-size);
+    padding: calc(var(--page-font-size) / 5);
+    line-height: var(--page-font-size);
+    transform: scale(0.8);
+    height: auto;
+    width: var(--page-font-size);
+    user-select: none;
+}
+
+.iconfopen, .icondoc, .iconfclosed {
+    background-position: center;
+    margin-bottom: 0;
+    height: var(--table-line-height);
+}
+
+.icondoc {
+    filter: saturate(0.2);
+}
+
+@media screen and (max-width: 767px) {
+    div.directory {
+        margin-left: calc(0px - var(--spacing-large));
+        margin-right: calc(0px - var(--spacing-large));
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not(.light-mode) .iconfopen, html:not(.light-mode) .iconfclosed {
+        filter: hue-rotate(180deg) invert();
+    }
+}
+
+html.dark-mode .iconfopen, html.dark-mode .iconfclosed {
+    filter: hue-rotate(180deg) invert();
+}
+
+/*
+ Class list
+ */
+
+.classindex dl.odd {
+    background: var(--odd-color);
+    border-radius: var(--border-radius-small);
+}
+
+.classindex dl.even {
+    background-color: transparent;
+}
+
+/* 
+ Class Index Doxygen 1.8 
+*/
+
+table.classindex {
+    margin-left: 0;
+    margin-right: 0;
+    width: 100%;
+}
+
+table.classindex table div.ah {
+    background-image: none;
+    background-color: initial;
+    border-color: var(--separator-color);
+    color: var(--page-foreground-color);
+    box-shadow: var(--box-shadow);
+    border-radius: var(--border-radius-large);
+    padding: var(--spacing-small);
+}
+
+div.qindex {
+    background-color: var(--odd-color);
+    border-radius: var(--border-radius-small);
+    border: 1px solid var(--separator-color);
+    padding: var(--spacing-small) 0;
+}
+
+/*
+  Footer and nav-path
+ */
+
+#nav-path {
+    width: 100%;
+}
+
+#nav-path ul {
+    background-image: none;
+    background: var(--page-background-color);
+    border: none;
+    border-top: 1px solid var(--separator-color);
+    border-bottom: 1px solid var(--separator-color);
+    border-bottom: 0;
+    box-shadow: 0 0.75px 0 var(--separator-color);
+    font-size: var(--navigation-font-size);
+}
+
+img.footer {
+    width: 60px;
+}
+
+.navpath li.footer {
+    color: var(--page-secondary-foreground-color);
+}
+
+address.footer {
+    color: var(--page-secondary-foreground-color);
+    margin-bottom: var(--spacing-large);
+}
+
+#nav-path li.navelem {
+    background-image: none;
+    display: flex;
+    align-items: center;
+}
+
+.navpath li.navelem a {
+    text-shadow: none;
+    display: inline-block;
+    color: var(--primary-color) !important;
+}
+
+.navpath li.navelem b {
+    color: var(--primary-dark-color);
+    font-weight: 500;
+}
+
+li.navelem {
+    padding: 0;
+    margin-left: -8px;
+}
+
+li.navelem:first-child {
+    margin-left: var(--spacing-large);
+}
+
+li.navelem:first-child:before {
+    display: none;
+}
+
+#nav-path li.navelem:after {
+    content: '';
+    border: 5px solid var(--page-background-color);
+    border-bottom-color: transparent;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    transform: translateY(-1px) scaleY(4.2);
+    z-index: 10;
+    margin-left: 6px;
+}
+
+#nav-path li.navelem:before {
+    content: '';
+    border: 5px solid var(--separator-color);
+    border-bottom-color: transparent;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    transform: translateY(-1px) scaleY(3.2);
+    margin-right: var(--spacing-small);
+}
+
+.navpath li.navelem a:hover {
+    color: var(--primary-color);
+}
+
+/*
+ Scrollbars for Webkit
+*/
+
+#nav-tree::-webkit-scrollbar,
+div.fragment::-webkit-scrollbar,
+pre.fragment::-webkit-scrollbar,
+div.memproto::-webkit-scrollbar,
+.contents center::-webkit-scrollbar,
+.contents .center::-webkit-scrollbar,
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody::-webkit-scrollbar,
+div.contents .toc::-webkit-scrollbar,
+.contents .dotgraph::-webkit-scrollbar,
+.contents .tabs-overview-container::-webkit-scrollbar {
+    background: transparent;
+    width: calc(var(--webkit-scrollbar-size) + var(--webkit-scrollbar-padding) + var(--webkit-scrollbar-padding));
+    height: calc(var(--webkit-scrollbar-size) + var(--webkit-scrollbar-padding) + var(--webkit-scrollbar-padding));
+}
+
+#nav-tree::-webkit-scrollbar-thumb,
+div.fragment::-webkit-scrollbar-thumb,
+pre.fragment::-webkit-scrollbar-thumb,
+div.memproto::-webkit-scrollbar-thumb,
+.contents center::-webkit-scrollbar-thumb,
+.contents .center::-webkit-scrollbar-thumb,
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody::-webkit-scrollbar-thumb,
+div.contents .toc::-webkit-scrollbar-thumb,
+.contents .dotgraph::-webkit-scrollbar-thumb,
+.contents .tabs-overview-container::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border: var(--webkit-scrollbar-padding) solid transparent;
+    border-radius: calc(var(--webkit-scrollbar-padding) + var(--webkit-scrollbar-padding));
+    background-clip: padding-box;  
+}
+
+#nav-tree:hover::-webkit-scrollbar-thumb,
+div.fragment:hover::-webkit-scrollbar-thumb,
+pre.fragment:hover::-webkit-scrollbar-thumb,
+div.memproto:hover::-webkit-scrollbar-thumb,
+.contents center:hover::-webkit-scrollbar-thumb,
+.contents .center:hover::-webkit-scrollbar-thumb,
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody:hover::-webkit-scrollbar-thumb,
+div.contents .toc:hover::-webkit-scrollbar-thumb,
+.contents .dotgraph:hover::-webkit-scrollbar-thumb,
+.contents .tabs-overview-container:hover::-webkit-scrollbar-thumb {
+    background-color: var(--webkit-scrollbar-color);
+}
+
+#nav-tree::-webkit-scrollbar-track,
+div.fragment::-webkit-scrollbar-track,
+pre.fragment::-webkit-scrollbar-track,
+div.memproto::-webkit-scrollbar-track,
+.contents center::-webkit-scrollbar-track,
+.contents .center::-webkit-scrollbar-track,
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody::-webkit-scrollbar-track,
+div.contents .toc::-webkit-scrollbar-track,
+.contents .dotgraph::-webkit-scrollbar-track,
+.contents .tabs-overview-container::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+#nav-tree::-webkit-scrollbar-corner {
+    background-color: var(--side-nav-background);
+}
+
+#nav-tree,
+div.fragment,
+pre.fragment,
+div.memproto,
+.contents center,
+.contents .center,
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody,
+div.contents .toc {
+    overflow-x: auto;
+    overflow-x: overlay;
+}
+
+#nav-tree {
+    overflow-x: auto;
+    overflow-y: auto;
+    overflow-y: overlay;
+}
+
+/*
+ Scrollbars for Firefox
+*/
+
+#nav-tree,
+div.fragment,
+pre.fragment,
+div.memproto,
+.contents center,
+.contents .center,
+.contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody,
+div.contents .toc,
+.contents .dotgraph,
+.contents .tabs-overview-container {
+    scrollbar-width: thin;
+}
+
+/*
+  Optional Dark mode toggle button
+*/
+
+doxygen-awesome-dark-mode-toggle {
+    display: inline-block;
+    margin: 0 0 0 var(--spacing-small);
+    padding: 0;
+    width: var(--searchbar-height);
+    height: var(--searchbar-height);
+    background: none;
+    border: none;
+    border-radius: var(--searchbar-height);
+    vertical-align: middle;
+    text-align: center;
+    line-height: var(--searchbar-height);
+    font-size: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    cursor: pointer;
+}
+
+doxygen-awesome-dark-mode-toggle > svg {
+    transition: transform var(--animation-duration) ease-in-out;
+}
+
+doxygen-awesome-dark-mode-toggle:active > svg {
+    transform: scale(.5);
+}
+
+doxygen-awesome-dark-mode-toggle:hover {
+    background-color: rgba(0,0,0,.03);
+}
+
+html.dark-mode doxygen-awesome-dark-mode-toggle:hover {
+    background-color: rgba(0,0,0,.18);
+}
+
+/*
+ Optional fragment copy button
+*/
+.doxygen-awesome-fragment-wrapper {
+    position: relative;
+}
+
+doxygen-awesome-fragment-copy-button {
+    opacity: 0;
+    background: var(--fragment-background);
+    width: 28px;
+    height: 28px;
+    position: absolute;
+    right: calc(var(--spacing-large) - (var(--spacing-large) / 2.5));
+    top: calc(var(--spacing-large) - (var(--spacing-large) / 2.5));
+    border: 1px solid var(--fragment-foreground);
+    cursor: pointer;
+    border-radius: var(--border-radius-small);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.doxygen-awesome-fragment-wrapper:hover doxygen-awesome-fragment-copy-button, doxygen-awesome-fragment-copy-button.success {
+    opacity: .28;
+}
+
+doxygen-awesome-fragment-copy-button:hover, doxygen-awesome-fragment-copy-button.success {
+    opacity: 1 !important;
+}
+
+doxygen-awesome-fragment-copy-button:active:not([class~=success]) svg {
+    transform: scale(.91);
+}
+
+doxygen-awesome-fragment-copy-button svg {
+    fill: var(--fragment-foreground);
+    width: 18px;
+    height: 18px;
+}
+
+doxygen-awesome-fragment-copy-button.success svg {
+    fill: rgb(14, 168, 14);
+}
+
+doxygen-awesome-fragment-copy-button.success {
+    border-color: rgb(14, 168, 14);
+}
+
+@media screen and (max-width: 767px) {
+    .textblock > .doxygen-awesome-fragment-wrapper > doxygen-awesome-fragment-copy-button,
+    .textblock li > .doxygen-awesome-fragment-wrapper > doxygen-awesome-fragment-copy-button,
+    .memdoc li > .doxygen-awesome-fragment-wrapper > doxygen-awesome-fragment-copy-button,
+    .memdoc > .doxygen-awesome-fragment-wrapper > doxygen-awesome-fragment-copy-button,
+    dl dd > .doxygen-awesome-fragment-wrapper > doxygen-awesome-fragment-copy-button {
+        right: 0;
+    }
+}
+
+/*
+ Optional paragraph link button
+*/
+
+a.anchorlink {
+    font-size: 90%;
+    margin-left: var(--spacing-small);
+    color: var(--page-foreground-color) !important;
+    text-decoration: none;
+    opacity: .15;
+    display: none;
+    transition: opacity var(--animation-duration) ease-in-out, color var(--animation-duration) ease-in-out;
+}
+
+a.anchorlink svg {
+    fill: var(--page-foreground-color);
+}
+
+h3 a.anchorlink svg, h4 a.anchorlink svg {
+    margin-bottom: -3px;
+    margin-top: -4px;
+}
+
+a.anchorlink:hover {
+    opacity: .45;
+}
+
+h2:hover a.anchorlink, h1:hover a.anchorlink, h3:hover a.anchorlink, h4:hover a.anchorlink  {
+    display: inline-block;
+}
+
+/*
+ Optional tab feature
+*/
+
+.tabbed > ul {
+    padding-inline-start: 0px;
+    margin: 0;
+    padding: var(--spacing-small) 0;
+}
+
+.tabbed > ul > li {
+    display: none;
+}
+
+.tabbed > ul > li.selected {
+    display: block;
+}
+
+.tabs-overview-container {
+    overflow-x: auto;
+    display: block;
+    overflow-y: visible;
+}
+
+.tabs-overview {
+    border-bottom: 1px solid var(--separator-color);
+    display: flex;
+    flex-direction: row;
+}
+
+@media screen and (max-width: 767px) {
+    .tabs-overview-container {
+        margin: 0 calc(0px - var(--spacing-large));
+    }
+    .tabs-overview {
+        padding: 0 var(--spacing-large)
+    }
+}
+
+.tabs-overview button.tab-button {
+    color: var(--page-foreground-color);
+    margin: 0;
+    border: none;
+    background: transparent;
+    padding: calc(var(--spacing-large) / 2) 0;
+    display: inline-block;
+    font-size: var(--page-font-size);
+    cursor: pointer;
+    box-shadow: 0 1px 0 0 var(--separator-color);
+    position: relative;
+    
+    -webkit-tap-highlight-color: transparent;
+}
+
+.tabs-overview button.tab-button .tab-title::before {
+    display: block;
+    content: attr(title);
+    font-weight: 600;
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
+}
+
+.tabs-overview button.tab-button .tab-title {
+    float: left;
+    white-space: nowrap;
+    font-weight: normal;
+    padding: calc(var(--spacing-large) / 2) var(--spacing-large);
+    border-radius: var(--border-radius-medium);
+    transition: background-color var(--animation-duration) ease-in-out, font-weight var(--animation-duration) ease-in-out;
+}
+
+.tabs-overview button.tab-button:not(:last-child) .tab-title {
+    box-shadow: 8px 0 0 -7px var(--separator-color);
+}
+
+.tabs-overview button.tab-button:hover .tab-title {
+    background: var(--separator-color);
+    box-shadow: none;
+}
+
+.tabs-overview button.tab-button.active .tab-title {
+    font-weight: 600;
+}
+
+.tabs-overview button.tab-button::after {
+    content: '';
+    display: block;
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    height: 0;
+    width: 0%;
+    margin: 0 auto;
+    border-radius: var(--border-radius-small) var(--border-radius-small) 0 0;
+    background-color: var(--primary-color);
+    transition: width var(--animation-duration) ease-in-out, height var(--animation-duration) ease-in-out;
+}
+
+.tabs-overview button.tab-button.active::after {
+    width: 100%;
+    box-sizing: border-box;
+    height: 3px;
+}
+
+
+/*
+ Navigation Buttons
+*/
+
+.section_buttons:not(:empty) {
+    margin-top: calc(var(--spacing-large) * 3);
+}
+
+.section_buttons table.markdownTable {
+    display: block;
+    width: 100%;
+}
+
+.section_buttons table.markdownTable tbody {
+    display: table !important;
+    width: 100%;
+    box-shadow: none;
+    border-spacing: 10px;
+}
+
+.section_buttons table.markdownTable td {
+    padding: 0;
+}
+
+.section_buttons table.markdownTable th {
+    display: none;
+}
+
+.section_buttons table.markdownTable tr.markdownTableHead {
+    border: none;
+}
+
+.section_buttons tr th, .section_buttons tr td {
+    background: none;
+    border: none;
+    padding: var(--spacing-large) 0 var(--spacing-small);
+}
+
+.section_buttons a {
+    display: inline-block;
+    border: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-medium);
+    color: var(--page-secondary-foreground-color) !important;
+    text-decoration: none;
+    transition: color var(--animation-duration) ease-in-out, background-color var(--animation-duration) ease-in-out;
+}
+
+.section_buttons a:hover {
+    color: var(--page-foreground-color) !important;
+    background-color: var(--odd-color);
+}
+
+.section_buttons tr td.markdownTableBodyLeft a {
+    padding: var(--spacing-medium) var(--spacing-large) var(--spacing-medium) calc(var(--spacing-large) / 2);
+}
+
+.section_buttons tr td.markdownTableBodyRight a {
+    padding: var(--spacing-medium) calc(var(--spacing-large) / 2) var(--spacing-medium) var(--spacing-large);
+}
+
+.section_buttons tr td.markdownTableBodyLeft a::before,
+.section_buttons tr td.markdownTableBodyRight a::after {
+    color: var(--page-secondary-foreground-color) !important;
+    display: inline-block;
+    transition: color .08s ease-in-out, transform .09s ease-in-out;
+}
+
+.section_buttons tr td.markdownTableBodyLeft a::before {
+    content: '〈';
+    padding-right: var(--spacing-large);
+}
+
+
+.section_buttons tr td.markdownTableBodyRight a::after {
+    content: '〉';
+    padding-left: var(--spacing-large);
+}
+
+
+.section_buttons tr td.markdownTableBodyLeft a:hover::before {
+    color: var(--page-foreground-color) !important;
+    transform: translateX(-3px);
+}
+
+.section_buttons tr td.markdownTableBodyRight a:hover::after {
+    color: var(--page-foreground-color) !important;
+    transform: translateX(3px);
+}
+
+@media screen and (max-width: 450px) {
+    .section_buttons a {
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    .section_buttons tr td:nth-of-type(1).markdownTableBodyLeft a {
+        border-radius: var(--border-radius-medium) 0 0 var(--border-radius-medium);
+        border-right: none;
+    }
+
+    .section_buttons tr td:nth-of-type(2).markdownTableBodyRight a {
+        border-radius: 0 var(--border-radius-medium) var(--border-radius-medium) 0;
+    }
+}

--- a/project/doxygen/header.html
+++ b/project/doxygen/header.html
@@ -1,0 +1,84 @@
+<!-- HTML header for doxygen 1.13.2-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$langISO">
+<head>
+<meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=11"/>
+<meta name="generator" content="Doxygen $doxygenversion"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
+<!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
+<!--BEGIN PROJECT_ICON-->
+<link rel="icon" href="$relpath^$projecticon" type="image/x-icon" />
+<!--END PROJECT_ICON-->
+<link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<script type="text/javascript">var page_layout=1;</script>
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
+<script type="text/javascript" src="$relpath^jquery.js"></script>
+<script type="text/javascript" src="$relpath^dynsections.js"></script>
+<!--BEGIN COPY_CLIPBOARD-->
+<script type="text/javascript" src="$relpath^clipboard.js"></script>
+<!--END COPY_CLIPBOARD-->
+$treeview
+$search
+$mathjax
+$darkmode
+<link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
+$extrastylesheet
+<script type="text/javascript" src="$relpath^doxygen-awesome-darkmode-toggle.js"></script>
+        <script type="text/javascript">
+            DoxygenAwesomeDarkModeToggle.init()
+        </script>
+</head>
+<body>
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<div id="side-nav" class="ui-resizable side-nav-resizable"><!-- do not remove this div, it is closed by doxygen! -->
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
+
+<div id="top"><!-- do not remove this div, it is closed by doxygen! -->
+
+<!--BEGIN TITLEAREA-->
+<div id="titlearea">
+<table cellspacing="0" cellpadding="0">
+ <tbody>
+ <tr id="projectrow">
+  <!--BEGIN PROJECT_LOGO-->
+  <td id="projectlogo"><img alt="Logo" src="$relpath^$projectlogo"$logosize/></td>
+  <!--END PROJECT_LOGO-->
+  <!--BEGIN PROJECT_NAME-->
+  <td id="projectalign">
+   <div id="projectname">$projectname<!--BEGIN PROJECT_NUMBER--><span id="projectnumber">&#160;$projectnumber</span><!--END PROJECT_NUMBER-->
+   </div>
+   <!--BEGIN PROJECT_BRIEF--><div id="projectbrief">$projectbrief</div><!--END PROJECT_BRIEF-->
+  </td>
+  <!--END PROJECT_NAME-->
+  <!--BEGIN !PROJECT_NAME-->
+   <!--BEGIN PROJECT_BRIEF-->
+    <td>
+    <div id="projectbrief">$projectbrief</div>
+    </td>
+   <!--END PROJECT_BRIEF-->
+  <!--END !PROJECT_NAME-->
+  <!--BEGIN DISABLE_INDEX-->
+   <!--BEGIN SEARCHENGINE-->
+     <!--BEGIN !FULL_SIDEBAR-->
+    <td>$searchbox</td>
+     <!--END !FULL_SIDEBAR-->
+   <!--END SEARCHENGINE-->
+  <!--END DISABLE_INDEX-->
+ </tr>
+  <!--BEGIN SEARCHENGINE-->
+   <!--BEGIN FULL_SIDEBAR-->
+   <tr><td colspan="2">$searchbox</td></tr>
+   <!--END FULL_SIDEBAR-->
+  <!--END SEARCHENGINE-->
+ </tbody>
+</table>
+</div>
+<!--END TITLEAREA-->
+<!-- end header part -->

--- a/src/fitpack.f90
+++ b/src/fitpack.f90
@@ -17,6 +17,19 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief Umbrella module that re-exports the complete FITPACK public API.
+!!
+!! Use this single module to access all FITPACK derived types, kind parameters,
+!! error flags, fitting-mode constants, boundary-behavior flags, and named constants.
+!! Individual domain modules (fitpack_curves, fitpack_surfaces, etc.) can also be
+!! imported directly for finer-grained dependency control.
+!!
+!! @par Example
+!! @code{.f90}
+!!   use fitpack, only: fitpack_curve, FP_REAL, FITPACK_OK
+!!   type(fitpack_curve) :: spl
+!!   spl = fitpack_curve(x, y, ierr=ierr)
+!! @endcode
 module fitpack
    use fitpack_core
    use fitpack_fitters

--- a/src/fitpack_convex_curves.f90
+++ b/src/fitpack_convex_curves.f90
@@ -17,6 +17,14 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief OOP wrapper for constrained-convexity curve fitting.
+!!
+!! Provides fitpack_convex_curve, an extension of fitpack_curve that enforces local
+!! convexity or concavity constraints during spline fitting. Always uses cubic splines
+!! (\f$ k = 3 \f$). The underlying core routines are concon (automatic knot placement)
+!! and cocosp (least-squares with user-supplied knots).
+!!
+!! @see Dierckx, Ch. 8, §8.3–8.4 (pp. 173–196); concon, cocosp
 module fitpack_convex_curves
     use fitpack_core
     use fitpack_fitters
@@ -26,9 +34,16 @@ module fitpack_convex_curves
 
     public :: fitpack_convex_curve
 
-    !> A curve fitter with local convexity/concavity constraints.
-    !> Uses concon (automatic knots) and cocosp (least-squares with given knots).
-    !> Always cubic (order=3).
+    !> @brief Cubic spline fitter with pointwise convexity/concavity constraints.
+    !!
+    !! Extends fitpack_curve with per-data-point convexity flags: each point can be
+    !! constrained to lie on a locally concave (\f$ v_i = 1 \f$), convex
+    !! (\f$ v_i = -1 \f$), or unconstrained (\f$ v_i = 0 \f$) portion of the spline.
+    !! The fitting routines solve a constrained quadratic programming problem to determine
+    !! knot positions and coefficients that satisfy these shape constraints while minimizing
+    !! the smoothing functional.
+    !!
+    !! @see Dierckx, Ch. 8, §8.3–8.4 (pp. 173–196)
     type, extends(fitpack_curve) :: fitpack_convex_curve
 
         !> Convexity constraints at data points: 1=concave, -1=convex, 0=unconstrained

--- a/src/fitpack_fitters.f90
+++ b/src/fitpack_fitters.f90
@@ -17,6 +17,11 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief Abstract base module for all FITPACK OOP fitters.
+!!
+!! Defines fitpack_fitter, the abstract base type from which all curve and surface
+!! fitters inherit. Provides shared state (smoothing factor, residuals, workspaces)
+!! and the deferred communication interface for parallel serialization.
 module fitpack_fitters
     use fitpack_core
     implicit none
@@ -24,8 +29,11 @@ module fitpack_fitters
 
     public :: fitpack_fitter
 
-    !> Abstract base type for all fitpack OOP fitters.
-    !> Contains the shared fitting state fields and communication helpers.
+    !> @brief Abstract base type for all FITPACK OOP fitters.
+    !!
+    !! Stores the common fitting state: computation mode (`iopt`), smoothing parameter,
+    !! weighted sum of squared residuals (`fp`), B-spline coefficients, and workspaces.
+    !! Subtypes extend this with domain-specific data (knots, data points, etc.).
     type, abstract :: fitpack_fitter
 
         !> Fitting state flag

--- a/src/fitpack_grid_surfaces.f90
+++ b/src/fitpack_grid_surfaces.f90
@@ -17,6 +17,15 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief OOP wrapper for bivariate surface fitting to data on a rectangular grid.
+!!
+!! Provides fitpack_grid_surface, a derived type for fitting tensor-product B-spline
+!! surfaces \f$ z = s(x, y) \f$ to data values given on a rectangular grid
+!! \f$ (x_i, y_j) \f$. The underlying core routine is regrid, which exploits the
+!! grid structure for faster fitting than surfit. Supports evaluation, partial
+!! derivatives, integration, cross-section extraction, and derivative-spline computation.
+!!
+!! @see Dierckx, Ch. 5, §5.4 (pp. 98–103); regrid, bispev, parder, pardeu, dblint, profil
 module fitpack_grid_surfaces
     use fitpack_core, only: FITPACK_SUCCESS,FP_REAL,FP_SIZE,FP_FLAG,FP_COMM,zero,IOPT_NEW_SMOOTHING,IOPT_OLD_FIT, &
                             IOPT_NEW_LEASTSQUARES,bispev,fitpack_error_handling,get_smoothing,regrid, &
@@ -30,7 +39,14 @@ module fitpack_grid_surfaces
 
     public :: fitpack_grid_surface
 
-    !> A public type describing a surface fitter z = s(x,y) to gridded x,y data
+    !> @brief Bivariate surface fitter \f$ z = s(x, y) \f$ for gridded data.
+    !!
+    !! Stores grid vectors \f$ x_i \f$ (\f$ i = 1, \ldots, m_x \f$) and
+    !! \f$ y_j \f$ (\f$ j = 1, \ldots, m_y \f$) together with gridded function values
+    !! \f$ z(j, i) \f$, the fitted tensor-product B-spline representation, and the fitting
+    !! state. Uses regrid, which is significantly more efficient than surfit for gridded input.
+    !!
+    !! @see Dierckx, Ch. 5, §5.4 (pp. 98–103)
     type, extends(fitpack_fitter) :: fitpack_grid_surface
 
         !> The data points

--- a/src/fitpack_gridded_polar.f90
+++ b/src/fitpack_gridded_polar.f90
@@ -17,6 +17,18 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief OOP wrapper for bivariate spline fitting on a gridded polar disc.
+!!
+!! Provides fitpack_grid_polar, a derived type for fitting bicubic splines to data
+!! sampled on a polar grid \f$ (u_i, v_j) \f$ over a disc of constant radius \f$ r \f$.
+!! The coordinate mapping is:
+!! \f[
+!!     x = u \, r \cos v, \quad y = u \, r \sin v, \quad 0 \leq u \leq 1, \; -\pi \leq v \leq \pi
+!! \f]
+!! Continuity constraints at the origin and optional specification of the function value
+!! \f$ z_0 = f(0,0) \f$ are supported. Uses the pogrid core routine.
+!!
+!! @see Dierckx, Ch. 11, §11.1 (pp. 255–263); pogrid
 module fitpack_gridded_polar
     use fitpack_core
     use fitpack_fitters
@@ -25,11 +37,14 @@ module fitpack_gridded_polar
 
     public :: fitpack_grid_polar
 
-    !> A public type describing a polar fitter z = f(x,y) to GRIDDED polar data,
-    !> which is distributed across the domain x**2+y**2 <= rad(atan(y/x))**2
-    !> through the transform:  x = u*rad*cos(v),
-    !>                         y = u*rad*sin(v)
-    !> Gridded data is provided in terms of (u,v) coordinates and the *constant* boundary radius, r
+    !> @brief Bicubic spline fitter for data on a gridded polar disc.
+    !!
+    !! Stores the grid coordinates \f$ u_i \f$, \f$ v_j \f$, the constant boundary
+    !! radius \f$ r \f$, gridded function values \f$ z(i, j) \f$, and the fitted B-spline
+    !! representation. The origin value \f$ z_0 \f$ may optionally be prescribed (exactly
+    !! or approximately), and zero-gradient boundary conditions at the origin can be enforced.
+    !!
+    !! @see Dierckx, Ch. 11, §11.1 (pp. 255–263)
     type, extends(fitpack_fitter) :: fitpack_grid_polar
 
         !> Coordinates of the data points in grid coordinates (u,v) and domain size

--- a/src/fitpack_gridded_sphere.f90
+++ b/src/fitpack_gridded_sphere.f90
@@ -17,6 +17,17 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief OOP wrapper for bivariate spline fitting on the sphere to gridded data.
+!!
+!! Provides fitpack_grid_sphere, a derived type for fitting bicubic splines to data given
+!! on a latitude-longitude grid over the sphere. The colatitude grid
+!! \f$ u_i \in [0, \pi] \f$ (\f$ i = 1, \ldots, m_u \f$) and the \f$ 2\pi \f$-periodic
+!! longitude grid \f$ v_j \f$ (\f$ j = 1, \ldots, m_v \f$) define the sampling.
+!! Boundary conditions at the north (\f$ u = 0 \f$) and south (\f$ u = \pi \f$) poles
+!! can be configured for function value, exactness, continuity order, and gradient
+!! vanishing. Uses the spgrid core routine.
+!!
+!! @see Dierckx, Ch. 11, §11.2 (pp. 263–269); spgrid
 module fitpack_gridded_sphere
     use fitpack_core
     use fitpack_fitters
@@ -25,10 +36,14 @@ module fitpack_gridded_sphere
 
     public :: fitpack_grid_sphere
 
-    !> A public type describing a sphere fitter z = s(u,v) to GRIDDED sphere data,
-    !> on the latitude-longitude grid (u(i),v(j)), i=1,...,mu ; j=1,...,mv , spgrid determines a smooth
-    !> u = latitude, 0<=u<=pi,
-    !> v = 2*pi-periodic longitude, vb<=v<=ve (vb = v(1), ve=vb+2*pi).
+    !> @brief Bicubic spline fitter for data on a latitude-longitude grid.
+    !!
+    !! Stores the colatitude grid \f$ u_i \f$, the \f$ 2\pi \f$-periodic longitude grid
+    !! \f$ v_j \f$, gridded function values \f$ z(j, i) \f$, and the fitted B-spline
+    !! representation. North and south pole boundary conditions (function value,
+    !! continuity order, gradient vanishing) are independently configurable.
+    !!
+    !! @see Dierckx, Ch. 11, §11.2 (pp. 263–269)
     type, extends(fitpack_fitter) :: fitpack_grid_sphere
 
         !> Coordinates of the data points in grid coordinates (u,v) and domain size

--- a/src/fitpack_parametric.f90
+++ b/src/fitpack_parametric.f90
@@ -17,6 +17,19 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief OOP wrappers for parametric curve fitting in \f$ \mathbb{R}^d \f$.
+!!
+!! Provides three types for fitting parametric curves through data points in
+!! \f$ d \f$-dimensional space (\f$ d \geq 1 \f$):
+!! - fitpack_parametric_curve — open parametric spline (parcur)
+!! - fitpack_closed_curve — closed (periodic) parametric spline (clocur)
+!! - fitpack_constrained_curve — parametric spline with derivative constraints at endpoints (concur)
+!!
+!! Each component \f$ s_j(u) \f$ of the curve is represented as a B-spline of degree \f$ k \f$
+!! over a common knot vector, with the parameter \f$ u \f$ either user-supplied or
+!! automatically computed from cumulative chord lengths.
+!!
+!! @see Dierckx, Ch. 9 (pp. 199–228); parcur, clocur, concur
 module fitpack_parametric_curves
     use fitpack_core
     use fitpack_fitters
@@ -29,8 +42,14 @@ module fitpack_parametric_curves
 
     integer, parameter :: MAX_K = 5
 
-    !> A public type describing a parametric curve fitter defined by points x(:,i) in the idim-dimensional
-    !> space, attached to a set of strictly increasing parameter values u(i)
+    !> @brief Open parametric curve fitter in \f$ \mathbb{R}^d \f$.
+    !!
+    !! Fits a parametric spline curve \f$ \mathbf{s}(u) = (s_1(u), \ldots, s_d(u)) \f$
+    !! through \f$ m \f$ data points \f$ \mathbf{x}_i \in \mathbb{R}^d \f$ associated with
+    !! strictly increasing parameter values \f$ u_i \f$. If no parameter values are provided,
+    !! they are computed automatically from cumulative chord lengths.
+    !!
+    !! @see Dierckx, Ch. 9, §9.1 (pp. 199–212); parcur
     type, extends(fitpack_fitter) :: fitpack_parametric_curve
 
         !> Number of points
@@ -104,18 +123,31 @@ module fitpack_parametric_curves
 
     end type fitpack_parametric_curve
 
-    !> Derived type describing a closed parametric curve. No changes are made to the storage,
-    !> but the appropriate package functions will be called depending on the type
+    !> @brief Closed (periodic) parametric curve fitter.
+    !!
+    !! Extension of fitpack_parametric_curve for curves that close on themselves,
+    !! i.e. \f$ \mathbf{s}(u_1) = \mathbf{s}(u_m) \f$. Uses the clocur core routine
+    !! which enforces periodic boundary conditions on the B-spline representation.
+    !!
+    !! @see Dierckx, Ch. 9, §9.2 (pp. 213–216); clocur
     type, extends(fitpack_parametric_curve) :: fitpack_closed_curve
 
     end type fitpack_closed_curve
 
-    !> Derived type describing a parametric curve with constraints at the boundaries.
-    !> The dimensional splines will satisfy the following boundary constraints
-    !>                     (l)
-    !>       if ib >= 0 :  sj   (u(1)) = db(1:idim,0:ib-1), ib = boundary constraint on the (i-1)-th derivative
-    !>   and                (l)
-    !>       if ie >= 0 :  sj   (u(m)) = de(1:idim,0:ie-1), ie = boundary constraint on the (i-1)-th derivative
+    !> @brief Parametric curve fitter with derivative constraints at the endpoints.
+    !!
+    !! Extension of fitpack_parametric_curve that enforces prescribed values of
+    !! derivatives at the left and/or right boundaries. For each component
+    !! \f$ s_j(u) \f$, the constraints are:
+    !! \f[
+    !!     s_j^{(\ell)}(u_1) = \text{db}(j, \ell), \quad \ell = 0, \ldots, \text{ib} - 1
+    !! \f]
+    !! \f[
+    !!     s_j^{(\ell)}(u_m) = \text{de}(j, \ell), \quad \ell = 0, \ldots, \text{ie} - 1
+    !! \f]
+    !! Uses the concur core routine.
+    !!
+    !! @see Dierckx, Ch. 9, §9.3 (pp. 217–228); concur
     type, extends(fitpack_parametric_curve) :: fitpack_constrained_curve
 
         !> Left boundary derivatives

--- a/src/fitpack_parametric.f90
+++ b/src/fitpack_parametric.f90
@@ -354,12 +354,19 @@ module fitpack_parametric_curves
        this%ie = 0
     end subroutine clean_constraints
 
-    ! A call to set_constraints will RESET ALL contraints: a missing "ddx_end" means: no constraints
-    ! at the endpoint
+    !> @brief Set or reset endpoint derivative constraints for a constrained parametric curve.
+    !!
+    !! Resets all constraints, then applies the supplied left and/or right boundary conditions.
+    !! Omitting `ddx_begin` or `ddx_end` removes constraints at that endpoint.
+    !!
+    !! @param[in,out] this      The constrained curve object.
+    !! @param[in]     ddx_begin Left endpoint constraints: column 0 = function value,
+    !!                          column \f$ \ell \f$ = \f$ \ell \f$-th derivative (\f$ d \times (ib) \f$).
+    !! @param[in]     ddx_end   Right endpoint constraints (same layout as `ddx_begin`).
+    !! @param[out]    ierr      Error flag (optional).
     subroutine set_constraints(this,ddx_begin,ddx_end,ierr)
         class(fitpack_constrained_curve), intent(inout) :: this
 
-        !> Begin point constraints: (:,0)=function; (:,i)=i-th derivative
         real(FP_REAL), optional, intent(in) :: ddx_begin(:,0:)
         real(FP_REAL), optional, intent(in) :: ddx_end  (:,0:)
 

--- a/src/fitpack_parametric_surfaces.f90
+++ b/src/fitpack_parametric_surfaces.f90
@@ -17,6 +17,15 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief OOP wrapper for parametric surface fitting in \f$ \mathbb{R}^d \f$.
+!!
+!! Provides fitpack_parametric_surface, a derived type for fitting bicubic parametric
+!! tensor-product spline surfaces through gridded data in \f$ d \f$-dimensional space.
+!! The surface maps parameter pairs \f$ (u, v) \f$ to points
+!! \f$ \mathbf{s}(u, v) = (s_1(u,v), \ldots, s_d(u,v)) \f$, with optional periodicity
+!! in either or both parameter directions.
+!!
+!! @see Dierckx, Ch. 10, §10.2 (pp. 241–254); parsur, surev
 module fitpack_parametric_surfaces
     use fitpack_core
     use fitpack_fitters
@@ -25,8 +34,15 @@ module fitpack_parametric_surfaces
 
     public :: fitpack_parametric_surface
 
-    !> A public type describing a bicubic parametric surface fitter defined by points z(j,i,:) in the
-    !> idim-dimensional space, organized on a grid of strictly increasing parameter values u(i), v(j)
+    !> @brief Bicubic parametric surface fitter in \f$ \mathbb{R}^d \f$.
+    !!
+    !! Fits a tensor-product bicubic spline surface
+    !! \f$ \mathbf{s}(u, v) = (s_1(u,v), \ldots, s_d(u,v)) \f$ through data points
+    !! \f$ \mathbf{z}(j, i) \in \mathbb{R}^d \f$ given on a rectangular parameter grid
+    !! \f$ (u_i, v_j) \f$. Each dimension \f$ u \f$ and \f$ v \f$ may be flagged as
+    !! periodic. Uses the parsur core routine.
+    !!
+    !! @see Dierckx, Ch. 10, §10.2 (pp. 241–254)
     type, extends(fitpack_fitter) :: fitpack_parametric_surface
 
         !> Number of dimensions

--- a/src/fitpack_polar.f90
+++ b/src/fitpack_polar.f90
@@ -17,6 +17,19 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief OOP wrapper for bivariate spline fitting on scattered polar domains.
+!!
+!! Provides fitpack_polar, a derived type for fitting bicubic splines to data scattered
+!! over a general polar domain \f$ x^2 + y^2 \leq r(\theta)^2 \f$, where \f$ r(\theta) \f$
+!! is a user-supplied boundary function. The Cartesian coordinates are transformed to
+!! normalized polar coordinates:
+!! \f[
+!!     x = u \, r(v) \cos v, \quad y = u \, r(v) \sin v, \quad 0 \leq u \leq 1, \; -\pi \leq v \leq \pi
+!! \f]
+!! and a bicubic spline \f$ s(u, v) \f$ is fitted with appropriate continuity constraints
+!! at the origin.
+!!
+!! @see Dierckx, Ch. 11, §11.1 (pp. 255–263); polar
 module fitpack_polar_domains
     use fitpack_core
     use fitpack_fitters
@@ -25,16 +38,15 @@ module fitpack_polar_domains
 
     public :: fitpack_polar
 
-    !> A public type describing a polar fitter z = f(x,y) to scattered polar data,
-    !> which is arbitrarily scattered over the polar domain x**2+y**2 <= rad(atan(y/x))**2
-    !> through the transform:  x = u*rad(v)*cos(v),
-    !>                         y = u*rad(v)*sin(v)
-    !> the approximation problem is reduced to the determination of a bi-cubic spline s(u,v) fitting a
-    !> corresponding set of data points (u(i),v(i),z(i)) on the rectangle 0<=u<=1,-pi<=v<=pi.
-
-    !> rad is an external real function defining the boundary of the approximation domain, i.e
-    !>          x = rad(v)*cos(v) , y = rad(v)*sin(v), -pi <= v <= pi.
-    !> It can be a sphere or anything else.
+    !> @brief Bicubic spline fitter for data scattered over a general polar domain.
+    !!
+    !! Stores the scattered Cartesian data \f$ (x_i, y_i, z_i) \f$, the user-supplied
+    !! boundary function \f$ r(\theta) \f$, optional weights, and the fitted B-spline
+    !! representation. The smoothing parameter controls the trade-off between closeness
+    !! of fit and smoothness, while continuity at the origin (\f$ u = 0 \f$) is enforced
+    !! up to order \f$ C^0 \f$, \f$ C^1 \f$, or \f$ C^2 \f$.
+    !!
+    !! @see Dierckx, Ch. 11, §11.1 (pp. 255–263)
     type, extends(fitpack_fitter) :: fitpack_polar
 
         !> Scattered data points

--- a/src/fitpack_spheres.f90
+++ b/src/fitpack_spheres.f90
@@ -17,6 +17,15 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief OOP wrapper for bivariate spline fitting on the sphere to scattered data.
+!!
+!! Provides fitpack_sphere, a derived type for fitting bicubic splines to data scattered
+!! over the unit sphere, parameterized by colatitude \f$ \theta \in [0, \pi] \f$ and
+!! longitude \f$ \phi \in [0, 2\pi] \f$. The fitted surface
+!! \f$ r = s(\theta, \phi) \f$ satisfies appropriate pole constraints to ensure smoothness
+!! at \f$ \theta = 0 \f$ and \f$ \theta = \pi \f$. Uses the sphere core routine.
+!!
+!! @see Dierckx, Ch. 11, §11.2 (pp. 263–269); sphere
 module fitpack_sphere_domains
     use fitpack_core
     use fitpack_fitters
@@ -25,10 +34,14 @@ module fitpack_sphere_domains
 
     public :: fitpack_sphere
 
-    !> A public type describing a smooth bicubic surface fitter r = s(teta,phi),
-    !  0 <= teta <= pi   "Latitude"
-    !> 0 <= phi <= 2*pi  "Longitude"
-    !> which is arbitrarily scattered over the sphere domain
+    !> @brief Bicubic spline fitter for data scattered on the sphere.
+    !!
+    !! Stores the scattered spherical data \f$ (\theta_i, \phi_i, r_i) \f$, optional
+    !! weights, and the fitted B-spline representation. The smoothing parameter controls
+    !! closeness of fit versus smoothness. Pole constraints ensure regularity at
+    !! \f$ \theta = 0 \f$ (north pole) and \f$ \theta = \pi \f$ (south pole).
+    !!
+    !! @see Dierckx, Ch. 11, §11.2 (pp. 263–269)
     type, extends(fitpack_fitter) :: fitpack_sphere
 
         !> Scattered data points

--- a/src/fitpack_surfaces.f90
+++ b/src/fitpack_surfaces.f90
@@ -17,6 +17,14 @@
 !                    Oxford university press, 1993.
 !
 ! **************************************************************************************************
+!> @brief OOP wrapper for bivariate surface fitting to scattered data.
+!!
+!! Provides fitpack_surface, a derived type for fitting tensor-product B-spline surfaces
+!! \f$ z = s(x, y) \f$ to scattered \f$ (x_i, y_i, z_i) \f$ data. The underlying core
+!! routine is surfit, which uses automatic knot placement with a smoothing parameter.
+!! Supports evaluation, partial derivatives, integration, and cross-section extraction.
+!!
+!! @see Dierckx, Ch. 5, §5.3 (pp. 85–98); surfit, bispev, parder, dblint, profil
 module fitpack_surfaces
     use fitpack_core
     use fitpack_fitters
@@ -26,7 +34,14 @@ module fitpack_surfaces
 
     public :: fitpack_surface
 
-    !> A public type describing a bivariate surface fitter z = s(x,y) to scattered x,y data
+    !> @brief Bivariate surface fitter \f$ z = s(x, y) \f$ for scattered data.
+    !!
+    !! Stores the input data points \f$ (x_i, y_i, z_i) \f$, optional weights \f$ w_i \f$,
+    !! the fitted tensor-product B-spline representation (knots and coefficients), and the
+    !! fitting state. The smoothing parameter \f$ s \f$ controls the trade-off between
+    !! closeness of fit and smoothness.
+    !!
+    !! @see Dierckx, Ch. 5, §5.3 (pp. 85–98)
     type, extends(fitpack_fitter) :: fitpack_surface
 
         !> The input data points


### PR DESCRIPTION
## Summary

- Add complete Doxygen documentation with MathJax equation rendering and doxygen-awesome dark-mode theme
- Document ~112 core routines, ~35 public API wrappers, ~20 utility routines, and all 13 OOP types across 12 modules
- Add 4 tutorial/guide pages (curves, surfaces, polar/spherical domains, book reference index) and a landing page
- Add GitHub Actions workflow for automatic deployment to GitHub Pages

## Details

**Phase A — Infrastructure**
- `project/doxygen/Doxyfile` configured for Fortran with MathJax CDN, call graphs, dark mode
- `doxygen-awesome` CSS theme + dark-mode toggle JS
- `.github/workflows/deploy-docs.yml` for gh-pages deployment

**Phase B — Core routine documentation (B1–B9)**
- Every public routine in `fitpack_core.F90` now has `!> @brief`, `@param`, `@return`, `@see` blocks
- MathJax inline (`\f$`) and display (`\f[`) equations reference book formulas
- Cross-references to Dierckx (1993) chapters, sections, and equation numbers

**Phase C — OOP type documentation**
- Module-level and type-level Doxygen for all 12 source files
- Usage examples in `@code` blocks for key types

**Phase D — Tutorial pages**
- `doc/tutorial_curves.md` — smoothing, periodic, parametric, convexity-constrained curves
- `doc/tutorial_surfaces.md` — scattered vs gridded, derivatives, integration, cross-sections
- `doc/tutorial_special.md` — polar and spherical domains, pole boundary conditions
- `doc/book_reference.md` — routine-to-book-chapter mapping table

**Phase E — Verification**
- `fpm build` compiles successfully (comment-only changes to source)
- All 58 tests pass
- `doxygen` generates with only 1 minor warning (parser quirk with array-dimension params)

## Test plan

- [x] `fpm build` — compiles successfully
- [x] `fpm test` — all 58 tests pass
- [x] `doxygen Doxyfile` — generates HTML with 1 minor warning
- [x] Tutorial `@ref` cross-references resolve correctly
