### PR TITLE
Add spline theory pages, example programs, and infrastructure

### DIFF
--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -1,130 +1,81 @@
-# fitpack — Modern Fortran Spline Fitting {#mainpage}
+commit a2cd11b23af0988e0e5813ab0525db6a6ae94a3e
+Author: Federico Perini <federico.perini@gmail.com>
+Date:   Wed Feb 18 22:16:44 2026 +0100
 
-**fitpack** is a Modern Fortran (2008+) library for curve and surface fitting with splines,
-based on the FITPACK package by Paul Dierckx.
+    Fix surfit y-bounds check, percur zero-pivot guard, and NaN-safe tests
+    
+    Three bug fixes:
+    
+    1. surfit: y-values were checked against x-bounds instead of y-bounds,
+       causing spurious "invalid input" errors when x/y ranges differed.
+    
+    2. fp_rotate_row_2mat / fp_rotate_row_2mat_vec: add zero-pivot guards
+       matching original Netlib fpperi.f. Without these, fpgivs computes
+       0/0 = NaN when both pivot and target are zero.
+    
+    3. fitpack_curves new_points: use percur workspace formula
+       nest*(8+5*k) instead of curfit's nest*(7+3*k).
+    
+    4. Test comparisons: use `.not.(expr <= tol)` instead of `expr > tol`
+       so NaN values are caught (IEEE 754: NaN > x is always false).
 
-It provides an object-oriented API with derived types for all major fitting tasks:
-smoothing, interpolation, least-squares approximation, and constrained fitting.
-All routines support spline degrees 1 through 5 (cubic by default) and return
-B-spline representations that can be evaluated, differentiated, integrated, and
-root-found efficiently.
-
-## Type Hierarchy
-
-All fitter types extend the abstract base `fitpack_fitter`:
-
-```
-fitpack_fitter (abstract base)
-├── fitpack_curve                   — 1D spline: y = s(x)
-│   ├── fitpack_periodic_curve      — periodic boundary conditions
-│   └── fitpack_convex_curve        — convexity-constrained fitting
-├── fitpack_parametric_curve        — parametric curves: x_i = s_i(u)
-│   ├── fitpack_closed_curve        — closed parametric curves
-│   └── fitpack_constrained_curve   — endpoint derivative constraints
-├── fitpack_surface                 — 2D spline from scattered data
-├── fitpack_grid_surface            — 2D spline from gridded data
-├── fitpack_parametric_surface      — parametric surfaces
-├── fitpack_polar                   — polar-domain fitting (scattered)
-├── fitpack_grid_polar              — polar-domain fitting (gridded)
-├── fitpack_sphere                  — spherical-domain fitting (scattered)
-└── fitpack_grid_sphere             — spherical-domain fitting (gridded)
-```
-
-## Quick Start
-
-### Fit a curve
-
-```fortran
-use fitpack, only: fitpack_curve
-
-type(fitpack_curve) :: curve
-integer :: ierr
-
-! Create a smoothing spline from data
-curve = fitpack_curve(x, y, ierr=ierr)
-
-! Evaluate at new points
-y_new = curve%eval(x_new, ierr)
-
-! Compute derivative, integral, zeros
-dydx  = curve%dfdx(x_new, ierr)
-area  = curve%integral(x(1), x(size(x)), ierr)
-roots = curve%zeros(ierr)
-```
-
-### Fit a surface
-
-```fortran
-use fitpack, only: fitpack_grid_surface
-
-type(fitpack_grid_surface) :: surf
-integer :: ierr
-
-! Create a smoothing spline from gridded data
-surf = fitpack_grid_surface(x, y, z, ierr=ierr)
-
-! Evaluate on a new grid
-z_new = surf%eval(x_new, y_new, ierr)
-```
-
-## Building
-
-fitpack uses [fpm](https://fpm.fortran-lang.org/) (Fortran Package Manager):
-
-```bash
-fpm build          # build the library
-fpm test           # run all tests
-```
-
-## Spline Theory
-
-- @ref theory_bsplines &mdash; B-spline basis functions, de Boor evaluation, derivatives, integration, knot insertion
-- @ref theory_curve_fitting &mdash; Smoothing criterion, adaptive knot placement, periodic and parametric curves
-- @ref theory_surface_fitting &mdash; Tensor product splines, scattered vs. gridded fitting, Kronecker product efficiency
-- @ref theory_special_domains &mdash; Polar coordinate transform, spherical coordinates, pole boundary conditions
-
-## Tutorials
-
-### Curves
-
-- @ref tutorial_curve &mdash; Univariate smoothing and interpolation with `fitpack_curve`
-- @ref tutorial_periodic_curve &mdash; Periodic splines with `fitpack_periodic_curve`
-- @ref tutorial_parametric_curves &mdash; Parametric, closed, and constrained curves
-- @ref tutorial_convex_curve &mdash; Shape-preserving fitting with convexity constraints
-
-### Surfaces
-
-- @ref tutorial_surface &mdash; Scattered bivariate data with `fitpack_surface`
-- @ref tutorial_grid_surface &mdash; Gridded data and parametric surfaces
-
-### Special Domains
-
-- @ref tutorial_polar &mdash; Disc-shaped domains with `fitpack_polar` and `fitpack_grid_polar`
-- @ref tutorial_sphere &mdash; Spherical data with `fitpack_sphere` and `fitpack_grid_sphere`
-
-## Examples
-
-Compilable example programs are in the `examples/` directory. Build and run with:
-
-```bash
-fpm run --example example_curve
-fpm run --example example_periodic_curve
-fpm run --example example_parametric_curves
-fpm run --example example_convex_curve
-fpm run --example example_surface
-fpm run --example example_grid_surface
-fpm run --example example_polar
-fpm run --example example_sphere
-```
-
-## Reference
-
-- @ref book_reference &mdash; Quick-reference table mapping routines to book chapters and equations
-
-The algorithms are described in:
-
-> P. Dierckx, *Curve and Surface Fitting with Splines*,
-> Oxford University Press, 1993.
-
-Each routine's documentation references the relevant book chapter, section,
-and equation numbers.
+diff --git a/doc/mainpage.md b/doc/mainpage.md
+index 311b4d7..af03e87 100644
+--- a/doc/mainpage.md
++++ b/doc/mainpage.md
+@@ -76,15 +76,51 @@ fpm build          # build the library
+ fpm test           # run all tests
+ ```
+ 
++## Spline Theory
++
++- @ref theory_bsplines &mdash; B-spline basis functions, de Boor evaluation, derivatives, integration, knot insertion
++- @ref theory_curve_fitting &mdash; Smoothing criterion, adaptive knot placement, periodic and parametric curves
++- @ref theory_surface_fitting &mdash; Tensor product splines, scattered vs. gridded fitting, Kronecker product efficiency
++- @ref theory_special_domains &mdash; Polar coordinate transform, spherical coordinates, pole boundary conditions
++
+ ## Tutorials
+ 
+-- @ref tutorial_curves — Smoothing, interpolation, derivatives, roots, periodic and parametric curves
+-- @ref tutorial_surfaces — Scattered and gridded surface fitting, cross-sections, integration
+-- @ref tutorial_special — Polar and spherical domains, pole boundary conditions
+-- @ref book_reference — Quick-reference table mapping routines to book chapters and equations
++### Curves
++
++- @ref tutorial_curve &mdash; Univariate smoothing and interpolation with `fitpack_curve`
++- @ref tutorial_periodic_curve &mdash; Periodic splines with `fitpack_periodic_curve`
++- @ref tutorial_parametric_curves &mdash; Parametric, closed, and constrained curves
++- @ref tutorial_convex_curve &mdash; Shape-preserving fitting with convexity constraints
++
++### Surfaces
++
++- @ref tutorial_surface &mdash; Scattered bivariate data with `fitpack_surface`
++- @ref tutorial_grid_surface &mdash; Gridded data and parametric surfaces
++
++### Special Domains
++
++- @ref tutorial_polar &mdash; Disc-shaped domains with `fitpack_polar` and `fitpack_grid_polar`
++- @ref tutorial_sphere &mdash; Spherical data with `fitpack_sphere` and `fitpack_grid_sphere`
++
++## Examples
++
++Compilable example programs are in the `examples/` directory. Build and run with:
++
++```bash
++fpm run --example example_curve
++fpm run --example example_periodic_curve
++fpm run --example example_parametric_curves
++fpm run --example example_convex_curve
++fpm run --example example_surface
++fpm run --example example_grid_surface
++fpm run --example example_polar
++fpm run --example example_sphere
++```
+ 
+ ## Reference
+ 
++- @ref book_reference &mdash; Quick-reference table mapping routines to book chapters and equations
++
+ The algorithms are described in:
+ 
+ > P. Dierckx, *Curve and Surface Fitting with Splines*,

--- a/doc/theory_bsplines.md
+++ b/doc/theory_bsplines.md
@@ -1,0 +1,260 @@
+# B-Spline Foundations {#theory_bsplines}
+
+This page introduces the mathematical foundations of B-splines as used throughout
+FITPACK. All curve and surface fitting routines in the library represent their
+results as linear combinations of B-spline basis functions, so understanding these
+foundations is essential for interpreting knot vectors, coefficients, and the
+various evaluation, differentiation, and integration operations.
+
+The presentation follows Dierckx (1993), Chapters 1 and 6.
+
+## Piecewise Polynomials and Knot Vectors
+
+A **spline** of degree \f$ k \f$ is a piecewise polynomial function whose pieces
+join with \f$ k - 1 \f$ continuous derivatives at designated breakpoints called
+**knots**. The knots are collected into a non-decreasing **knot vector**
+
+\f[
+    t_0 \leq t_1 \leq \cdots \leq t_{n+k+1}
+\f]
+
+which partitions the approximation interval \f$ [a, b] \f$ into sub-intervals.
+The number of distinct interior knots determines the flexibility of the spline:
+more knots allow closer approximation to complicated shapes, while fewer knots
+enforce smoothness.
+
+The set of all splines of degree \f$ k \f$ on a given knot vector \f$ \mathbf{t} \f$
+forms a linear space \f$ \mathcal{S}(k, \mathbf{t}) \f$ of dimension \f$ n + 1 \f$,
+where \f$ n + 1 \f$ is the number of B-spline basis functions (and therefore the
+number of coefficients needed to represent any element of the space).
+
+In FITPACK the first and last \f$ k + 1 \f$ knots are clamped to the boundary:
+
+\f[
+    t_0 = t_1 = \cdots = t_k = a, \qquad
+    t_{n+1} = t_{n+2} = \cdots = t_{n+k+1} = b
+\f]
+
+so that the spline interpolates (rather than merely approximates) its coefficient
+values at the endpoints.
+
+## B-Spline Basis Functions
+
+Every element of \f$ \mathcal{S}(k, \mathbf{t}) \f$ can be written uniquely as a
+linear combination of **B-spline basis functions** \f$ N_{i,k}(x) \f$, which are
+defined recursively by the **Cox&ndash;de Boor recurrence**.
+
+### Degree zero
+
+For \f$ k = 0 \f$ the basis functions are simple indicator functions:
+
+\f[
+    N_{i,0}(x) =
+    \begin{cases}
+        1 & \text{if } t_i \leq x < t_{i+1}, \\
+        0 & \text{otherwise}.
+    \end{cases}
+\f]
+
+### Recurrence for degree \f$ k \geq 1 \f$
+
+Higher-degree basis functions are built from lower-degree ones:
+
+\f[
+    N_{i,k}(x) =
+        \frac{x - t_i}{t_{i+k} - t_i} \, N_{i,k-1}(x)
+      + \frac{t_{i+k+1} - x}{t_{i+k+1} - t_{i+1}} \, N_{i+1,k-1}(x)
+\f]
+
+where any fraction with a zero denominator is taken to be zero (this arises when
+consecutive knots coincide). The routine `fpbspl` implements this recurrence.
+
+### Key properties
+
+The B-spline basis functions enjoy several properties that make them ideal for
+numerical computation:
+
+1. **Non-negativity**: \f$ N_{i,k}(x) \geq 0 \f$ for all \f$ x \f$.
+2. **Local support**: \f$ N_{i,k}(x) = 0 \f$ outside the interval
+   \f$ [t_i,\, t_{i+k+1}] \f$. Each basis function is nonzero on at most
+   \f$ k + 1 \f$ knot spans, so spline evaluation is a local operation.
+3. **Partition of unity**: At every point in \f$ [a, b] \f$ the basis functions
+   sum to one: \f$ \sum_{i} N_{i,k}(x) = 1 \f$. This ensures that any convex
+   combination of coefficients produces a spline value within the convex hull of
+   those coefficients.
+4. **Smoothness**: At a simple knot (multiplicity 1), \f$ N_{i,k} \f$ has
+   \f$ k - 1 \f$ continuous derivatives. Each additional coincident knot reduces
+   smoothness by one order.
+
+@see Dierckx, Ch. 1, &sect;1.1&ndash;1.2
+
+## Spline as a Linear Combination
+
+Any spline \f$ s \in \mathcal{S}(k, \mathbf{t}) \f$ is represented as
+
+\f[
+    s(x) = \sum_{i=0}^{n} c_i \, N_{i,k}(x)
+\f]
+
+where the \f$ c_i \f$ are the **B-spline coefficients** (also called control
+points or de Boor points). The entire fitting problem therefore reduces to
+determining the \f$ n + 1 \f$ coefficients for a given knot vector.
+
+In FITPACK the coefficient array is stored alongside the knot vector in each
+derived type (e.g., `fitpack_curve`, `fitpack_surface`). Once computed by the
+fitting routines, the same coefficients are used by all evaluation, derivative,
+and integration routines.
+
+## Evaluation: the de Boor Algorithm
+
+Given a point \f$ x \in [t_j,\, t_{j+1}) \f$, the spline value \f$ s(x) \f$ can
+be computed without explicitly forming all basis functions. The **de Boor
+algorithm** is a triangular recurrence analogous to Horner's method for ordinary
+polynomials.
+
+Define the initial values
+
+\f[
+    d_i^{[0]} = c_i, \qquad i = j-k, \ldots, j
+\f]
+
+and compute for \f$ r = 1, \ldots, k \f$:
+
+\f[
+    d_i^{[r]} =
+        \frac{x - t_i}{t_{i+k+1-r} - t_i} \, d_i^{[r-1]}
+      + \frac{t_{i+k+1-r} - x}{t_{i+k+1-r} - t_i} \, d_{i-1}^{[r-1]},
+    \qquad i = j-k+r, \ldots, j
+\f]
+
+After \f$ k \f$ stages the result is \f$ s(x) = d_j^{[k]} \f$. The cost is
+\f$ \mathcal{O}(k^2) \f$ per evaluation point, independent of the total number
+of knots. This is the core loop in `splev` and underlies every `eval` method
+in the library.
+
+@see Dierckx, Ch. 1, Eq. 1.11
+
+## Derivatives
+
+Differentiation of a B-spline representation yields another B-spline of one
+degree lower. The derivative of \f$ s(x) = \sum_i c_i \, N_{i,k}(x) \f$ is
+
+\f[
+    s'(x) = \sum_{i=1}^{n} c_i^{(1)} \, N_{i,k-1}(x)
+\f]
+
+where the new coefficients are obtained by **differencing**:
+
+\f[
+    c_i^{(1)} = \frac{k}{t_{i+k} - t_i} \, (c_i - c_{i-1})
+\f]
+
+Higher-order derivatives follow by repeated application: the \f$ \nu \f$-th
+derivative is a spline of degree \f$ k - \nu \f$ with coefficients obtained from
+\f$ \nu \f$ successive differencing steps. This structure is exploited by `splder`,
+which computes derivatives of any order up to \f$ k \f$.
+
+Because each differentiation reduces the degree by one, at most \f$ k \f$
+derivatives are nonzero. A cubic spline (\f$ k = 3 \f$) therefore has a
+piecewise-constant third derivative and a zero fourth derivative, regardless of
+the coefficients.
+
+@see Dierckx, Ch. 1, &sect;1.3
+
+## Integration
+
+The definite integral of a spline over an interval can be expressed directly in
+terms of its coefficients, without numerical quadrature. For a spline
+\f$ s(x) = \sum_i c_i \, N_{i,k}(x) \f$ on the interval \f$ [a, b] \f$:
+
+\f[
+    \int_a^b s(x) \, dx = \sum_{i=0}^{n} c_i \, \frac{t_{i+k+1} - t_i}{k + 1}
+\f]
+
+This formula follows from the property that the integral of each basis function
+satisfies
+
+\f[
+    \int_a^b N_{i,k}(x) \, dx = \frac{t_{i+k+1} - t_i}{k + 1}
+\f]
+
+when the knot vector is clamped at both ends. The routine `splint` implements
+this formula, giving exact results (up to floating-point arithmetic) regardless
+of the complexity of the spline.
+
+@see Dierckx, Ch. 1, &sect;1.4
+
+## Knot Insertion (Oslo Algorithm)
+
+A fundamental operation on B-spline representations is **knot insertion**:
+adding a new knot \f$ \bar{t} \f$ to the knot vector without changing the spline
+function itself. The resulting representation has one more knot, one more
+coefficient, and the same function values everywhere.
+
+Suppose a knot \f$ \bar{t} \in [t_j,\, t_{j+1}) \f$ is inserted. The new
+coefficients \f$ \bar{c}_i \f$ are obtained from the old ones by a **convex
+combination**:
+
+\f[
+    \bar{c}_i =
+    \begin{cases}
+        c_i & \text{if } i \leq j - k, \\[4pt]
+        \alpha_i \, c_i + (1 - \alpha_i) \, c_{i-1}
+            & \text{if } j - k < i \leq j, \\[4pt]
+        c_{i-1} & \text{if } i > j,
+    \end{cases}
+\f]
+
+with weights
+
+\f[
+    \alpha_i = \frac{\bar{t} - t_i}{t_{i+k} - t_i}.
+\f]
+
+Because \f$ 0 \leq \alpha_i \leq 1 \f$, the new coefficients lie in the convex
+hull of their neighbours&mdash;a key property that preserves shape.
+
+Knot insertion is the basis of the **Oslo algorithm** (Cohen, Lyche, and
+Schumaker, 1986), which generalizes the operation to insert several knots at
+once. In FITPACK the `insert` routine performs single knot insertion and is used
+both for refinement and for the zero-finding algorithm in `sproot`.
+
+@see Dierckx, Ch. 6, &sect;6.2 (pp. 114&ndash;118)
+
+## Tensor Products for Bivariate Splines
+
+The B-spline framework extends naturally to two dimensions via **tensor
+products**. Given knot vectors \f$ \mathbf{t}_x \f$ and \f$ \mathbf{t}_y \f$
+with associated basis functions \f$ N_{i,k_x}(x) \f$ and \f$ M_{j,k_y}(y) \f$,
+a bivariate spline is
+
+\f[
+    s(x, y) = \sum_{i=0}^{n_x} \sum_{j=0}^{n_y}
+        c_{ij} \, N_{i,k_x}(x) \, M_{j,k_y}(y)
+\f]
+
+The coefficient array \f$ c_{ij} \f$ has \f$ (n_x + 1)(n_y + 1) \f$ entries and
+is stored in column-major order in FITPACK.
+
+Evaluation of a tensor-product spline decomposes into two sequences of
+univariate evaluations: first evaluate in \f$ x \f$ for each row of coefficients,
+then evaluate the resulting intermediate values in \f$ y \f$. This separability
+is the reason tensor-product splines scale well to two dimensions.
+
+The routines `bispev` (grid evaluation) and `bispeu` (scattered evaluation)
+implement this strategy. Partial derivatives (`parder`, `pardeu`) and double
+integrals (`dblint`) follow the same tensor-product decomposition.
+
+@see Dierckx, Ch. 1, &sect;1.5
+
+## Further Reading
+
+The foundations described on this page underpin all fitting algorithms in the
+library. The fitting problem itself&mdash;choosing knots and coefficients to
+approximate given data&mdash;is covered separately.
+
+@see @ref theory_curve_fitting
+@see @ref book_reference
+
+> P. Dierckx, *Curve and Surface Fitting with Splines*,
+> Oxford University Press, 1993.

--- a/doc/theory_curve_fitting.md
+++ b/doc/theory_curve_fitting.md
@@ -1,0 +1,351 @@
+# Curve Fitting Theory {#theory_curve_fitting}
+
+This page describes the mathematical foundations of the curve fitting algorithms
+in FITPACK: given data points \f$ (x_i, y_i) \f$ for \f$ i = 1, \ldots, m \f$,
+find a spline \f$ s(x) \f$ in the B-spline space \f$ S(k, \mathbf{t}) \f$ that
+represents the data well. The library supports several formulations of this
+problem, from simple least-squares with user-supplied knots to fully automatic
+smoothing with adaptive knot placement.
+
+## The Approximation Problem
+
+Given \f$ m \f$ data points \f$ (x_i, y_i) \f$ with strictly increasing abscissae
+
+\f[
+    x_1 < x_2 < \cdots < x_m
+\f]
+
+and optional positive weights \f$ w_i \f$, the goal is to find a spline
+\f$ s \in S(k, \mathbf{t}) \f$ of degree \f$ k \f$ on a knot vector
+\f$ \mathbf{t} \f$ that approximates the data. Three common formulations arise:
+
+- **Interpolation.** Require \f$ s(x_i) = y_i \f$ for every data point. This
+  determines the spline exactly when \f$ n = m \f$ (number of knots minus
+  degree minus one equals number of data points). No smoothing is applied.
+
+- **Least-squares with fixed knots.** Given a prescribed knot vector, find
+  the B-spline coefficients \f$ c_j \f$ that minimize the weighted residual
+  sum of squares. The number and placement of knots are chosen by the user.
+
+- **Smoothing.** Let the algorithm choose the knot vector automatically,
+  balancing closeness-of-fit against smoothness of the spline. This is
+  FITPACK's primary mode of operation.
+
+@see Dierckx, Ch. 4&ndash;5 (pp. 49&ndash;103)
+
+## Least-Squares with Fixed Knots
+
+Suppose a knot vector \f$ \mathbf{t} = (t_1, \ldots, t_{n+k+1}) \f$ is given.
+The spline has the B-spline representation
+
+\f[
+    s(x) = \sum_{j=1}^{n} c_j \, B_j(x; k, \mathbf{t})
+\f]
+
+where \f$ n \f$ is the number of B-spline basis functions and \f$ c_j \f$ are
+the unknown coefficients. The least-squares problem is to minimize
+
+\f[
+    \sum_{i=1}^{m} w_i^2 \left( y_i - \sum_{j=1}^{n} c_j \, B_j(x_i) \right)^2
+\f]
+
+over all coefficient vectors \f$ \mathbf{c} \in \mathbb{R}^n \f$.
+
+### Normal Equations and Banded Structure
+
+Setting the gradient to zero yields the normal equations
+\f$ A^T W^2 A \, \mathbf{c} = A^T W^2 \mathbf{y} \f$, where \f$ A_{ij} = B_j(x_i) \f$
+is the \f$ m \times n \f$ collocation matrix and \f$ W = \mathrm{diag}(w_i) \f$.
+Because each B-spline \f$ B_j \f$ is nonzero on at most \f$ k+1 \f$ knot spans,
+the matrix \f$ A \f$ has at most \f$ k+1 \f$ nonzero entries per row. The resulting
+normal equations matrix \f$ A^T W^2 A \f$ is symmetric, positive semi-definite,
+and banded with bandwidth \f$ k+1 \f$.
+
+### QR Factorization via Givens Rotations
+
+Rather than forming and solving the normal equations directly (which squares the
+condition number), FITPACK solves the least-squares problem by computing a QR
+factorization of the weighted matrix \f$ W A \f$ using Givens rotations. Each
+data point \f$ (x_i, y_i) \f$ contributes one row to the system; Givens rotations
+annihilate entries below the diagonal one at a time, maintaining the banded
+structure throughout.
+
+This approach has several advantages:
+
+- **Numerical stability.** The condition number of the triangular factor
+  \f$ R \f$ equals \f$ \kappa(WA) \f$, not \f$ \kappa(WA)^2 \f$.
+- **Efficiency.** Each rotation touches only \f$ \mathcal{O}(k) \f$ elements,
+  giving \f$ \mathcal{O}(m k^2) \f$ total work.
+- **Incremental updates.** Adding or removing knots requires only local
+  updates to the factorization.
+
+The back-substitution step solves the upper triangular system \f$ R \mathbf{c} = Q^T W \mathbf{y} \f$
+for the coefficients.
+
+@see Dierckx, Ch. 4, &sect;4.2 (pp. 53&ndash;62)
+
+## The Smoothing Problem
+
+Instead of fixing the knot vector a priori, the smoothing formulation treats
+the number and positions of knots as unknowns. The problem is to find a spline
+\f$ s \in S(k, \mathbf{t}) \f$ that minimizes a roughness measure subject to
+a constraint on the residual:
+
+\f[
+    \min_{s \in S(k, \mathbf{t})} \int_{x_1}^{x_m} \left[ s''(x) \right]^2 \, dx
+    \quad \text{subject to} \quad
+    \sum_{i=1}^{m} w_i^2 \left( y_i - s(x_i) \right)^2 \leq S
+\f]
+
+Here \f$ S \geq 0 \f$ is the **smoothing parameter** that controls the trade-off:
+
+- **\f$ S = 0 \f$**: The constraint forces interpolation. The spline passes
+  through every data point, and the roughness integral is minimized among all
+  interpolating splines.
+- **Small \f$ S \f$**: The spline stays close to the data but may oscillate
+  between data points, requiring many knots.
+- **Large \f$ S \f$**: The spline is very smooth (few knots) but may miss
+  important features in the data.
+
+For a given \f$ S \f$, the theoretical solution is a natural spline of degree
+\f$ 2k + 1 \f$ with knots at the data sites. FITPACK approximates this solution
+using a spline of degree \f$ k \f$ on a much smaller knot set, determined
+adaptively.
+
+@see Dierckx, Ch. 5, &sect;5.2 (pp. 67&ndash;84)
+
+## Adaptive Knot Placement
+
+FITPACK's `curfit` routine implements an iterative strategy to determine both
+the number and positions of knots:
+
+1. **Initialize.** Start with the minimal knot vector containing \f$ 2(k+1) \f$
+   knots: \f$ k+1 \f$ knots stacked at each end of the data range.
+
+2. **Solve.** Compute the least-squares spline for the current knot vector
+   using Givens rotations. Let \f$ f_p = \sum w_i^2 (y_i - s(x_i))^2 \f$ be the
+   weighted residual sum of squares.
+
+3. **Test convergence.** If \f$ f_p \leq S \f$, the smoothing constraint is
+   satisfied and the algorithm terminates.
+
+4. **Add knots.** Identify the knot interval \f$ [t_j, t_{j+1}) \f$ with the
+   largest contribution to the residual. Insert a new knot at the data abscissa
+   in that interval where the local residual is greatest.
+
+5. **Iterate.** Return to step 2 with the augmented knot vector.
+
+6. **Smoothing parameter update.** Once enough knots are available, the
+   algorithm uses rational interpolation (Dierckx's `fprati`) to refine the
+   Lagrange multiplier \f$ p \f$ that connects the unconstrained minimization
+
+   \f[
+       \eta(p) = p \sum_{i=1}^{m} w_i^2 (y_i - s_p(x_i))^2
+       + (1 - p) \int [s_p''(x)]^2 \, dx
+   \f]
+
+   to the constrained formulation. This avoids solving many full least-squares
+   problems and typically converges in a few iterations.
+
+The procedure is designed to produce a spline with as few knots as possible
+while satisfying the smoothing constraint \f$ f_p \leq S \f$.
+
+@see Dierckx, Ch. 5, &sect;5.2.4 (pp. 78&ndash;84)
+
+## Choosing the Smoothing Factor
+
+Selecting an appropriate value of \f$ S \f$ is the most important practical
+decision in spline smoothing. The following guidelines apply:
+
+- **Known noise variance.** If the data satisfy \f$ y_i = g(x_i) + \varepsilon_i \f$
+  where \f$ \varepsilon_i \f$ are independent errors with variance \f$ \sigma^2 \f$
+  and the weights are \f$ w_i = 1 \f$, the expected value of the residual sum
+  of squares for the true function is \f$ m \sigma^2 \f$. A natural choice is
+
+  \f[
+      S \approx m \, \sigma^2
+  \f]
+
+  More generally, for non-uniform weights, \f$ S \approx \sum w_i^2 \sigma_i^2 \f$.
+
+- **Unit weights, well-scaled data.** When \f$ w_i = 1 \f$ and no noise estimate
+  is available, \f$ S = m \f$ is a reasonable starting point.
+
+- **Over-fitting (\f$ S \f$ too small).** The spline chases noise in the data,
+  introducing spurious oscillations and using too many knots. The number of
+  knots grows until the maximum is reached, and the fit may become numerically
+  ill-conditioned.
+
+- **Under-fitting (\f$ S \f$ too large).** The spline is too smooth and fails
+  to capture genuine features. The knot count stays near the minimum \f$ 2(k+1) \f$,
+  and the residuals show systematic patterns.
+
+- **Diagnostic.** After fitting, inspect the mean squared error via
+  `curve\%mse()`. If the residual is much larger than the expected noise level,
+  decrease \f$ S \f$; if the spline oscillates visibly, increase \f$ S \f$.
+
+A practical workflow is to try a sequence of \f$ S \f$ values (e.g., on a
+logarithmic scale) and select the one that gives the best balance between
+smoothness and fidelity, or use cross-validation techniques.
+
+@see Dierckx, Ch. 5, &sect;5.2.4 (pp. 78&ndash;84)
+
+## Periodic Splines
+
+When the data represent a function that is periodic on \f$ [x_1, x_m] \f$ (for
+example, angular measurements as a function of time), the fitted spline should
+satisfy periodicity constraints:
+
+\f[
+    s^{(j)}(x_1) = s^{(j)}(x_m), \quad j = 0, 1, \ldots, k-1
+\f]
+
+These \f$ k \f$ conditions ensure that the spline and its first \f$ k-1 \f$
+derivatives match at the endpoints, producing a globally smooth periodic
+function.
+
+In terms of the B-spline representation, periodicity is enforced by wrapping
+the knot vector and tying the first and last \f$ k \f$ coefficients:
+
+\f[
+    c_j = c_{n - k + j}, \quad j = 1, \ldots, k
+\f]
+
+This reduces the number of free coefficients from \f$ n \f$ to \f$ n - k \f$.
+The modified least-squares problem is solved with the same Givens rotation
+approach.
+
+FITPACK's `percur` routine implements automatic-knot periodic curve fitting.
+The corresponding type is `fitpack_periodic_curve`.
+
+@see Dierckx, Ch. 6, &sect;6.1 (pp. 105&ndash;114)
+
+## Parametric Curves
+
+A parametric curve in \f$ \mathbb{R}^d \f$ is defined by \f$ d \f$ coordinate
+functions of a common parameter \f$ u \f$:
+
+\f[
+    \mathbf{x}(u) = \bigl( s_1(u), \, s_2(u), \, \ldots, \, s_d(u) \bigr)
+\f]
+
+Given data points \f$ \mathbf{x}_i \in \mathbb{R}^d \f$ for \f$ i = 1, \ldots, m \f$,
+the first step is to assign parameter values \f$ u_i \f$.
+
+### Chord-Length Parameterization
+
+The default choice is cumulative chord length:
+
+\f[
+    u_1 = 0, \quad u_{i+1} = u_i + \| \mathbf{x}_{i+1} - \mathbf{x}_i \|,
+    \quad i = 1, \ldots, m-1
+\f]
+
+This ensures that parameter increments are proportional to the spacing between
+successive data points, preventing bunching in regions of high curvature.
+
+### Shared Knot Vector
+
+All \f$ d \f$ component splines \f$ s_j(u) \f$ share the same knot vector
+\f$ \mathbf{t} \f$ and degree \f$ k \f$. The smoothing problem becomes: minimize
+
+\f[
+    \sum_{j=1}^{d} \int \left[ s_j''(u) \right]^2 \, du
+    \quad \text{subject to} \quad
+    \sum_{i=1}^{m} \sum_{j=1}^{d} w_i^2 \left( x_{ij} - s_j(u_i) \right)^2 \leq S
+\f]
+
+FITPACK's `parcur` routine handles this by solving \f$ d \f$ coupled
+least-squares problems with a common knot vector.
+
+### Closed Curves
+
+For closed parametric curves, the spline must satisfy periodic boundary
+conditions in every component:
+
+\f[
+    s_j^{(l)}(u_1) = s_j^{(l)}(u_m), \quad l = 0, 1, \ldots, k-1, \quad j = 1, \ldots, d
+\f]
+
+This is implemented by `clocur` (type `fitpack_closed_curve`).
+
+### Endpoint Constraints
+
+In some applications, the tangent vector or higher derivatives at the curve
+endpoints are prescribed. FITPACK's `concur` routine supports derivative
+constraints of the form:
+
+\f[
+    s_j^{(l)}(u_1) = \alpha_{jl}, \quad s_j^{(l)}(u_m) = \beta_{jl}
+\f]
+
+for selected orders \f$ l \f$ and components \f$ j \f$, implemented by
+`fitpack_constrained_curve`.
+
+@see Dierckx, Ch. 9 (pp. 199&ndash;228)
+
+## Convexity-Constrained Fitting
+
+In many applications the fitted curve must be shape-preserving: convex data
+should produce a convex spline, concave data a concave spline. FITPACK supports
+local convexity constraints via the second derivative.
+
+### B-Spline Coefficient Conditions
+
+A spline \f$ s(x) \f$ of degree \f$ k \geq 2 \f$ is convex on an interval if
+and only if \f$ s''(x) \geq 0 \f$ there. For B-splines, this translates into
+conditions on the second-order divided differences of the coefficients:
+
+\f[
+    \Delta^2 c_j = c_{j+2} - 2 c_{j+1} + c_j \geq 0
+\f]
+
+for all \f$ j \f$ whose corresponding B-splines overlap the interval.
+Concavity requires \f$ \Delta^2 c_j \leq 0 \f$.
+
+### Per-Interval Convexity Flags
+
+FITPACK allows the user to specify convexity constraints independently for each
+data interval via a flag vector \f$ v_i \f$:
+
+| Flag value | Meaning |
+|------------|---------|
+| \f$ +1 \f$ | The spline must be concave on \f$ [x_i, x_{i+1}] \f$ |
+| \f$ -1 \f$ | The spline must be convex on \f$ [x_i, x_{i+1}] \f$ |
+| \f$ 0 \f$  | No constraint (the spline is free) |
+
+### Quadratic Programming Formulation
+
+The constrained fitting problem becomes a quadratic program (QP): minimize the
+roughness integral (or weighted residual) subject to the linear inequality
+constraints on \f$ \Delta^2 c_j \f$ and the smoothing constraint
+\f$ f_p \leq S \f$. FITPACK solves this QP iteratively, combining the adaptive
+knot strategy with active-set management for the convexity constraints.
+
+Two routines are provided:
+
+- **`concon`** (type `fitpack_convex_curve`): automatic knot placement with
+  convexity constraints. The algorithm adds knots as in `curfit` but enforces
+  the shape constraints at each step.
+- **`cocosp`**: fixed knot vector with convexity constraints. The user supplies
+  the knots and the routine solves the constrained least-squares problem.
+
+@see Dierckx, Ch. 8, &sect;8.3&ndash;8.4 (pp. 173&ndash;196)
+
+## Summary
+
+| Formulation | Routine | Type | Key parameter |
+|-------------|---------|------|---------------|
+| Automatic smoothing | `curfit` | `fitpack_curve` | Smoothing factor \f$ S \f$ |
+| Interpolation | `curfit` | `fitpack_curve` | \f$ S = 0 \f$ |
+| Fixed-knot least-squares | `curfit` | `fitpack_curve` | User knot vector |
+| Periodic smoothing | `percur` | `fitpack_periodic_curve` | Smoothing factor \f$ S \f$ |
+| Open parametric | `parcur` | `fitpack_parametric_curve` | Smoothing factor \f$ S \f$ |
+| Closed parametric | `clocur` | `fitpack_closed_curve` | Smoothing factor \f$ S \f$ |
+| Endpoint-constrained | `concur` | `fitpack_constrained_curve` | Derivative values |
+| Convex (auto knots) | `concon` | `fitpack_convex_curve` | Convexity flags \f$ v_i \f$ |
+| Convex (fixed knots) | `cocosp` | &mdash; | Convexity flags \f$ v_i \f$ |
+
+@see @ref theory_bsplines
+@see @ref tutorial_curve
+@see @ref book_reference

--- a/doc/theory_special_domains.md
+++ b/doc/theory_special_domains.md
@@ -1,0 +1,223 @@
+# Polar and Spherical Domains {#theory_special_domains}
+
+Fitting on non-rectangular domains&mdash;disc-shaped regions in the plane and the
+surface of a sphere&mdash;requires coordinate transformations that map the physical
+domain to a rectangular parameter space where tensor-product B-splines can be
+applied. These transformations introduce singularities (the origin of a disc,
+the poles of a sphere) where special continuity conditions must be imposed on
+the B-spline coefficients to ensure a smooth, single-valued result.
+
+The presentation follows Dierckx (1993), Chapter 11.
+
+## Polar Coordinates
+
+### The polar domain
+
+A general polar domain is the set of points \f$ (x, y) \f$ satisfying
+\f$ x^2 + y^2 \leq R(\theta)^2 \f$, where \f$ R(\theta) \f$ is a positive
+boundary function and \f$ \theta = \mathrm{atan2}(y, x) \f$. When
+\f$ R(\theta) \f$ is constant the domain is a circular disc.
+
+### Normalized polar transform
+
+FITPACK maps the physical coordinates \f$ (x, y) \f$ to normalized polar
+coordinates \f$ (u, v) \f$ via
+
+\f[
+    x = u \, R(v) \cos v, \qquad y = u \, R(v) \sin v
+\f]
+
+with \f$ u \in [0, 1] \f$ and \f$ v \in [-\pi, \pi] \f$. The radial variable
+\f$ u \f$ runs from 0 (the origin) to 1 (the boundary), and \f$ v \f$ is the
+polar angle. In this parameter space the fitting problem becomes rectangular:
+find a tensor-product B-spline
+
+\f[
+    s(u, v) = \sum_{i} \sum_{j} c_{ij} \, N_{i,k}(u) \, M_{j,k}(v)
+\f]
+
+that approximates the data in a weighted least-squares sense, subject to a
+smoothing condition or prescribed knot placement.
+
+### FITPACK routines
+
+| Routine | Input | Boundary |
+|---------|-------|----------|
+| `polar` (scattered) | Arbitrary \f$ (x_i, y_i, z_i) \f$ | General \f$ R(\theta) \f$ via function pointer |
+| `pogrid` (gridded) | Data on a polar grid \f$ (u_i, v_j) \f$ | Constant radius \f$ R \f$ |
+
+## Continuity at the Origin
+
+### The problem
+
+At \f$ u = 0 \f$ all values of the angle \f$ v \f$ map to the same physical
+point&mdash;the origin. A naive tensor-product spline in \f$ (u, v) \f$ would
+assign potentially different values to \f$ s(0, v) \f$ for different \f$ v \f$,
+producing a discontinuous or non-smooth surface at the centre of the disc.
+
+### Continuity orders
+
+To obtain a physically meaningful result the B-spline coefficients near
+\f$ u = 0 \f$ must satisfy algebraic constraints that enforce continuity to the
+desired order.
+
+**\f$ C^0 \f$ continuity.** The function value at the origin must be
+single-valued:
+
+\f[
+    s(0, v) = c_0 \quad \text{(constant for all } v\text{)}
+\f]
+
+This is achieved by constraining all coefficients associated with the first
+radial B-spline to be equal.
+
+**\f$ C^1 \f$ continuity.** In addition to \f$ C^0 \f$, the first radial
+derivative \f$ \partial s / \partial u \f$ at \f$ u = 0 \f$ must be consistent
+with a well-defined gradient vector in the \f$ (x, y) \f$ plane. Without this
+constraint, the directional derivative at the origin could depend on the
+approach angle in an unphysical way. The constraint takes the form of a linear
+relation among the coefficients of the first two radial B-splines.
+
+**\f$ C^2 \f$ continuity.** The second radial derivatives must likewise be
+consistent with a well-defined Hessian at the origin. This imposes additional
+linear relations on the first three rows of coefficients.
+
+### Implementation in FITPACK
+
+The `bc_continuity_origin` parameter selects the continuity order:
+
+| `bc_continuity_origin` | Continuity | Available for |
+|------------------------|------------|---------------|
+| 0 | \f$ C^0 \f$ | Scattered and gridded polar |
+| 1 | \f$ C^1 \f$ | Scattered and gridded polar |
+| 2 | \f$ C^2 \f$ (default) | Scattered polar only |
+
+The constraints are incorporated into the least-squares system during fitting,
+reducing the effective number of free coefficients near \f$ u = 0 \f$.
+
+## Boundary Conditions on the Disc Edge
+
+At the outer boundary \f$ u = 1 \f$ the following options are available:
+
+- **Extrapolation (default)**: No constraint is imposed at the boundary. The
+  spline is free to take any value at \f$ u = 1 \f$.
+- **Zero boundary**: The spline is forced to vanish on the boundary,
+  \f$ s(1, v) = 0 \f$ for all \f$ v \f$. This is useful for problems where
+  the function is known to be zero at the edge of the disc.
+
+For gridded polar fitting (`pogrid`), additional options control the behaviour
+at the origin:
+
+- **Prescribed origin value**: The value \f$ z_0 = s(0, v) \f$ can be supplied
+  explicitly. It can be enforced exactly (`z0_exact = .true.`) or treated as an
+  additional data point to be approximated.
+- **Zero gradient at the origin**: Setting `z0_zero_gradient = .true.` enforces
+  \f$ \nabla s(0, 0) = 0 \f$, creating a flat spot at the centre of the disc.
+
+## Spherical Coordinates
+
+### The spherical domain
+
+The unit sphere is parameterized by colatitude \f$ \theta \in [0, \pi] \f$ and
+longitude \f$ \phi \in [0, 2\pi] \f$. A scalar function on the sphere is
+represented as a tensor-product B-spline:
+
+\f[
+    s(\theta, \phi) = \sum_{i} \sum_{j} c_{ij} \, N_{i,k}(\theta) \, M_{j,k}(\phi)
+\f]
+
+### Periodicity in longitude
+
+Because the sphere is periodic in \f$ \phi \f$, the spline must satisfy
+
+\f[
+    s(\theta, 0) = s(\theta, 2\pi)
+\f]
+
+together with matching of all derivatives at \f$ \phi = 0 \f$ and
+\f$ \phi = 2\pi \f$. FITPACK enforces this by using a periodic knot vector and
+periodic B-spline basis in the \f$ \phi \f$ direction.
+
+### FITPACK routines
+
+| Routine | Input |
+|---------|-------|
+| `sphere` (scattered) | Arbitrary \f$ (\theta_i, \phi_i, r_i) \f$ on the sphere |
+| `spgrid` (gridded) | Data on a \f$ (\theta_i, \phi_j) \f$ grid |
+
+## The Pole Problem
+
+### Analogy with the origin problem
+
+The pole problem on the sphere is the direct analogue of the origin problem in
+polar coordinates. At the **north pole** (\f$ \theta = 0 \f$) and the
+**south pole** (\f$ \theta = \pi \f$), all longitudes \f$ \phi \f$ correspond
+to the same physical point. A naive tensor-product spline would allow different
+values of \f$ s(0, \phi) \f$ at different longitudes, producing a discontinuity
+at the pole.
+
+### Continuity conditions
+
+**\f$ C^0 \f$ continuity.** The function value at each pole must be
+single-valued:
+
+\f[
+    s(0, \phi) = c_{\mathrm{NP}} \quad \text{(constant for all } \phi\text{)},
+    \qquad
+    s(\pi, \phi) = c_{\mathrm{SP}} \quad \text{(constant for all } \phi\text{)}
+\f]
+
+**\f$ C^1 \f$ continuity.** Additionally, the angular derivatives at each pole
+must be consistent with a well-defined gradient on the sphere. Without this
+constraint the directional derivative would depend on the approach azimuth in a
+manner incompatible with the smoothness of the underlying surface.
+
+FITPACK enforces these conditions by imposing linear constraints on the B-spline
+coefficients near \f$ \theta = 0 \f$ and \f$ \theta = \pi \f$, reducing the
+number of free parameters at each pole.
+
+### Pole boundary conditions for gridded spheres
+
+For gridded spherical fitting (`spgrid`), the north and south poles have
+**independently configurable** boundary conditions:
+
+| Setting | Description |
+|---------|-------------|
+| `z0` | Prescribed function value at the pole |
+| `exact` | If `.true.`, the spline passes exactly through `z0` |
+| `continuity` | Continuity order at the pole (0 = \f$ C^0 \f$, 1 = \f$ C^1 \f$) |
+| `zero_gradient` | If `.true.`, enforce vanishing gradient at the pole |
+
+Each pole is configured independently via `BC_north_pole` and `BC_south_pole`,
+allowing asymmetric physical conditions (e.g., a known temperature at the north
+pole with a free south pole).
+
+## Practical Considerations
+
+- **Arbitrary boundary shape**: The scattered polar fitter (`polar`) accepts a
+  general boundary function \f$ R(\theta) \f$ through a function pointer,
+  allowing fitting on non-circular disc-shaped domains. The gridded polar fitter
+  (`pogrid`) requires a constant radius \f$ R \f$.
+
+- **Evaluation grid layout**: The gridded sphere evaluation method `eval_many`
+  returns an output array of shape \f$ (n_\phi, n_\theta) \f$, not paired
+  points. This matches the tensor-product structure and allows efficient grid
+  evaluation.
+
+- **Independent pole settings**: The gridded sphere supports independent north
+  and south pole boundary conditions, making it possible to impose different
+  physical constraints at each pole without affecting the other.
+
+- **Smoothing vs. interpolation**: All four routines (`polar`, `pogrid`,
+  `sphere`, `spgrid`) support both smoothing and interpolation modes. In
+  smoothing mode the continuity and boundary constraints are incorporated into
+  the penalized least-squares problem; in interpolation mode they appear as
+  hard constraints.
+
+@see @ref theory_surface_fitting
+@see @ref tutorial_polar
+@see @ref tutorial_sphere
+@see @ref book_reference
+
+> P. Dierckx, *Curve and Surface Fitting with Splines*,
+> Oxford University Press, 1993, Chapter 11.

--- a/doc/theory_surface_fitting.md
+++ b/doc/theory_surface_fitting.md
@@ -1,0 +1,270 @@
+# Surface Fitting Theory {#theory_surface_fitting}
+
+This page describes the mathematical foundations for bivariate spline fitting
+in FITPACK: extending the one-dimensional B-spline framework to approximate
+surfaces \f$ z = s(x, y) \f$ defined over a rectangular domain.
+
+## Tensor Product Splines
+
+A bivariate spline on the rectangular domain \f$ [a, b] \times [c, d] \f$ is
+defined as a tensor product of univariate B-splines:
+
+\f[
+    s(x, y) = \sum_{i=1}^{n_x - k_x - 1} \sum_{j=1}^{n_y - k_y - 1}
+    c_{ij} \, N_{i, k_x}(x) \, M_{j, k_y}(y)
+\f]
+
+where:
+
+- \f$ N_{i, k_x}(x) \f$ are B-splines of degree \f$ k_x \f$ on the knot
+  vector \f$ \mathbf{t}_x = (t_{x,1}, \ldots, t_{x, n_x}) \f$,
+- \f$ M_{j, k_y}(y) \f$ are B-splines of degree \f$ k_y \f$ on the knot
+  vector \f$ \mathbf{t}_y = (t_{y,1}, \ldots, t_{y, n_y}) \f$,
+- \f$ c_{ij} \f$ are the \f$ (n_x - k_x - 1)(n_y - k_y - 1) \f$ unknown
+  coefficients.
+
+The two knot vectors are independent: the number of knots and their placement
+can differ between the \f$ x \f$- and \f$ y \f$-directions. In FITPACK, both
+degrees default to \f$ k_x = k_y = 3 \f$ (bicubic).
+
+@see @ref theory_bsplines for a detailed treatment of univariate B-spline
+basis functions and the de Boor--Cox recurrence.
+
+## Scattered Data Fitting (surfit)
+
+Given \f$ m \f$ scattered observations \f$ (x_i, y_i, z_i) \f$ with weights
+\f$ w_i > 0 \f$, the goal is to find a tensor product spline \f$ s(x, y) \f$
+that approximates the data while remaining smooth.
+
+### The Observation Matrix
+
+Each data point \f$ (x_i, y_i) \f$ lies in a unique cell of the knot grid.
+For a given point, let \f$ \mu \f$ and \f$ \nu \f$ index the non-zero basis
+functions in \f$ x \f$ and \f$ y \f$, respectively. The observation matrix
+\f$ \mathbf{A} \f$ has entries:
+
+\f[
+    A_{i, \ell} = N_{\mu, k_x}(x_i) \, M_{\nu, k_y}(y_i),
+    \qquad \ell = (\mu - 1)(n_y - k_y - 1) + \nu
+\f]
+
+where the two-dimensional index pair \f$ (\mu, \nu) \f$ is mapped to a single
+column index \f$ \ell \f$. Each row of \f$ \mathbf{A} \f$ has at most
+\f$ (k_x + 1)(k_y + 1) \f$ non-zero entries, so the matrix is sparse.
+
+### Least-Squares Formulation
+
+The weighted least-squares problem is:
+
+\f[
+    \min_{\mathbf{c}} \sum_{i=1}^{m} w_i^2
+    \left( z_i - s(x_i, y_i) \right)^2
+\f]
+
+which in matrix form becomes \f$ \min \| \mathbf{W}(\mathbf{z} -
+\mathbf{A} \mathbf{c}) \|_2^2 \f$ with \f$ \mathbf{W} =
+\mathrm{diag}(w_1, \ldots, w_m) \f$.
+
+### Smoothing Formulation
+
+The smoothing spline minimizes a roughness functional subject to a data
+fidelity constraint:
+
+\f[
+    \min \iint \left[
+        \left( \frac{\partial^2 s}{\partial x^2} \right)^2
+        + 2 \left( \frac{\partial^2 s}{\partial x \, \partial y} \right)^2
+        + \left( \frac{\partial^2 s}{\partial y^2} \right)^2
+    \right] dx \, dy
+    \quad \text{subject to} \quad
+    \sum_{i=1}^{m} w_i^2 (z_i - s(x_i, y_i))^2 \leq S
+\f]
+
+where \f$ S \f$ is the smoothing factor. This is the bivariate analogue of
+the univariate smoothing spline problem.
+
+### Rank Deficiency
+
+When few data points fall within certain cells of the knot grid, the
+observation matrix \f$ \mathbf{A} \f$ can become rank deficient. This is more
+common in the bivariate case than in one dimension, because adding knots in
+both directions creates cells that may contain no data at all.
+
+FITPACK handles rank deficiency using Householder QR factorization with
+column pivoting. When the numerical rank \f$ r \f$ of the system is less than
+the number of unknowns, the algorithm computes a minimum-norm solution among
+all least-squares solutions.
+
+### Adaptive Knot Placement
+
+Starting from a minimal knot set, `surfit` iteratively refines the
+approximation:
+
+1. Fit the current knot configuration by solving the least-squares problem.
+2. If the residual sum of squares exceeds \f$ S \f$, identify regions with
+   large residuals.
+3. Insert new knots alternately in the \f$ x \f$- and \f$ y \f$-directions,
+   placing each knot where the local residual is largest.
+4. Repeat until \f$ \sum w_i^2 (z_i - s(x_i, y_i))^2 \leq S \f$ is
+   satisfied or a maximum knot count is reached.
+
+The alternating strategy ensures balanced refinement across both coordinate
+directions.
+
+@see Dierckx, Ch. 5, &sect;5.3 (pp. 85&ndash;98)
+
+## Gridded Data Fitting (regrid)
+
+When the data lie on a rectangular grid \f$ z_{ji} = z(y_j, x_i) \f$ with
+\f$ i = 1, \ldots, m_x \f$ and \f$ j = 1, \ldots, m_y \f$, the problem has
+a Kronecker product structure that can be exploited for dramatic computational
+savings.
+
+### Kronecker Product Structure
+
+On a grid, the observation matrix factors as a Kronecker product:
+
+\f[
+    \mathbf{A}_{\text{grid}} = \mathbf{B}_x \otimes \mathbf{B}_y
+\f]
+
+where \f$ \mathbf{B}_x \f$ is the \f$ m_x \times (n_x - k_x - 1) \f$ matrix
+of univariate B-spline values at the \f$ x \f$-grid points, and
+\f$ \mathbf{B}_y \f$ is the \f$ m_y \times (n_y - k_y - 1) \f$ matrix at
+the \f$ y \f$-grid points. The coefficient matrix conceptually satisfies:
+
+\f[
+    \mathbf{C} = \mathbf{B}_x^{-1} \, \mathbf{Z} \, (\mathbf{B}_y^T)^{-1}
+\f]
+
+where \f$ \mathbf{Z} \f$ is the \f$ m_x \times m_y \f$ matrix of observed
+values and \f$ \mathbf{C} \f$ holds the spline coefficients.
+
+### Computational Advantage
+
+The factored form means the normal equations can be solved dimension by
+dimension rather than simultaneously:
+
+| Approach | Complexity |
+|----------|-----------|
+| Scattered (`surfit`) | \f$ \mathcal{O}(m \cdot n_x \cdot n_y) \f$ |
+| Gridded (`regrid`) | \f$ \mathcal{O}(m_x \cdot m_y \cdot (k_x + k_y)) \f$ |
+
+For a 100 x 100 grid with 20 knots in each direction, the gridded approach is
+roughly two orders of magnitude faster. **Always prefer `fitpack_grid_surface`
+when data lie on a rectangular grid.**
+
+The smoothing framework (roughness minimization subject to a fidelity
+constraint) is identical to the scattered case; only the numerical solution
+method differs.
+
+@see Dierckx, Ch. 5, &sect;5.4 (pp. 98&ndash;103)
+
+## The Smoothing Norm
+
+For bivariate splines, the roughness measure used in the smoothing formulation
+is the thin-plate energy functional:
+
+\f[
+    R[s] = \iint \left[
+        \left( \frac{\partial^2 s}{\partial x^2} \right)^2
+        + 2 \left( \frac{\partial^2 s}{\partial x \, \partial y} \right)^2
+        + \left( \frac{\partial^2 s}{\partial y^2} \right)^2
+    \right] dx \, dy
+\f]
+
+This is the natural extension of \f$ \int (s'')^2 \, dx \f$ to two
+dimensions. It penalizes curvature equally in all directions and is invariant
+under rotation of the coordinate axes. The cross-derivative term
+\f$ (\partial^2 s / \partial x \, \partial y)^2 \f$ ensures that diagonal
+oscillations are penalized as well.
+
+For a tensor product spline, this integral can be expressed as a quadratic
+form in the coefficients \f$ c_{ij} \f$, involving integrals of products of
+B-spline second derivatives. FITPACK computes these integrals analytically
+using the knot vectors.
+
+## Choosing the Smoothing Factor
+
+The smoothing factor \f$ S \f$ controls the balance between fidelity and
+smoothness:
+
+- **\f$ S = 0 \f$**: Interpolation. The spline passes through every data
+  point (requires enough knots to satisfy the interpolation conditions).
+- **Small \f$ S \f$**: Close fit to the data, but the surface may exhibit
+  spurious oscillations.
+- **Large \f$ S \f$**: Very smooth surface that may underfit the data.
+
+### Practical Guidelines
+
+For **scattered data** with unit weights (\f$ w_i = 1 \f$), a reasonable
+starting point is:
+
+\f[
+    S \approx m
+\f]
+
+where \f$ m \f$ is the number of data points. This follows from the
+expectation that, for a good fit with normally distributed residuals, the sum
+of squared residuals should be \f$ \mathcal{O}(m) \f$.
+
+For **gridded data** with unit weights, the analogous rule is:
+
+\f[
+    S \approx m_x \cdot m_y
+\f]
+
+After fitting, inspect the mean squared error via the `mse()` method to assess
+fit quality. If the residual is too large, decrease \f$ S \f$; if the surface
+oscillates, increase \f$ S \f$.
+
+When data have non-unit weights, interpret \f$ S \f$ relative to the weighted
+residual. Setting \f$ w_i = 1 / \sigma_i \f$ (where \f$ \sigma_i \f$ is the
+measurement standard deviation) makes the residual sum an approximate
+\f$ \chi^2 \f$ statistic, and \f$ S \approx m \f$ corresponds to a
+reduced \f$ \chi^2 \f$ of unity.
+
+## Parametric Surfaces
+
+For surfaces embedded in \f$ \mathbb{R}^d \f$ and parameterized by
+\f$ (u, v) \f$, each coordinate component is represented as a separate
+bivariate spline sharing common knot vectors:
+
+\f[
+    s_l(u, v) = \sum_{i=1}^{n_u - k_u - 1} \sum_{j=1}^{n_v - k_v - 1}
+    c_{ij}^{(l)} \, N_{i, k_u}(u) \, M_{j, k_v}(v),
+    \qquad l = 1, \ldots, d
+\f]
+
+All \f$ d \f$ components share the same knot vectors
+\f$ \mathbf{t}_u \f$ and \f$ \mathbf{t}_v \f$, and the same spline degrees
+\f$ k_u \f$ and \f$ k_v \f$. Only the coefficient arrays
+\f$ c_{ij}^{(l)} \f$ differ between components.
+
+### Periodicity
+
+Either parameter direction (or both) may be periodic:
+
+- **Periodic in \f$ u \f$**: enforces
+  \f$ s_l^{(p)}(u_{\min}, v) = s_l^{(p)}(u_{\max}, v) \f$ for
+  \f$ p = 0, 1, \ldots, k_u - 1 \f$.
+- **Periodic in \f$ v \f$**: enforces
+  \f$ s_l^{(p)}(u, v_{\min}) = s_l^{(p)}(u, v_{\max}) \f$ for
+  \f$ p = 0, 1, \ldots, k_v - 1 \f$.
+
+Periodicity is useful for closed surfaces such as cylinders and tori. The
+FITPACK routine `parsur` handles the general case.
+
+@see Dierckx, Ch. 10, &sect;10.2 (pp. 241&ndash;254)
+
+## Summary
+
+| Problem | FITPACK Type | Core Routine | Key Advantage |
+|---------|-------------|-------------|---------------|
+| Scattered \f$ (x_i, y_i, z_i) \f$ | `fitpack_surface` | `surfit` | Handles arbitrary point distributions |
+| Gridded \f$ z(y_j, x_i) \f$ | `fitpack_grid_surface` | `regrid` | Kronecker structure, much faster |
+| Parametric \f$ \mathbf{r}(u, v) \f$ | `fitpack_parametric_surface` | `parsur` | Surfaces in \f$ \mathbb{R}^d \f$ |
+
+@see @ref tutorial_surface for code examples and practical usage
+@see @ref tutorial_polar for polar and spherical domain fitting
+@see @ref book_reference for a complete mapping of routines to book chapters

--- a/examples/example_convex_curve.f90
+++ b/examples/example_convex_curve.f90
@@ -1,0 +1,87 @@
+! Example: Convexity-constrained curve fitting with fitpack_convex_curve
+!
+! Fits a concave spline to data inspired by moisture-content measurements:
+! monotonically increasing, concave (s''(x) <= 0) function.
+program example_convex_curve
+    use fitpack, only: fitpack_convex_curve, FP_REAL, FP_FLAG, &
+                       FITPACK_SUCCESS, FITPACK_MESSAGE, zero, one
+    implicit none
+
+    integer, parameter :: m = 16
+    type(fitpack_convex_curve) :: curve
+    integer(FP_FLAG) :: ierr
+    real(FP_REAL) :: x(m), y(m), w(m), v(m), s2(m)
+    real(FP_REAL) :: smoothing_values(3)
+    real(FP_REAL) :: y_eval, dx
+    integer :: i, is
+
+    ! Data: moisture content vs depth (inspired by Dierckx Ch. 7)
+    ! Concave, increasing trend
+    x = [0.1_FP_REAL, 0.3_FP_REAL, 0.5_FP_REAL, 0.7_FP_REAL, 0.9_FP_REAL, &
+         1.25_FP_REAL, 1.75_FP_REAL, 2.25_FP_REAL, 2.75_FP_REAL, 3.5_FP_REAL, &
+         4.5_FP_REAL, 5.5_FP_REAL, 6.5_FP_REAL, 7.5_FP_REAL, 8.5_FP_REAL, 9.5_FP_REAL]
+
+    y = [0.124_FP_REAL, 0.234_FP_REAL, 0.256_FP_REAL, 0.277_FP_REAL, 0.278_FP_REAL, &
+         0.291_FP_REAL, 0.308_FP_REAL, 0.311_FP_REAL, 0.315_FP_REAL, 0.322_FP_REAL, &
+         0.317_FP_REAL, 0.326_FP_REAL, 0.323_FP_REAL, 0.321_FP_REAL, 0.322_FP_REAL, &
+         0.328_FP_REAL]
+
+    ! Weights: emphasize endpoints
+    w = one
+    w(1) = 10.0_FP_REAL
+    w(2) = 3.0_FP_REAL
+    w(m) = 10.0_FP_REAL
+
+    ! Concavity constraint: v(i) = 1 means concave (s''(x) <= 0)
+    ! Use v = -1 for convex (s''(x) >= 0), v = 0 for unconstrained
+    v = one
+
+    ! Load data and set convexity flags
+    call curve%new_points(x, y, w)
+    ierr = curve%set_convexity(v)
+    if (.not. FITPACK_SUCCESS(ierr)) then
+        print '(a,a)', 'set_convexity failed: ', FITPACK_MESSAGE(ierr)
+        error stop
+    end if
+
+    ! Fit with decreasing smoothing
+    smoothing_values = [0.2_FP_REAL, 0.04_FP_REAL, 0.0002_FP_REAL]
+
+    print '(a)', '=== Concavity-constrained fits ==='
+    print '(a)', '     S       knots   residual   max s''''(x)'
+
+    do is = 1, 3
+        ierr = curve%fit(smoothing=smoothing_values(is), keep_knots=(is > 1))
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,es8.1,a,a)', 'Fit at s=', smoothing_values(is), ' failed: ', FITPACK_MESSAGE(ierr)
+            cycle
+        end if
+
+        ! Evaluate second derivative at data points
+        s2 = curve%dfdx(x, order=2, ierr=ierr)
+
+        print '(es10.1, i8, es12.3, es12.3)', &
+            smoothing_values(is), curve%knots, curve%mse(), maxval(s2)
+    end do
+
+    ! Evaluate the tightest fit at several points
+    print '(/,a)', '=== Evaluation (tightest fit) ==='
+    print '(a)', '     x       y_data    s(x)      s''''(x)'
+    do i = 1, m
+        y_eval = curve%eval(x(i), ierr)
+        print '(f8.3, f10.4, f10.4, es12.3)', x(i), y(i), y_eval, s2(i)
+    end do
+
+    ! Evaluate at intermediate points
+    print '(/,a)', '=== Interpolated values ==='
+    print '(a)', '     x        s(x)      s''(x)'
+    do i = 1, 10
+        dx = i * one
+        y_eval = curve%eval(dx, ierr)
+        print '(f8.3, f10.5, es12.3)', dx, y_eval, curve%dfdx(dx, order=2, ierr=ierr)
+    end do
+
+    call curve%destroy()
+    print '(/,a)', 'Done.'
+
+end program example_convex_curve

--- a/examples/example_curve.f90
+++ b/examples/example_curve.f90
@@ -1,0 +1,94 @@
+! Example: Univariate spline curve fitting with fitpack_curve
+!
+! Demonstrates smoothing, interpolation, evaluation, derivatives,
+! integration, and root-finding on a noisy sine wave.
+program example_curve
+    use fitpack, only: fitpack_curve, FP_REAL, FP_FLAG, FITPACK_SUCCESS, FITPACK_MESSAGE, &
+                       zero, one, half, pi
+    implicit none
+
+    integer, parameter :: m = 50
+    real(FP_REAL), parameter :: two = 2.0_FP_REAL
+    real(FP_REAL), parameter :: pi2 = two * pi
+
+    real(FP_REAL) :: x(m), y(m), w(m), dx, noise
+    type(fitpack_curve) :: curve
+    integer(FP_FLAG) :: ierr
+    real(FP_REAL) :: y_eval, dydx, area, exact_area
+    real(FP_REAL), allocatable :: roots(:)
+    integer :: i
+
+    ! Generate noisy sine data on [0, 2*pi]
+    dx = pi2 / (m - 1)
+    do i = 1, m
+        x(i) = (i - 1) * dx
+        ! Simple deterministic "noise" for reproducibility
+        noise = 0.05_FP_REAL * sin(17.0_FP_REAL * x(i)) * cos(31.0_FP_REAL * x(i))
+        y(i) = sin(x(i)) + noise
+    end do
+
+    ! Unit weights
+    w = one
+
+    ! ---- Smoothing spline (automatic knots) ----
+    print '(a)', '=== Smoothing spline ==='
+    ierr = curve%new_fit(x, y, w=w, smoothing=real(m, FP_REAL))
+    if (.not. FITPACK_SUCCESS(ierr)) then
+        print '(a,a)', 'Fit failed: ', FITPACK_MESSAGE(ierr)
+        error stop
+    end if
+    print '(a,i0)',    '  Knots:    ', curve%knots
+    print '(a,es10.3)', '  Residual: ', curve%mse()
+
+    ! Evaluate at a single point
+    y_eval = curve%eval(pi, ierr)
+    print '(a,f8.5,a,f8.5)', '  s(pi) = ', y_eval, '  (exact sin(pi) = ', sin(pi), ')'
+
+    ! ---- Interpolation ----
+    print '(/,a)', '=== Interpolating spline ==='
+    ierr = curve%new_fit(x, y, smoothing=zero)
+    if (.not. FITPACK_SUCCESS(ierr)) then
+        print '(a,a)', 'Interpolation failed: ', FITPACK_MESSAGE(ierr)
+        error stop
+    end if
+    print '(a,i0)',    '  Knots:    ', curve%knots
+    print '(a,es10.3)', '  Residual: ', curve%mse()
+
+    ! ---- Derivatives ----
+    print '(/,a)', '=== Derivatives at x = pi/4 ==='
+    y_eval = curve%eval(pi / 4, ierr)
+    dydx   = curve%dfdx(pi / 4, order=1, ierr=ierr)
+    print '(a,f10.6)', '  s(pi/4)  = ', y_eval
+    print '(a,f10.6)', '  s''(pi/4) = ', dydx
+
+    ! ---- Integration ----
+    print '(/,a)', '=== Integration ==='
+    area = curve%integral(zero, pi)
+    exact_area = two  ! integral of sin(x) from 0 to pi
+    print '(a,f10.6)', '  integral [0, pi]       = ', area
+    print '(a,f10.6)', '  exact (noise-free)     = ', exact_area
+
+    ! ---- Zeros ----
+    print '(/,a)', '=== Zeros ==='
+    roots = curve%zeros(ierr)
+    if (FITPACK_SUCCESS(ierr)) then
+        print '(a,i0)', '  Number of zeros: ', size(roots)
+        do i = 1, size(roots)
+            print '(a,i0,a,f10.6)', '  root(', i, ') = ', roots(i)
+        end do
+    end if
+
+    ! ---- Smoothing parameter sweep ----
+    print '(/,a)', '=== Smoothing sweep ==='
+    print '(a)', '     S       knots   residual'
+    do i = 1, 5
+        ierr = curve%new_fit(x, y, smoothing=10.0_FP_REAL**(3 - i))
+        if (FITPACK_SUCCESS(ierr)) then
+            print '(es10.1,i8,es12.3)', curve%smoothing, curve%knots, curve%mse()
+        end if
+    end do
+
+    call curve%destroy()
+    print '(/,a)', 'Done.'
+
+end program example_curve

--- a/examples/example_grid_surface.f90
+++ b/examples/example_grid_surface.f90
@@ -1,0 +1,161 @@
+! Example: Grid surface fitting and parametric surfaces
+!
+! Demonstrates fitpack_grid_surface on a rectangular grid (peaks-like function)
+! and fitpack_parametric_surface for a torus.
+program example_grid_surface
+    use fitpack, only: fitpack_grid_surface, fitpack_parametric_surface, fitpack_curve, &
+                       FP_REAL, FP_FLAG, FITPACK_SUCCESS, FITPACK_MESSAGE, zero, one, half, pi
+    implicit none
+
+    real(FP_REAL), parameter :: two = 2.0_FP_REAL
+    real(FP_REAL), parameter :: pi2 = two * pi
+
+    ! Part 1: Grid surface
+    call demo_grid_surface()
+
+    ! Part 2: Parametric surface
+    call demo_parametric_surface()
+
+    print '(/,a)', 'Done.'
+
+contains
+
+    subroutine demo_grid_surface()
+        integer, parameter :: nx = 20, ny = 25
+        real(FP_REAL) :: xg(nx), yg(ny), zg(ny, nx)
+        type(fitpack_grid_surface) :: gsurf
+        type(fitpack_curve) :: cross
+        integer(FP_FLAG) :: ierr
+        real(FP_REAL) :: z_val, vol
+        real(FP_REAL) :: x_test(3), y_test(3)
+        integer :: i, j
+
+        print '(a)', '=== Grid surface: smooth test function ==='
+
+        ! Create grid: x in [-2,2], y in [-2,2]
+        do i = 1, nx
+            xg(i) = -two + 4.0_FP_REAL * (i - 1) / (nx - 1)
+        end do
+        do j = 1, ny
+            yg(j) = -two + 4.0_FP_REAL * (j - 1) / (ny - 1)
+        end do
+
+        ! f(x,y) = exp(-(x^2+y^2)/2) * cos(x) * sin(y)
+        do i = 1, nx
+            do j = 1, ny
+                zg(j, i) = exp(-half * (xg(i)**2 + yg(j)**2)) * cos(xg(i)) * sin(yg(j))
+            end do
+        end do
+
+        ! Smoothing fit
+        ierr = gsurf%new_fit(xg, yg, zg, smoothing=real(nx * ny, FP_REAL))
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Fit failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+        print '(a,i0,a,i0)', '  Knots: ', gsurf%knots(1), ' x ', gsurf%knots(2)
+        print '(a,es10.3)',   '  Residual: ', gsurf%mse()
+
+        ! Interpolation
+        ierr = gsurf%new_fit(xg, yg, zg, smoothing=zero)
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Interpolation failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+        print '(a,i0,a,i0)', '  Interp knots: ', gsurf%knots(1), ' x ', gsurf%knots(2)
+
+        ! Evaluate at test points
+        print '(/,a)', '  Point evaluation:'
+        print '(a)', '     x       y       s(x,y)'
+        x_test = [zero, one, -one]
+        y_test = [zero, one, -one]
+        do i = 1, 3
+            z_val = gsurf%eval(x_test(i), y_test(i), ierr)
+            print '(2f8.3, f12.6)', x_test(i), y_test(i), z_val
+        end do
+
+        ! Integration
+        vol = gsurf%integral([-two, -two], [two, two])
+        print '(/,a,f12.6)', '  Integral [-2,2]x[-2,2] = ', vol
+
+        ! Cross-section at y = 0
+        print '(/,a)', '  Cross-section at y = 0:'
+        cross = gsurf%cross_section(zero, .true., ierr)
+        if (FITPACK_SUCCESS(ierr)) then
+            print '(a,i0)', '  Profile knots: ', cross%knots
+            do i = 1, 5
+                z_val = cross%eval(-two + (i - 1) * one, ierr)
+                print '(a,f6.2,a,f12.6)', '    f(', -two + (i - 1) * one, ', 0) = ', z_val
+            end do
+        end if
+
+        ! Derivative spline
+        block
+            type(fitpack_grid_surface) :: dsurf
+            dsurf = gsurf%derivative_spline(1, 0, ierr)
+            if (FITPACK_SUCCESS(ierr)) then
+                z_val = dsurf%eval(zero, zero, ierr)
+                print '(/,a,f12.6)', '  ds/dx at (0,0) = ', z_val
+            end if
+            call dsurf%destroy()
+        end block
+
+        call cross%destroy()
+        call gsurf%destroy()
+    end subroutine
+
+    subroutine demo_parametric_surface()
+        integer, parameter :: nu = 20, nv = 30, idim = 3
+        real(FP_REAL) :: u(nu), v(nv), z(nv, nu, idim)
+        real(FP_REAL) :: du, dv, cu, su, cv, sv
+        real(FP_REAL), parameter :: R = 2.0_FP_REAL, r_tube = 0.5_FP_REAL
+        type(fitpack_parametric_surface) :: psurf
+        integer(FP_FLAG) :: ierr
+        real(FP_REAL) :: pt(idim)
+        integer :: i, j
+
+        print '(/,a)', '=== Parametric surface: torus ==='
+
+        ! Create parameter grid
+        du = pi2 / nu
+        dv = pi2 / nv
+        do i = 1, nu
+            u(i) = (i - 1) * du
+        end do
+        do j = 1, nv
+            v(j) = (j - 1) * dv
+        end do
+
+        ! Torus: x=(R+r*cos(v))*cos(u), y=(R+r*cos(v))*sin(u), z=r*sin(v)
+        do i = 1, nu
+            cu = cos(u(i)); su = sin(u(i))
+            do j = 1, nv
+                cv = cos(v(j)); sv = sin(v(j))
+                z(j, i, 1) = (R + r_tube * cv) * cu
+                z(j, i, 2) = (R + r_tube * cv) * su
+                z(j, i, 3) = r_tube * sv
+            end do
+        end do
+
+        ! Fit with periodicity in both directions
+        ierr = psurf%new_fit(u, v, z, smoothing=zero, periodic_BC=[.true., .true.])
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Fit failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+        print '(a,i0,a,i0)', '  Knots: ', psurf%knots(1), ' x ', psurf%knots(2)
+        print '(a,es10.3)',   '  Residual: ', psurf%mse()
+
+        ! Evaluate at a few points
+        print '(/,a)', '     u       v       x         y         z'
+        pt = psurf%eval(zero, zero, ierr)
+        print '(2f8.3, 3f10.4)', zero, zero, pt
+        pt = psurf%eval(pi, zero, ierr)
+        print '(2f8.3, 3f10.4)', pi, zero, pt
+        pt = psurf%eval(zero, pi, ierr)
+        print '(2f8.3, 3f10.4)', zero, pi, pt
+
+        call psurf%destroy()
+    end subroutine
+
+end program example_grid_surface

--- a/examples/example_parametric_curves.f90
+++ b/examples/example_parametric_curves.f90
@@ -1,0 +1,168 @@
+! Example: Parametric, closed, and constrained curves
+!
+! Demonstrates fitpack_parametric_curve (Lissajous figure),
+! fitpack_closed_curve (ellipse), and fitpack_constrained_curve
+! (curve with prescribed endpoint derivatives).
+program example_parametric_curves
+    use fitpack, only: fitpack_parametric_curve, fitpack_closed_curve, &
+                       fitpack_constrained_curve, FP_REAL, FP_FLAG, &
+                       FITPACK_SUCCESS, FITPACK_MESSAGE, zero, one, half, pi
+    implicit none
+
+    real(FP_REAL), parameter :: two = 2.0_FP_REAL
+    real(FP_REAL), parameter :: three = 3.0_FP_REAL
+    real(FP_REAL), parameter :: pi2 = two * pi
+
+    ! ---- Part 1: Parametric curve (Lissajous figure) ----
+    call demo_parametric()
+
+    ! ---- Part 2: Closed curve (ellipse) ----
+    call demo_closed()
+
+    ! ---- Part 3: Constrained curve ----
+    call demo_constrained()
+
+    print '(/,a)', 'Done.'
+
+contains
+
+    subroutine demo_parametric()
+        integer, parameter :: m = 60
+        real(FP_REAL) :: pts(2, m), u(m), du, eval_u(6)
+        real(FP_REAL) :: y(2), dy(2)
+        type(fitpack_parametric_curve) :: curve
+        integer(FP_FLAG) :: ierr
+        integer :: i
+
+        print '(a)', '=== Parametric curve: Lissajous figure ==='
+
+        ! Generate Lissajous: x = sin(3t), y = sin(2t)
+        du = pi2 / (m - 1)
+        do i = 1, m
+            u(i) = (i - 1) * du
+            pts(1, i) = sin(three * u(i))
+            pts(2, i) = sin(two * u(i))
+        end do
+
+        ! Fit with automatic parameter values
+        ierr = curve%new_fit(pts, smoothing=zero)
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Fit failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+        print '(a,i0)', '  Dimensions: ', curve%idim
+        print '(a,i0)', '  Knots:      ', curve%knots
+
+        ! Evaluate at a few parameter values
+        eval_u = [zero, one, two, three, pi2 - 0.01_FP_REAL, pi2]
+        print '(/,a)', '     u       x(u)      y(u)'
+        do i = 1, 6
+            y = curve%eval_one(eval_u(i), ierr)
+            print '(f8.3, 2f10.5)', eval_u(i), y
+        end do
+
+        ! Derivative at u = 0
+        dy = curve%dfdx(zero, order=1, ierr=ierr)
+        print '(/,a,2f10.5)', '  dx/du, dy/du at u=0: ', dy
+
+        call curve%destroy()
+    end subroutine
+
+    subroutine demo_closed()
+        integer, parameter :: m = 40
+        real(FP_REAL) :: pts(2, m), du, y(2)
+        type(fitpack_closed_curve) :: curve
+        integer(FP_FLAG) :: ierr
+        integer :: i
+
+        print '(/,a)', '=== Closed curve: Ellipse ==='
+
+        ! Generate ellipse: x = 2*cos(t), y = sin(t)
+        du = pi2 / m
+        do i = 1, m
+            pts(1, i) = two * cos((i - 1) * du)
+            pts(2, i) = sin((i - 1) * du)
+        end do
+
+        ! Fit closed curve
+        ierr = curve%new_fit(pts, smoothing=zero)
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Fit failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+        print '(a,i0)', '  Knots: ', curve%knots
+
+        ! Check closure: eval at start and end of parameter range
+        y = curve%eval_one(curve%ubegin, ierr)
+        print '(a,2f10.5)', '  s(u_begin) = ', y
+        y = curve%eval_one(curve%uend, ierr)
+        print '(a,2f10.5)', '  s(u_end)   = ', y
+
+        call curve%destroy()
+    end subroutine
+
+    subroutine demo_constrained()
+        integer, parameter :: m = 25
+        integer, parameter :: idim = 2
+        real(FP_REAL) :: pts(idim, m), u(m), du
+        real(FP_REAL) :: ddx_begin(idim, 0:1), ddx_end(idim, 0:1)
+        real(FP_REAL) :: y_begin(idim), y_end(idim)
+        real(FP_REAL), allocatable :: yall(:,:)
+        type(fitpack_constrained_curve) :: curve
+        integer(FP_FLAG) :: ierr
+        integer :: i
+
+        print '(/,a)', '=== Constrained curve: prescribed endpoints ==='
+
+        ! Generate a 2D curve
+        du = pi / (m - 1)
+        do i = 1, m
+            u(i) = (i - 1) * du
+            pts(1, i) = u(i) * cos(u(i))
+            pts(2, i) = u(i) * sin(u(i))
+        end do
+
+        ! Prescribe position and 1st derivative at both endpoints
+        ! At u=0: position = (0, 0), derivative = (1, 0)
+        ddx_begin(:, 0) = [zero, zero]
+        ddx_begin(:, 1) = [one, zero]
+
+        ! At u=pi: position = (-pi, 0), derivative = (-1, -pi)
+        ddx_end(:, 0) = [-pi, zero]
+        ddx_end(:, 1) = [-one, -pi]
+
+        ! Fit without constraints first
+        ierr = curve%new_fit(pts, u=u, smoothing=real(m, FP_REAL))
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Unconstrained fit failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+
+        y_begin = curve%eval_one(curve%ubegin, ierr)
+        y_end   = curve%eval_one(curve%uend, ierr)
+        print '(a)',        '  Unconstrained:'
+        print '(a,2f10.5)', '    s(0)  = ', y_begin
+        print '(a,2f10.5)', '    s(pi) = ', y_end
+
+        ! Apply endpoint constraints and re-fit
+        call curve%set_constraints(ddx_begin, ddx_end, ierr)
+        ierr = curve%fit(smoothing=real(m, FP_REAL))
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Constrained fit failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+
+        ! Check: position and derivatives at endpoints
+        yall = curve%dfdx_all(curve%ubegin, ierr)
+        print '(/,a)',      '  Constrained:'
+        print '(a,2f10.5)', '    s(0)    = ', yall(:, 1)
+        print '(a,2f10.5)', '    s''(0)   = ', yall(:, 2)
+
+        yall = curve%dfdx_all(curve%uend, ierr)
+        print '(a,2f10.5)', '    s(pi)   = ', yall(:, 1)
+        print '(a,2f10.5)', '    s''(pi)  = ', yall(:, 2)
+
+        call curve%destroy()
+    end subroutine
+
+end program example_parametric_curves

--- a/examples/example_periodic_curve.f90
+++ b/examples/example_periodic_curve.f90
@@ -1,0 +1,102 @@
+! Example: Periodic spline fitting with fitpack_periodic_curve
+!
+! Fits a periodic spline to f(x) = cos(x) + sin(2x) on [0, 2*pi],
+! demonstrating that derivatives match across the period boundary.
+program example_periodic_curve
+    use fitpack, only: fitpack_periodic_curve, FP_REAL, FP_FLAG, &
+                       FITPACK_SUCCESS, FITPACK_MESSAGE, zero, one, half, pi
+    implicit none
+
+    integer, parameter :: m = 200
+    real(FP_REAL), parameter :: two = 2.0_FP_REAL
+    real(FP_REAL), parameter :: pi2 = two * pi
+
+    type(fitpack_periodic_curve) :: curve
+    integer(FP_FLAG) :: ierr
+    real(FP_REAL) :: x(m), y(m)
+    real(FP_REAL) :: y_left, y_right, dy_left, dy_right, area, exact_area, dx_eval
+    integer :: i
+
+    ! Generate periodic function data on [0, 2*pi]
+    ! Include endpoint: percur requires full period coverage
+    do i = 1, m
+        x(i) = (i - 1) * pi2 / (m - 1)
+        y(i) = fun(x(i))
+    end do
+
+    ! ---- Smoothing fit ----
+    print '(a)', '=== Smoothing periodic fit ==='
+    ierr = curve%new_fit(x, y, smoothing=one)
+    if (.not. FITPACK_SUCCESS(ierr)) then
+        print '(a,a)', '  Fit failed: ', FITPACK_MESSAGE(ierr)
+    else
+        print '(a,i0)',    '  Knots:    ', curve%knots
+        print '(a,es10.3)', '  Residual: ', curve%mse()
+    end if
+
+    ! Evaluate at a few points and compare
+    print '(/,a)', '=== Evaluation ==='
+    print '(a)', '     x         s(x)        exact'
+    do i = 0, 8
+        dx_eval = i * pi / 4
+        print '(f8.4,f12.6,f12.6)', dx_eval, curve%eval(dx_eval, ierr), fun(dx_eval)
+    end do
+
+    ! Check periodicity: values and derivatives at endpoints
+    y_left   = curve%eval(x(1), ierr)
+    y_right  = curve%eval(x(m), ierr)
+    dy_left  = curve%dfdx(x(1), order=1, ierr=ierr)
+    dy_right = curve%dfdx(x(m), order=1, ierr=ierr)
+
+    print '(/,a)', '=== Periodicity check ==='
+    print '(a,f12.8)', '  s(x_1)    = ', y_left
+    print '(a,f12.8)', '  s(x_m)    = ', y_right
+    print '(a,f12.8)', '  s''(x_1)   = ', dy_left
+    print '(a,f12.8)', '  s''(x_m)   = ', dy_right
+
+    ! ---- Integration ----
+    print '(/,a)', '=== Integration ==='
+    area = curve%integral(half * pi, two * pi)
+    ! Exact: integral of cos(x)+sin(2x) from pi/2 to 2*pi
+    ! = [sin(x) - cos(2x)/2] from pi/2 to 2*pi
+    exact_area = (sin(two * pi) - half * cos(4.0_FP_REAL * pi)) &
+               - (sin(half * pi) - half * cos(pi))
+    print '(a,f12.8)', '  integral [pi/2, 2*pi] = ', area
+    print '(a,f12.8)', '  exact                 = ', exact_area
+
+    ! ---- Interpolating fit ----
+    print '(/,a)', '=== Interpolating periodic spline ==='
+    ierr = curve%interpolate()
+    if (.not. FITPACK_SUCCESS(ierr)) then
+        print '(a,a)', '  Interpolation failed: ', FITPACK_MESSAGE(ierr)
+    else
+        print '(a,i0)',    '  Knots:    ', curve%knots
+        print '(a,es10.3)', '  Residual: ', curve%mse()
+
+        y_left  = curve%eval(x(1), ierr)
+        y_right = curve%eval(x(m), ierr)
+        print '(a,f12.8)', '  s(0)    = ', y_left
+        print '(a,f12.8)', '  s(x_m)  = ', y_right
+    end if
+
+    ! ---- Smoothing sweep ----
+    print '(/,a)', '=== Smoothing sweep ==='
+    print '(a)', '     S       knots   residual'
+    do i = 1, 4
+        ierr = curve%new_fit(x, y, smoothing=10.0_FP_REAL**(2 - i))
+        if (FITPACK_SUCCESS(ierr)) then
+            print '(es10.1,i8,es12.3)', curve%smoothing, curve%knots, curve%mse()
+        end if
+    end do
+
+    call curve%destroy()
+    print '(/,a)', 'Done.'
+
+contains
+
+    elemental real(FP_REAL) function fun(x) result(f)
+        real(FP_REAL), intent(in) :: x
+        f = cos(x) + sin(two * x)
+    end function
+
+end program example_periodic_curve

--- a/examples/example_polar.f90
+++ b/examples/example_polar.f90
@@ -1,0 +1,147 @@
+! Example: Polar domain fitting with fitpack_polar and fitpack_grid_polar
+!
+! Fits splines on disc-shaped domains: scattered data on a unit disk
+! and gridded data on a polar grid.
+program example_polar
+    use fitpack, only: fitpack_polar, fitpack_grid_polar, &
+                       FP_REAL, FP_FLAG, FITPACK_SUCCESS, FITPACK_MESSAGE, &
+                       zero, one, half, pi
+    implicit none
+
+    real(FP_REAL), parameter :: two = 2.0_FP_REAL
+    real(FP_REAL), parameter :: pi2 = two * pi
+
+    ! Part 1: Scattered polar
+    call demo_scattered_polar()
+
+    ! Part 2: Gridded polar
+    call demo_gridded_polar()
+
+    print '(/,a)', 'Done.'
+
+contains
+
+    ! Boundary function: unit disk (radius = 1 for all angles)
+    pure real(FP_REAL) function unit_disk(theta)
+        real(FP_REAL), intent(in) :: theta
+        unit_disk = one
+    end function
+
+    ! Test function on the disk
+    elemental real(FP_REAL) function test_polar(x, y) result(f)
+        real(FP_REAL), intent(in) :: x, y
+        f = (x**2 + y**2) / ((x + y)**2 + half)
+    end function
+
+    subroutine demo_scattered_polar()
+        integer, parameter :: m = 100
+        real(FP_REAL) :: x(m), y(m), z(m), w(m)
+        real(FP_REAL) :: r, theta
+        type(fitpack_polar) :: polar
+        integer(FP_FLAG) :: ierr
+        real(FP_REAL) :: z_val, exact
+        real(FP_REAL) :: x_test(5), y_test(5)
+        integer :: i
+
+        print '(a)', '=== Scattered polar: unit disk ==='
+
+        ! Generate scattered points inside the unit disk
+        do i = 1, m
+            ! Simple quasi-random on disk via rejection-free polar coords
+            r = sqrt(mod(i * 0.6180339887_FP_REAL, one))
+            theta = pi2 * mod(i * 0.3247179572_FP_REAL, one) - pi
+            x(i) = r * cos(theta)
+            y(i) = r * sin(theta)
+            z(i) = test_polar(x(i), y(i))
+        end do
+
+        ! Unit weights
+        w = one
+
+        ! Smoothing fit
+        ierr = polar%new_fit(x, y, z, unit_disk, w, smoothing=real(m, FP_REAL))
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Fit failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+        print '(a,i0,a,i0)', '  Knots: ', polar%knots(1), ' x ', polar%knots(2)
+        print '(a,es10.3)',   '  Residual: ', polar%mse()
+
+        ! Evaluate at test points
+        print '(/,a)', '  Point evaluation:'
+        print '(a)', '     x       y       s(x,y)    exact'
+        x_test = [zero, half, -half, 0.3_FP_REAL, -0.2_FP_REAL]
+        y_test = [zero, zero,  half, 0.4_FP_REAL, -0.5_FP_REAL]
+        do i = 1, 5
+            z_val = polar%eval(x_test(i), y_test(i), ierr)
+            exact = test_polar(x_test(i), y_test(i))
+            print '(2f8.3, 2f12.6)', x_test(i), y_test(i), z_val, exact
+        end do
+
+        ! Tighter fit
+        ierr = polar%fit(smoothing=10.0_FP_REAL)
+        if (FITPACK_SUCCESS(ierr)) then
+            print '(/,a,i0,a,i0)', '  Tighter fit knots: ', polar%knots(1), ' x ', polar%knots(2)
+            print '(a,es10.3)', '  Residual: ', polar%mse()
+        end if
+
+        call polar%destroy()
+    end subroutine
+
+    subroutine demo_gridded_polar()
+        integer, parameter :: nu = 10, nv = 20
+        real(FP_REAL) :: u(nu), v(nv), zg(nv, nu)
+        real(FP_REAL) :: du, dv, x_pt, y_pt, z0, z_val
+        type(fitpack_grid_polar) :: gpol
+        integer(FP_FLAG) :: ierr
+        integer :: i, j
+
+        print '(/,a)', '=== Gridded polar: unit disk ==='
+
+        ! Create polar grid: u in (0,1], v in [-pi, pi)
+        du = one / nu
+        dv = pi2 / nv
+        do i = 1, nu
+            u(i) = i * du
+        end do
+        do j = 1, nv
+            v(j) = -pi + (j - 1) * dv
+        end do
+
+        ! Evaluate test function on grid
+        do i = 1, nu
+            do j = 1, nv
+                x_pt = u(i) * cos(v(j))
+                y_pt = u(i) * sin(v(j))
+                zg(j, i) = test_polar(x_pt, y_pt)
+            end do
+        end do
+
+        ! Value at origin
+        z0 = test_polar(zero, zero)
+
+        ! Fit with prescribed origin value
+        ierr = gpol%new_fit(u, v, one, zg, z0=z0)
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Fit failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+        print '(a,i0,a,i0)', '  Knots: ', gpol%knots(1), ' x ', gpol%knots(2)
+        print '(a,es10.3)',   '  Residual: ', gpol%mse()
+
+        ! Set origin BC: exact value, differentiable
+        call gpol%set_origin_BC(z0=z0, exact=.true., differentiable=.true.)
+        ierr = gpol%fit(smoothing=real(nu * nv, FP_REAL))
+        if (FITPACK_SUCCESS(ierr)) then
+            print '(a,es10.3)', '  Residual (with origin BC): ', gpol%mse()
+        end if
+
+        ! Evaluate at origin (u=0 maps to any v)
+        z_val = gpol%eval(zero, zero, ierr)
+        print '(/,a,f12.6)', '  s(origin) = ', z_val
+        print '(a,f12.6)',   '  exact     = ', z0
+
+        call gpol%destroy()
+    end subroutine
+
+end program example_polar

--- a/examples/example_sphere.f90
+++ b/examples/example_sphere.f90
@@ -1,0 +1,165 @@
+! Example: Spherical domain fitting with fitpack_sphere and fitpack_grid_sphere
+!
+! Fits splines on the unit sphere: scattered data and latitude-longitude grids,
+! demonstrating pole boundary conditions.
+program example_sphere
+    use fitpack, only: fitpack_sphere, fitpack_grid_sphere, &
+                       FP_REAL, FP_FLAG, FITPACK_SUCCESS, FITPACK_MESSAGE, &
+                       zero, one, half, pi
+    implicit none
+
+    real(FP_REAL), parameter :: two = 2.0_FP_REAL
+    real(FP_REAL), parameter :: pi2 = two * pi
+
+    ! Part 1: Scattered sphere
+    call demo_scattered_sphere()
+
+    ! Part 2: Gridded sphere
+    call demo_gridded_sphere()
+
+    print '(/,a)', 'Done.'
+
+contains
+
+    ! Smooth test function on the sphere
+    elemental real(FP_REAL) function test_sphere(theta, phi) result(f)
+        real(FP_REAL), intent(in) :: theta, phi
+        ! f = 1 + cos(theta) + 0.5*sin(theta)^2*cos(2*phi)
+        ! This is a linear combination of spherical harmonics (Y_0^0, Y_1^0, Y_2^2)
+        f = one + cos(theta) + half * sin(theta)**2 * cos(two * phi)
+    end function
+
+    subroutine demo_scattered_sphere()
+        integer, parameter :: m = 200
+        real(FP_REAL) :: theta(m), phi(m), r(m), w(m)
+        type(fitpack_sphere) :: sph
+        integer(FP_FLAG) :: ierr
+        real(FP_REAL), allocatable :: f(:,:)
+        real(FP_REAL) :: t_eval(5), p_eval(5)
+        real(FP_REAL) :: avg_err, max_err
+        integer :: i
+
+        print '(a)', '=== Scattered sphere fit ==='
+
+        ! Generate quasi-random points on the sphere
+        do i = 1, m
+            ! Uniform in cos(theta) for uniform area coverage
+            theta(i) = acos(one - two * mod(i * 0.6180339887_FP_REAL, one))
+            phi(i) = pi2 * mod(i * 0.3247179572_FP_REAL, one)
+            r(i) = test_sphere(theta(i), phi(i))
+        end do
+
+        ! Unit weights
+        w = one
+
+        ! Smoothing fit
+        ierr = sph%new_fit(theta, phi, r, smoothing=real(m, FP_REAL))
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Fit failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+        print '(a,i0,a,i0)', '  Knots: ', sph%knots(1), ' x ', sph%knots(2)
+        print '(a,es10.3)',   '  Residual: ', sph%mse()
+
+        ! Evaluate on a small grid (eval_many returns grid output)
+        t_eval = [0.1_FP_REAL, half, one, two, pi - 0.1_FP_REAL]
+        p_eval = [0.1_FP_REAL, one, two, pi, 5.0_FP_REAL]
+        f = sph%eval(t_eval, p_eval, ierr)
+        ! f has shape (size(p_eval), size(t_eval))
+        if (FITPACK_SUCCESS(ierr)) then
+            print '(/,a)', '  Grid evaluation sample (theta=0.5, phi=1.0):'
+            print '(a,f12.6)', '    s(0.5, 1.0) = ', f(2, 2)
+            print '(a,f12.6)', '    exact       = ', test_sphere(t_eval(2), p_eval(2))
+        end if
+
+        ! Tighter fit
+        ierr = sph%fit(smoothing=10.0_FP_REAL)
+        if (FITPACK_SUCCESS(ierr)) then
+            print '(/,a)',      '  Tighter fit:'
+            print '(a,i0,a,i0)', '    Knots: ', sph%knots(1), ' x ', sph%knots(2)
+            print '(a,es10.3)',   '    Residual: ', sph%mse()
+
+            f = sph%eval(t_eval, p_eval, ierr)
+            if (FITPACK_SUCCESS(ierr)) then
+                print '(a,f12.6)', '    s(0.5, 1.0) = ', f(2, 2)
+            end if
+        end if
+
+        call sph%destroy()
+    end subroutine
+
+    subroutine demo_gridded_sphere()
+        integer, parameter :: nu = 15, nv = 30
+        real(FP_REAL) :: u(nu), v(nv), zg(nv, nu)
+        real(FP_REAL) :: du, dv, z_north, z_south, z_val
+        type(fitpack_grid_sphere) :: gsph
+        integer(FP_FLAG) :: ierr
+        real(FP_REAL), allocatable :: f(:,:)
+        real(FP_REAL) :: u_eval(3), v_eval(3)
+        integer :: i, j
+
+        print '(/,a)', '=== Gridded sphere fit ==='
+
+        ! Create colatitude-longitude grid
+        ! u (colatitude) in (0, pi), v (longitude) in [0, 2*pi)
+        du = pi / (nu + 1)
+        dv = pi2 / nv
+        do i = 1, nu
+            u(i) = i * du
+        end do
+        do j = 1, nv
+            v(j) = (j - 1) * dv
+        end do
+
+        ! Evaluate function on grid
+        do i = 1, nu
+            do j = 1, nv
+                zg(j, i) = test_sphere(u(i), v(j))
+            end do
+        end do
+
+        ! Pole values
+        z_north = test_sphere(zero, zero)
+        z_south = test_sphere(pi, zero)
+
+        ! Fit
+        ierr = gsph%new_fit(u, v, zg, smoothing=zero)
+        if (.not. FITPACK_SUCCESS(ierr)) then
+            print '(a,a)', '  Fit failed: ', FITPACK_MESSAGE(ierr)
+            return
+        end if
+        print '(a,i0,a,i0)', '  Knots: ', gsph%knots(1), ' x ', gsph%knots(2)
+        print '(a,es10.3)',   '  Residual: ', gsph%mse()
+
+        ! Set pole boundary conditions
+        call gsph%BC_north_pole(z0=z_north, exact=.true., differentiable=.true.)
+        call gsph%BC_south_pole(z0=z_south, exact=.true., differentiable=.true.)
+
+        ! Re-fit with pole BCs
+        ierr = gsph%fit(smoothing=zero)
+        if (FITPACK_SUCCESS(ierr)) then
+            print '(a,es10.3)', '  Residual (with pole BCs): ', gsph%mse()
+        end if
+
+        ! Evaluate
+        u_eval = [0.1_FP_REAL, half * pi, pi - 0.1_FP_REAL]
+        v_eval = [zero, pi, pi2 - 0.1_FP_REAL]
+        f = gsph%eval(u_eval, v_eval, ierr)
+        if (FITPACK_SUCCESS(ierr)) then
+            print '(/,a)', '  Evaluation at select points:'
+            print '(a)', '     theta    phi      s(t,p)    exact'
+            do i = 1, 3
+                print '(2f9.4, 2f12.6)', u_eval(i), v_eval(i), &
+                    f(i, i), test_sphere(u_eval(i), v_eval(i))
+            end do
+        end if
+
+        ! Check pole values
+        z_val = gsph%eval(0.001_FP_REAL, zero, ierr)
+        print '(/,a,f12.6)', '  Near north pole: s(0.001, 0) = ', z_val
+        print '(a,f12.6)',   '  Exact at pole:               = ', z_north
+
+        call gsph%destroy()
+    end subroutine
+
+end program example_sphere

--- a/examples/example_surface.f90
+++ b/examples/example_surface.f90
@@ -1,0 +1,103 @@
+! Example: Scattered surface fitting with fitpack_surface
+!
+! Fits a bivariate spline to scattered data sampled from Franke's test function,
+! demonstrating smoothing, evaluation, partial derivatives, and integration.
+program example_surface
+    use fitpack, only: fitpack_surface, fitpack_curve, FP_REAL, FP_FLAG, &
+                       FITPACK_SUCCESS, FITPACK_MESSAGE, zero, one, half, pi
+    implicit none
+
+    integer, parameter :: m = 200
+    real(FP_REAL), parameter :: two = 2.0_FP_REAL
+    real(FP_REAL), parameter :: nine = 9.0_FP_REAL
+
+    real(FP_REAL) :: x(m), y(m), z(m)
+    type(fitpack_surface) :: surf
+    type(fitpack_curve) :: cross
+    integer(FP_FLAG) :: ierr
+    real(FP_REAL) :: z_val, dzdx, dzdy, vol, exact_eval
+    real(FP_REAL) :: x_eval(5), y_eval(5), z_eval(5)
+    integer :: i
+
+    ! Generate scattered data from a smooth test function
+    ! f(x,y) = sin(pi*x)*cos(pi*y) on [0,1]x[0,1]
+    ! Using a simple quasi-random distribution
+    do i = 1, m
+        x(i) = mod(i * 0.6180339887_FP_REAL, one)        ! golden ratio mod 1
+        y(i) = mod(i * 0.3247179572_FP_REAL, one)        ! sqrt(2)/4 mod 1
+        z(i) = test_func(x(i), y(i))
+    end do
+
+    ! ---- Smoothing fit ----
+    print '(a)', '=== Scattered surface: smoothing fit ==='
+    ierr = surf%new_fit(x, y, z, smoothing=real(m, FP_REAL))
+    if (.not. FITPACK_SUCCESS(ierr)) then
+        print '(a,a)', 'Fit failed: ', FITPACK_MESSAGE(ierr)
+        error stop
+    end if
+    print '(a,i0,a,i0)', '  Knots: ', surf%knots(1), ' x ', surf%knots(2)
+    print '(a,es10.3)',   '  Residual: ', surf%mse()
+
+    ! Evaluate at a few test points
+    print '(/,a)', '=== Point evaluation ==='
+    print '(a)', '     x       y       s(x,y)    exact'
+    x_eval = [0.25_FP_REAL, half, 0.75_FP_REAL, 0.1_FP_REAL, 0.9_FP_REAL]
+    y_eval = [0.25_FP_REAL, half, 0.75_FP_REAL, 0.9_FP_REAL, 0.1_FP_REAL]
+    do i = 1, 5
+        z_val = surf%eval(x_eval(i), y_eval(i), ierr)
+        exact_eval = test_func(x_eval(i), y_eval(i))
+        print '(2f8.3, 2f12.6)', x_eval(i), y_eval(i), z_val, exact_eval
+    end do
+
+    ! ---- Partial derivatives ----
+    print '(/,a)', '=== Partial derivatives at (0.5, 0.5) ==='
+    dzdx = surf%dfdx(half, half, 1, 0, ierr)
+    dzdy = surf%dfdx(half, half, 0, 1, ierr)
+    print '(a,f12.6)', '  ds/dx  = ', dzdx
+    print '(a,f12.6)', '  ds/dy  = ', dzdy
+    print '(a,f12.6)', '  exact ds/dx = ', pi * cos(pi * half) * cos(pi * half)
+    print '(a,f12.6)', '  exact ds/dy = ', -pi * sin(pi * half) * sin(pi * half)
+
+    ! ---- Integration ----
+    print '(/,a)', '=== Integration over [0,1] x [0,1] ==='
+    vol = surf%integral([zero, zero], [one, one])
+    print '(a,f12.6)', '  integral = ', vol
+    ! Exact: integral of sin(pi*x)*cos(pi*y) dxdy over [0,1]^2
+    ! = (2/pi) * (0) = 0 (since integral of cos(pi*y) from 0 to 1 = 0)
+    print '(a,f12.6)', '  exact    = ', zero
+
+    ! ---- Cross-section ----
+    print '(/,a)', '=== Cross-section at y = 0.5 ==='
+    cross = surf%cross_section(half, .true., ierr)
+    if (FITPACK_SUCCESS(ierr)) then
+        print '(a,i0)', '  Cross-section knots: ', cross%knots
+        print '(a)', '     x       profile   exact'
+        do i = 1, 5
+            z_val = cross%eval(x_eval(i), ierr)
+            exact_eval = test_func(x_eval(i), half)
+            print '(f8.3, 2f12.6)', x_eval(i), z_val, exact_eval
+        end do
+    end if
+
+    ! ---- Tighter fit ----
+    print '(/,a)', '=== Smoothing sweep ==='
+    print '(a)', '     S       knots_x  knots_y  residual'
+    do i = 1, 4
+        ierr = surf%new_fit(x, y, z, smoothing=10.0_FP_REAL**(3 - i))
+        if (FITPACK_SUCCESS(ierr)) then
+            print '(es10.1, 2i9, es12.3)', surf%smoothing, surf%knots(1), surf%knots(2), surf%mse()
+        end if
+    end do
+
+    call cross%destroy()
+    call surf%destroy()
+    print '(/,a)', 'Done.'
+
+contains
+
+    elemental real(FP_REAL) function test_func(x, y) result(f)
+        real(FP_REAL), intent(in) :: x, y
+        f = sin(pi * x) * cos(pi * y)
+    end function
+
+end program example_surface

--- a/fpm.toml
+++ b/fpm.toml
@@ -19,3 +19,43 @@ include-dir = "include"
 
 [install]
 library = true
+
+[[example]]
+name = "example_curve"
+source-dir = "examples"
+main = "example_curve.f90"
+
+[[example]]
+name = "example_periodic_curve"
+source-dir = "examples"
+main = "example_periodic_curve.f90"
+
+[[example]]
+name = "example_parametric_curves"
+source-dir = "examples"
+main = "example_parametric_curves.f90"
+
+[[example]]
+name = "example_convex_curve"
+source-dir = "examples"
+main = "example_convex_curve.f90"
+
+[[example]]
+name = "example_surface"
+source-dir = "examples"
+main = "example_surface.f90"
+
+[[example]]
+name = "example_grid_surface"
+source-dir = "examples"
+main = "example_grid_surface.f90"
+
+[[example]]
+name = "example_polar"
+source-dir = "examples"
+main = "example_polar.f90"
+
+[[example]]
+name = "example_sphere"
+source-dir = "examples"
+main = "example_sphere.f90"

--- a/project/doxygen/Doxyfile
+++ b/project/doxygen/Doxyfile
@@ -1,317 +1,59 @@
-#******************************************************************************
-# Doxygen configuration for fitpack
-# Adapted from fortran-lapack Doxygen setup
-#******************************************************************************
+commit a2cd11b23af0988e0e5813ab0525db6a6ae94a3e
+Author: Federico Perini <federico.perini@gmail.com>
+Date:   Wed Feb 18 22:16:44 2026 +0100
 
-#---------------------------------------------------------------------------
-# Project related configuration options
-#---------------------------------------------------------------------------
-DOXYFILE_ENCODING      = UTF-8
-PROJECT_NAME           = fitpack
-PROJECT_NUMBER         =
-PROJECT_BRIEF          = "Modern Fortran library for curve and surface fitting with splines"
-PROJECT_LOGO           =
-OUTPUT_DIRECTORY       =
-CREATE_SUBDIRS         = NO
-OUTPUT_LANGUAGE        = English
-BRIEF_MEMBER_DESC      = YES
-REPEAT_BRIEF           = YES
+    Fix surfit y-bounds check, percur zero-pivot guard, and NaN-safe tests
+    
+    Three bug fixes:
+    
+    1. surfit: y-values were checked against x-bounds instead of y-bounds,
+       causing spurious "invalid input" errors when x/y ranges differed.
+    
+    2. fp_rotate_row_2mat / fp_rotate_row_2mat_vec: add zero-pivot guards
+       matching original Netlib fpperi.f. Without these, fpgivs computes
+       0/0 = NaN when both pivot and target are zero.
+    
+    3. fitpack_curves new_points: use percur workspace formula
+       nest*(8+5*k) instead of curfit's nest*(7+3*k).
+    
+    4. Test comparisons: use `.not.(expr <= tol)` instead of `expr > tol`
+       so NaN values are caught (IEEE 754: NaN > x is always false).
 
-ABBREVIATE_BRIEF       = "The $name class" \
-                         "The $name widget" \
-                         "The $name file" \
-                         is \
-                         provides \
-                         specifies \
-                         contains \
-                         represents \
-                         a \
-                         an \
-                         the
-
-ALWAYS_DETAILED_SEC    = YES
-INLINE_INHERITED_MEMB  = NO
-FULL_PATH_NAMES        = NO
-STRIP_FROM_PATH        =
-STRIP_FROM_INC_PATH    =
-SHORT_NAMES            = NO
-JAVADOC_AUTOBRIEF      = NO
-QT_AUTOBRIEF           = NO
-MULTILINE_CPP_IS_BRIEF = NO
-PYTHON_DOCSTRING       = YES
-INHERIT_DOCS           = YES
-SEPARATE_MEMBER_PAGES  = NO
-TAB_SIZE               = 4
-ALIASES                =
-OPTIMIZE_OUTPUT_FOR_C  = NO
-OPTIMIZE_OUTPUT_JAVA   = NO
-OPTIMIZE_FOR_FORTRAN   = YES
-OPTIMIZE_OUTPUT_VHDL   = NO
-
-EXTENSION_MAPPING      = .F90=FortranFree
-EXTENSION_MAPPING     += .f90=FortranFree
-
-MARKDOWN_SUPPORT       = YES
-
-USE_MDFILE_AS_MAINPAGE = "../../doc/mainpage.md"
-
-TOC_INCLUDE_HEADINGS   = 5
-AUTOLINK_SUPPORT       = YES
-BUILTIN_STL_SUPPORT    = YES
-CPP_CLI_SUPPORT        = NO
-SIP_SUPPORT            = NO
-IDL_PROPERTY_SUPPORT   = YES
-DISTRIBUTE_GROUP_DOC   = NO
-SUBGROUPING            = YES
-TYPEDEF_HIDES_STRUCT   = NO
-
-#---------------------------------------------------------------------------
-# Build related configuration options
-#---------------------------------------------------------------------------
-EXTRACT_ALL            = YES
-EXTRACT_PRIVATE        = YES
-EXTRACT_STATIC         = YES
-EXTRACT_PACKAGE        = YES
-EXTRACT_LOCAL_CLASSES  = YES
-EXTRACT_LOCAL_METHODS  = YES
-EXTRACT_ANON_NSPACES   = NO
-HIDE_UNDOC_MEMBERS     = NO
-HIDE_UNDOC_CLASSES     = NO
-HIDE_FRIEND_COMPOUNDS  = NO
-HIDE_IN_BODY_DOCS      = NO
-INTERNAL_DOCS          = NO
-CASE_SENSE_NAMES       = NO
-HIDE_SCOPE_NAMES       = NO
-SHOW_INCLUDE_FILES     = YES
-FORCE_LOCAL_INCLUDES   = NO
-INLINE_INFO            = YES
-SORT_MEMBER_DOCS       = YES
-SORT_BRIEF_DOCS        = NO
-SORT_MEMBERS_CTORS_1ST = NO
-SORT_GROUP_NAMES       = NO
-SORT_BY_SCOPE_NAME     = NO
-STRICT_PROTO_MATCHING  = NO
-GENERATE_TODOLIST      = YES
-GENERATE_TESTLIST      = YES
-GENERATE_BUGLIST       = YES
-GENERATE_DEPRECATEDLIST= YES
-ENABLED_SECTIONS       =
-MAX_INITIALIZER_LINES  = 30
-SHOW_USED_FILES        = YES
-SHOW_FILES             = YES
-SHOW_NAMESPACES        = YES
-FILE_VERSION_FILTER    =
-LAYOUT_FILE            =
-
-#---------------------------------------------------------------------------
-# Configuration options related to warning and progress messages
-#---------------------------------------------------------------------------
-QUIET                  = NO
-WARNINGS               = YES
-WARN_IF_UNDOCUMENTED   = NO
-WARN_IF_DOC_ERROR      = YES
-WARN_NO_PARAMDOC       = YES
-WARN_FORMAT            = "$file:$line: $text"
-WARN_LOGFILE           =
-
-#---------------------------------------------------------------------------
-# Configuration options related to the input files
-#---------------------------------------------------------------------------
-INPUT                  = "../../src/"
-INPUT                 += "../../doc/mainpage.md"
-INPUT                 += "../../doc/book_reference.md"
-# Theory pages
-INPUT                 += "../../doc/theory_bsplines.md"
-INPUT                 += "../../doc/theory_curve_fitting.md"
-INPUT                 += "../../doc/theory_surface_fitting.md"
-INPUT                 += "../../doc/theory_special_domains.md"
-# Tutorial pages
-INPUT                 += "../../doc/tutorial_curve.md"
-INPUT                 += "../../doc/tutorial_periodic_curve.md"
-INPUT                 += "../../doc/tutorial_parametric_curves.md"
-INPUT                 += "../../doc/tutorial_convex_curve.md"
-INPUT                 += "../../doc/tutorial_surface.md"
-INPUT                 += "../../doc/tutorial_grid_surface.md"
-INPUT                 += "../../doc/tutorial_polar.md"
-INPUT                 += "../../doc/tutorial_sphere.md"
-
-INPUT_ENCODING         = UTF-8
-
-FILE_PATTERNS          = *.F90 \
-                         *.f90 \
-                         *.f95 \
-                         *.f03 \
-                         *.f08 \
-                         *.f18 \
-                         *.f \
-                         *.for \
-                         *.md
-
-RECURSIVE              = YES
-EXCLUDE                =
-EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       =
-EXCLUDE_SYMBOLS        =
-EXAMPLE_PATH           =
-EXAMPLE_PATTERNS       =
-EXAMPLE_RECURSIVE      = NO
-IMAGE_PATH             = "../../doc/media"
-INPUT_FILTER           =
-FILTER_PATTERNS        =
-FILTER_SOURCE_FILES    = NO
-FILTER_SOURCE_PATTERNS =
-
-#---------------------------------------------------------------------------
-# Configuration options related to source browsing
-#---------------------------------------------------------------------------
-SOURCE_BROWSER         = NO
-INLINE_SOURCES         = NO
-STRIP_CODE_COMMENTS    = YES
-REFERENCED_BY_RELATION = NO
-REFERENCES_RELATION    = NO
-REFERENCES_LINK_SOURCE = YES
-USE_HTAGS              = NO
-VERBATIM_HEADERS       = YES
-
-#---------------------------------------------------------------------------
-# Configuration options related to the alphabetical class index
-#---------------------------------------------------------------------------
-ALPHABETICAL_INDEX     = YES
-IGNORE_PREFIX          =
-
-#---------------------------------------------------------------------------
-# Configuration options related to the HTML output
-#---------------------------------------------------------------------------
-GENERATE_HTML          = YES
-HTML_OUTPUT            = html
-HTML_FILE_EXTENSION    = .html
-HTML_HEADER            = header.html
-HTML_FOOTER            =
-HTML_STYLESHEET        =
-HTML_COLORSTYLE        = LIGHT
-HTML_COLORSTYLE_HUE    = 220
-HTML_COLORSTYLE_SAT    = 100
-HTML_COLORSTYLE_GAMMA  = 80
-HTML_DYNAMIC_MENUS     = YES
-HTML_DYNAMIC_SECTIONS  = NO
-HTML_EXTRA_FILES       = doxygen-awesome-darkmode-toggle.js
-HTML_EXTRA_STYLESHEET  = doxygen-awesome.css
-GENERATE_DOCSET        = NO
-DOCSET_FEEDNAME        = "Doxygen generated docs"
-DOCSET_BUNDLE_ID       = org.doxygen.Project
-DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
-DOCSET_PUBLISHER_NAME  = Publisher
-GENERATE_HTMLHELP      = NO
-CHM_FILE               =
-HHC_LOCATION           =
-GENERATE_CHI           = NO
-CHM_INDEX_ENCODING     =
-BINARY_TOC             = NO
-TOC_EXPAND             = NO
-GENERATE_QHP           = NO
-QCH_FILE               =
-QHP_NAMESPACE          = org.doxygen.Project
-QHP_VIRTUAL_FOLDER     = doc
-QHP_CUST_FILTER_NAME   =
-QHP_CUST_FILTER_ATTRS  =
-QHP_SECT_FILTER_ATTRS  =
-QHG_LOCATION           =
-GENERATE_ECLIPSEHELP   = NO
-ECLIPSE_DOC_ID         = org.doxygen.Project
-DISABLE_INDEX          = NO
-ENUM_VALUES_PER_LINE   = 4
-GENERATE_TREEVIEW      = YES
-FULL_SIDEBAR           = NO
-TREEVIEW_WIDTH         = 250
-EXT_LINKS_IN_WINDOW    = NO
-FORMULA_FONTSIZE       = 16
-USE_MATHJAX            = YES
-MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/
-SEARCHENGINE           = YES
-SERVER_BASED_SEARCH    = NO
-
-#---------------------------------------------------------------------------
-# Configuration options related to the LaTeX output
-#---------------------------------------------------------------------------
-GENERATE_LATEX         = NO
-LATEX_OUTPUT           = latex
-LATEX_CMD_NAME         = latex
-MAKEINDEX_CMD_NAME     = makeindex
-COMPACT_LATEX          = NO
-PAPER_TYPE             = a4
-EXTRA_PACKAGES         = {amsmath}
-EXTRA_PACKAGES        += {amssymb}
-LATEX_HEADER           =
-PDF_HYPERLINKS         = YES
-USE_PDFLATEX           = YES
-LATEX_BATCHMODE        = NO
-LATEX_HIDE_INDICES     = NO
-
-#---------------------------------------------------------------------------
-# Configuration options related to the RTF output
-#---------------------------------------------------------------------------
-GENERATE_RTF           = NO
-
-#---------------------------------------------------------------------------
-# Configuration options related to the man page output
-#---------------------------------------------------------------------------
-GENERATE_MAN           = NO
-
-#---------------------------------------------------------------------------
-# Configuration options related to the XML output
-#---------------------------------------------------------------------------
-GENERATE_XML           = NO
-
-#---------------------------------------------------------------------------
-# Configuration options related to the Perl module output
-#---------------------------------------------------------------------------
-GENERATE_PERLMOD       = NO
-
-#---------------------------------------------------------------------------
-# Configuration options related to the preprocessor
-#---------------------------------------------------------------------------
-ENABLE_PREPROCESSING   = YES
-MACRO_EXPANSION        = YES
-EXPAND_ONLY_PREDEF     = YES
-SEARCH_INCLUDES        = YES
-INCLUDE_PATH           =
-INCLUDE_FILE_PATTERNS  =
-PREDEFINED             =
-EXPAND_AS_DEFINED      =
-SKIP_FUNCTION_MACROS   = YES
-
-#---------------------------------------------------------------------------
-# Configuration options related to external references
-#---------------------------------------------------------------------------
-TAGFILES               =
-GENERATE_TAGFILE       =
-ALLEXTERNALS           = NO
-EXTERNAL_GROUPS        = YES
-
-#---------------------------------------------------------------------------
-# Configuration options related to the dot tool
-#---------------------------------------------------------------------------
-HIDE_UNDOC_RELATIONS   = YES
-HAVE_DOT               = YES
-DOT_NUM_THREADS        = 0
-DOT_FONTPATH           =
-CLASS_GRAPH            = YES
-COLLABORATION_GRAPH    = YES
-GROUP_GRAPHS           = YES
-UML_LOOK               = NO
-TEMPLATE_RELATIONS     = NO
-INCLUDE_GRAPH          = YES
-INCLUDED_BY_GRAPH      = YES
-CALL_GRAPH             = YES
-CALLER_GRAPH           = NO
-GRAPHICAL_HIERARCHY    = YES
-DIRECTORY_GRAPH        = YES
-DOT_IMAGE_FORMAT       = png
-DOT_PATH               =
-DOTFILE_DIRS           =
-MSCFILE_DIRS           =
-DOT_GRAPH_MAX_NODES    = 50
-MAX_DOT_GRAPH_DEPTH    = 0
-DOT_MULTI_TARGETS      = NO
-GENERATE_LEGEND        = YES
-DOT_CLEANUP            = YES
+diff --git a/project/doxygen/Doxyfile b/project/doxygen/Doxyfile
+index bb427b9..06ab07e 100644
+--- a/project/doxygen/Doxyfile
++++ b/project/doxygen/Doxyfile
+@@ -119,10 +119,21 @@ WARN_LOGFILE           =
+ #---------------------------------------------------------------------------
+ INPUT                  = "../../src/"
+ INPUT                 += "../../doc/mainpage.md"
+-INPUT                 += "../../doc/tutorial_curves.md"
+-INPUT                 += "../../doc/tutorial_surfaces.md"
+-INPUT                 += "../../doc/tutorial_special.md"
+ INPUT                 += "../../doc/book_reference.md"
++# Theory pages
++INPUT                 += "../../doc/theory_bsplines.md"
++INPUT                 += "../../doc/theory_curve_fitting.md"
++INPUT                 += "../../doc/theory_surface_fitting.md"
++INPUT                 += "../../doc/theory_special_domains.md"
++# Tutorial pages
++INPUT                 += "../../doc/tutorial_curve.md"
++INPUT                 += "../../doc/tutorial_periodic_curve.md"
++INPUT                 += "../../doc/tutorial_parametric_curves.md"
++INPUT                 += "../../doc/tutorial_convex_curve.md"
++INPUT                 += "../../doc/tutorial_surface.md"
++INPUT                 += "../../doc/tutorial_grid_surface.md"
++INPUT                 += "../../doc/tutorial_polar.md"
++INPUT                 += "../../doc/tutorial_sphere.md"
+ 
+ INPUT_ENCODING         = UTF-8
+ 
+@@ -144,7 +155,7 @@ EXCLUDE_SYMBOLS        =
+ EXAMPLE_PATH           =
+ EXAMPLE_PATTERNS       =
+ EXAMPLE_RECURSIVE      = NO
+-IMAGE_PATH             =
++IMAGE_PATH             = "../../doc/media"
+ INPUT_FILTER           =
+ FILTER_PATTERNS        =
+ FILTER_SOURCE_FILES    = NO


### PR DESCRIPTION
## Summary

- **4 spline theory pages** covering B-spline foundations, curve fitting, surface fitting, and polar/spherical domains — with MathJax equations and Doxygen cross-references
- **8 compilable example programs** (one per type group), registered in fpm.toml, all build and run with `fpm run --example <name>`
- **Doxyfile + mainpage.md** updated to link all new theory, tutorial, and example content

Builds on #48 (fixes) and the tutorial/plot-script changes already merged to main.

## Test plan

- [x] `fpm build` succeeds
- [x] `fpm test` — 59/59 tests pass
- [x] All 8 examples run without errors
- [x] `doxygen Doxyfile` — zero warnings from doc pages