### PR TITLE
Fix corrupted docs and MathJax rendering

### DIFF
--- a/doc/mainpage.md
+++ b/doc/mainpage.md
@@ -1,81 +1,130 @@
-commit a2cd11b23af0988e0e5813ab0525db6a6ae94a3e
-Author: Federico Perini <federico.perini@gmail.com>
-Date:   Wed Feb 18 22:16:44 2026 +0100
+# fitpack — Modern Fortran Spline Fitting {#mainpage}
 
-    Fix surfit y-bounds check, percur zero-pivot guard, and NaN-safe tests
-    
-    Three bug fixes:
-    
-    1. surfit: y-values were checked against x-bounds instead of y-bounds,
-       causing spurious "invalid input" errors when x/y ranges differed.
-    
-    2. fp_rotate_row_2mat / fp_rotate_row_2mat_vec: add zero-pivot guards
-       matching original Netlib fpperi.f. Without these, fpgivs computes
-       0/0 = NaN when both pivot and target are zero.
-    
-    3. fitpack_curves new_points: use percur workspace formula
-       nest*(8+5*k) instead of curfit's nest*(7+3*k).
-    
-    4. Test comparisons: use `.not.(expr <= tol)` instead of `expr > tol`
-       so NaN values are caught (IEEE 754: NaN > x is always false).
+**fitpack** is a Modern Fortran (2008+) library for curve and surface fitting with splines,
+based on the FITPACK package by Paul Dierckx.
 
-diff --git a/doc/mainpage.md b/doc/mainpage.md
-index 311b4d7..af03e87 100644
---- a/doc/mainpage.md
-+++ b/doc/mainpage.md
-@@ -76,15 +76,51 @@ fpm build          # build the library
- fpm test           # run all tests
- ```
- 
-+## Spline Theory
-+
-+- @ref theory_bsplines &mdash; B-spline basis functions, de Boor evaluation, derivatives, integration, knot insertion
-+- @ref theory_curve_fitting &mdash; Smoothing criterion, adaptive knot placement, periodic and parametric curves
-+- @ref theory_surface_fitting &mdash; Tensor product splines, scattered vs. gridded fitting, Kronecker product efficiency
-+- @ref theory_special_domains &mdash; Polar coordinate transform, spherical coordinates, pole boundary conditions
-+
- ## Tutorials
- 
--- @ref tutorial_curves — Smoothing, interpolation, derivatives, roots, periodic and parametric curves
--- @ref tutorial_surfaces — Scattered and gridded surface fitting, cross-sections, integration
--- @ref tutorial_special — Polar and spherical domains, pole boundary conditions
--- @ref book_reference — Quick-reference table mapping routines to book chapters and equations
-+### Curves
-+
-+- @ref tutorial_curve &mdash; Univariate smoothing and interpolation with `fitpack_curve`
-+- @ref tutorial_periodic_curve &mdash; Periodic splines with `fitpack_periodic_curve`
-+- @ref tutorial_parametric_curves &mdash; Parametric, closed, and constrained curves
-+- @ref tutorial_convex_curve &mdash; Shape-preserving fitting with convexity constraints
-+
-+### Surfaces
-+
-+- @ref tutorial_surface &mdash; Scattered bivariate data with `fitpack_surface`
-+- @ref tutorial_grid_surface &mdash; Gridded data and parametric surfaces
-+
-+### Special Domains
-+
-+- @ref tutorial_polar &mdash; Disc-shaped domains with `fitpack_polar` and `fitpack_grid_polar`
-+- @ref tutorial_sphere &mdash; Spherical data with `fitpack_sphere` and `fitpack_grid_sphere`
-+
-+## Examples
-+
-+Compilable example programs are in the `examples/` directory. Build and run with:
-+
-+```bash
-+fpm run --example example_curve
-+fpm run --example example_periodic_curve
-+fpm run --example example_parametric_curves
-+fpm run --example example_convex_curve
-+fpm run --example example_surface
-+fpm run --example example_grid_surface
-+fpm run --example example_polar
-+fpm run --example example_sphere
-+```
- 
- ## Reference
- 
-+- @ref book_reference &mdash; Quick-reference table mapping routines to book chapters and equations
-+
- The algorithms are described in:
- 
- > P. Dierckx, *Curve and Surface Fitting with Splines*,
+It provides an object-oriented API with derived types for all major fitting tasks:
+smoothing, interpolation, least-squares approximation, and constrained fitting.
+All routines support spline degrees 1 through 5 (cubic by default) and return
+B-spline representations that can be evaluated, differentiated, integrated, and
+root-found efficiently.
+
+## Type Hierarchy
+
+All fitter types extend the abstract base `fitpack_fitter`:
+
+```
+fitpack_fitter (abstract base)
+├── fitpack_curve                   — 1D spline: y = s(x)
+│   ├── fitpack_periodic_curve      — periodic boundary conditions
+│   └── fitpack_convex_curve        — convexity-constrained fitting
+├── fitpack_parametric_curve        — parametric curves: x_i = s_i(u)
+│   ├── fitpack_closed_curve        — closed parametric curves
+│   └── fitpack_constrained_curve   — endpoint derivative constraints
+├── fitpack_surface                 — 2D spline from scattered data
+├── fitpack_grid_surface            — 2D spline from gridded data
+├── fitpack_parametric_surface      — parametric surfaces
+├── fitpack_polar                   — polar-domain fitting (scattered)
+├── fitpack_grid_polar              — polar-domain fitting (gridded)
+├── fitpack_sphere                  — spherical-domain fitting (scattered)
+└── fitpack_grid_sphere             — spherical-domain fitting (gridded)
+```
+
+## Quick Start
+
+### Fit a curve
+
+```fortran
+use fitpack, only: fitpack_curve
+
+type(fitpack_curve) :: curve
+integer :: ierr
+
+! Create a smoothing spline from data
+curve = fitpack_curve(x, y, ierr=ierr)
+
+! Evaluate at new points
+y_new = curve%eval(x_new, ierr)
+
+! Compute derivative, integral, zeros
+dydx  = curve%dfdx(x_new, ierr)
+area  = curve%integral(x(1), x(size(x)), ierr)
+roots = curve%zeros(ierr)
+```
+
+### Fit a surface
+
+```fortran
+use fitpack, only: fitpack_grid_surface
+
+type(fitpack_grid_surface) :: surf
+integer :: ierr
+
+! Create a smoothing spline from gridded data
+surf = fitpack_grid_surface(x, y, z, ierr=ierr)
+
+! Evaluate on a new grid
+z_new = surf%eval(x_new, y_new, ierr)
+```
+
+## Building
+
+fitpack uses [fpm](https://fpm.fortran-lang.org/) (Fortran Package Manager):
+
+```bash
+fpm build          # build the library
+fpm test           # run all tests
+```
+
+## Spline Theory
+
+- @ref theory_bsplines &mdash; B-spline basis functions, de Boor evaluation, derivatives, integration, knot insertion
+- @ref theory_curve_fitting &mdash; Smoothing criterion, adaptive knot placement, periodic and parametric curves
+- @ref theory_surface_fitting &mdash; Tensor product splines, scattered vs. gridded fitting, Kronecker product efficiency
+- @ref theory_special_domains &mdash; Polar coordinate transform, spherical coordinates, pole boundary conditions
+
+## Tutorials
+
+### Curves
+
+- @ref tutorial_curve &mdash; Univariate smoothing and interpolation with `fitpack_curve`
+- @ref tutorial_periodic_curve &mdash; Periodic splines with `fitpack_periodic_curve`
+- @ref tutorial_parametric_curves &mdash; Parametric, closed, and constrained curves
+- @ref tutorial_convex_curve &mdash; Shape-preserving fitting with convexity constraints
+
+### Surfaces
+
+- @ref tutorial_surface &mdash; Scattered bivariate data with `fitpack_surface`
+- @ref tutorial_grid_surface &mdash; Gridded data and parametric surfaces
+
+### Special Domains
+
+- @ref tutorial_polar &mdash; Disc-shaped domains with `fitpack_polar` and `fitpack_grid_polar`
+- @ref tutorial_sphere &mdash; Spherical data with `fitpack_sphere` and `fitpack_grid_sphere`
+
+## Examples
+
+Compilable example programs are in the `examples/` directory. Build and run with:
+
+```bash
+fpm run --example example_curve
+fpm run --example example_periodic_curve
+fpm run --example example_parametric_curves
+fpm run --example example_convex_curve
+fpm run --example example_surface
+fpm run --example example_grid_surface
+fpm run --example example_polar
+fpm run --example example_sphere
+```
+
+## Reference
+
+- @ref book_reference &mdash; Quick-reference table mapping routines to book chapters and equations
+
+The algorithms are described in:
+
+> P. Dierckx, *Curve and Surface Fitting with Splines*,
+> Oxford University Press, 1993.
+
+Each routine's documentation references the relevant book chapter, section,
+and equation numbers.

--- a/doc/tutorial_periodic_curve.md
+++ b/doc/tutorial_periodic_curve.md
@@ -148,8 +148,8 @@ For the test function \f$ f(x) = \cos(x) + \sin(2x) \f$ the exact integral is
 
 \f[
     \int_{\pi/2}^{3\pi} \bigl[\cos(x) + \sin(2x)\bigr] \, dx
-    = \Bigl[\sin(x) - \tfrac{1}{2}\cos(2x)\Bigr]_{\pi/2}^{3\pi}
-    = -\tfrac{3}{2}
+    = \Bigl[\sin(x) - \frac{1}{2}\cos(2x)\Bigr]_{\pi/2}^{3\pi}
+    = -\frac{3}{2}
 \f]
 
 ## Smoothing and Interpolation

--- a/doc/tutorial_sphere.md
+++ b/doc/tutorial_sphere.md
@@ -103,8 +103,8 @@ The residual (weighted sum of squared errors) is returned by `sph\%mse()`.
 The following test function combines three harmonics:
 
 \f[
-    f(\theta, \phi) = Y_0^0 + Y_1^0 + \tfrac{1}{2}\, Y_2^2
-                    = 1 + \cos\theta + \tfrac{1}{2}\sin^2\!\theta\,\cos 2\phi
+    f(\theta, \phi) = Y_0^0 + Y_1^0 + \frac{1}{2}\, Y_2^2
+                    = 1 + \cos\theta + \frac{1}{2}\sin^2\!\theta\,\cos 2\phi
 \f]
 
 ```fortran

--- a/project/doxygen/Doxyfile
+++ b/project/doxygen/Doxyfile
@@ -1,59 +1,317 @@
-commit a2cd11b23af0988e0e5813ab0525db6a6ae94a3e
-Author: Federico Perini <federico.perini@gmail.com>
-Date:   Wed Feb 18 22:16:44 2026 +0100
+#******************************************************************************
+# Doxygen configuration for fitpack
+# Adapted from fortran-lapack Doxygen setup
+#******************************************************************************
 
-    Fix surfit y-bounds check, percur zero-pivot guard, and NaN-safe tests
-    
-    Three bug fixes:
-    
-    1. surfit: y-values were checked against x-bounds instead of y-bounds,
-       causing spurious "invalid input" errors when x/y ranges differed.
-    
-    2. fp_rotate_row_2mat / fp_rotate_row_2mat_vec: add zero-pivot guards
-       matching original Netlib fpperi.f. Without these, fpgivs computes
-       0/0 = NaN when both pivot and target are zero.
-    
-    3. fitpack_curves new_points: use percur workspace formula
-       nest*(8+5*k) instead of curfit's nest*(7+3*k).
-    
-    4. Test comparisons: use `.not.(expr <= tol)` instead of `expr > tol`
-       so NaN values are caught (IEEE 754: NaN > x is always false).
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+DOXYFILE_ENCODING      = UTF-8
+PROJECT_NAME           = fitpack
+PROJECT_NUMBER         =
+PROJECT_BRIEF          = "Modern Fortran library for curve and surface fitting with splines"
+PROJECT_LOGO           =
+OUTPUT_DIRECTORY       =
+CREATE_SUBDIRS         = NO
+OUTPUT_LANGUAGE        = English
+BRIEF_MEMBER_DESC      = YES
+REPEAT_BRIEF           = YES
 
-diff --git a/project/doxygen/Doxyfile b/project/doxygen/Doxyfile
-index bb427b9..06ab07e 100644
---- a/project/doxygen/Doxyfile
-+++ b/project/doxygen/Doxyfile
-@@ -119,10 +119,21 @@ WARN_LOGFILE           =
- #---------------------------------------------------------------------------
- INPUT                  = "../../src/"
- INPUT                 += "../../doc/mainpage.md"
--INPUT                 += "../../doc/tutorial_curves.md"
--INPUT                 += "../../doc/tutorial_surfaces.md"
--INPUT                 += "../../doc/tutorial_special.md"
- INPUT                 += "../../doc/book_reference.md"
-+# Theory pages
-+INPUT                 += "../../doc/theory_bsplines.md"
-+INPUT                 += "../../doc/theory_curve_fitting.md"
-+INPUT                 += "../../doc/theory_surface_fitting.md"
-+INPUT                 += "../../doc/theory_special_domains.md"
-+# Tutorial pages
-+INPUT                 += "../../doc/tutorial_curve.md"
-+INPUT                 += "../../doc/tutorial_periodic_curve.md"
-+INPUT                 += "../../doc/tutorial_parametric_curves.md"
-+INPUT                 += "../../doc/tutorial_convex_curve.md"
-+INPUT                 += "../../doc/tutorial_surface.md"
-+INPUT                 += "../../doc/tutorial_grid_surface.md"
-+INPUT                 += "../../doc/tutorial_polar.md"
-+INPUT                 += "../../doc/tutorial_sphere.md"
- 
- INPUT_ENCODING         = UTF-8
- 
-@@ -144,7 +155,7 @@ EXCLUDE_SYMBOLS        =
- EXAMPLE_PATH           =
- EXAMPLE_PATTERNS       =
- EXAMPLE_RECURSIVE      = NO
--IMAGE_PATH             =
-+IMAGE_PATH             = "../../doc/media"
- INPUT_FILTER           =
- FILTER_PATTERNS        =
- FILTER_SOURCE_FILES    = NO
+ABBREVIATE_BRIEF       = "The $name class" \
+                         "The $name widget" \
+                         "The $name file" \
+                         is \
+                         provides \
+                         specifies \
+                         contains \
+                         represents \
+                         a \
+                         an \
+                         the
+
+ALWAYS_DETAILED_SEC    = YES
+INLINE_INHERITED_MEMB  = NO
+FULL_PATH_NAMES        = NO
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
+SHORT_NAMES            = NO
+JAVADOC_AUTOBRIEF      = NO
+QT_AUTOBRIEF           = NO
+MULTILINE_CPP_IS_BRIEF = NO
+PYTHON_DOCSTRING       = YES
+INHERIT_DOCS           = YES
+SEPARATE_MEMBER_PAGES  = NO
+TAB_SIZE               = 4
+ALIASES                =
+OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = YES
+OPTIMIZE_OUTPUT_VHDL   = NO
+
+EXTENSION_MAPPING      = .F90=FortranFree
+EXTENSION_MAPPING     += .f90=FortranFree
+
+MARKDOWN_SUPPORT       = YES
+
+USE_MDFILE_AS_MAINPAGE = "../../doc/mainpage.md"
+
+TOC_INCLUDE_HEADINGS   = 5
+AUTOLINK_SUPPORT       = YES
+BUILTIN_STL_SUPPORT    = YES
+CPP_CLI_SUPPORT        = NO
+SIP_SUPPORT            = NO
+IDL_PROPERTY_SUPPORT   = YES
+DISTRIBUTE_GROUP_DOC   = NO
+SUBGROUPING            = YES
+TYPEDEF_HIDES_STRUCT   = NO
+
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = YES
+EXTRACT_STATIC         = YES
+EXTRACT_PACKAGE        = YES
+EXTRACT_LOCAL_CLASSES  = YES
+EXTRACT_LOCAL_METHODS  = YES
+EXTRACT_ANON_NSPACES   = NO
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_IN_BODY_DOCS      = NO
+INTERNAL_DOCS          = NO
+CASE_SENSE_NAMES       = NO
+HIDE_SCOPE_NAMES       = NO
+SHOW_INCLUDE_FILES     = YES
+FORCE_LOCAL_INCLUDES   = NO
+INLINE_INFO            = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = NO
+SORT_MEMBERS_CTORS_1ST = NO
+SORT_GROUP_NAMES       = NO
+SORT_BY_SCOPE_NAME     = NO
+STRICT_PROTO_MATCHING  = NO
+GENERATE_TODOLIST      = YES
+GENERATE_TESTLIST      = YES
+GENERATE_BUGLIST       = YES
+GENERATE_DEPRECATEDLIST= YES
+ENABLED_SECTIONS       =
+MAX_INITIALIZER_LINES  = 30
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES
+FILE_VERSION_FILTER    =
+LAYOUT_FILE            =
+
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = NO
+WARN_IF_DOC_ERROR      = YES
+WARN_NO_PARAMDOC       = YES
+WARN_FORMAT            = "$file:$line: $text"
+WARN_LOGFILE           =
+
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+INPUT                  = "../../src/"
+INPUT                 += "../../doc/mainpage.md"
+INPUT                 += "../../doc/book_reference.md"
+# Theory pages
+INPUT                 += "../../doc/theory_bsplines.md"
+INPUT                 += "../../doc/theory_curve_fitting.md"
+INPUT                 += "../../doc/theory_surface_fitting.md"
+INPUT                 += "../../doc/theory_special_domains.md"
+# Tutorial pages
+INPUT                 += "../../doc/tutorial_curve.md"
+INPUT                 += "../../doc/tutorial_periodic_curve.md"
+INPUT                 += "../../doc/tutorial_parametric_curves.md"
+INPUT                 += "../../doc/tutorial_convex_curve.md"
+INPUT                 += "../../doc/tutorial_surface.md"
+INPUT                 += "../../doc/tutorial_grid_surface.md"
+INPUT                 += "../../doc/tutorial_polar.md"
+INPUT                 += "../../doc/tutorial_sphere.md"
+
+INPUT_ENCODING         = UTF-8
+
+FILE_PATTERNS          = *.F90 \
+                         *.f90 \
+                         *.f95 \
+                         *.f03 \
+                         *.f08 \
+                         *.f18 \
+                         *.f \
+                         *.for \
+                         *.md
+
+RECURSIVE              = YES
+EXCLUDE                =
+EXCLUDE_SYMLINKS       = NO
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
+EXAMPLE_PATTERNS       =
+EXAMPLE_RECURSIVE      = NO
+IMAGE_PATH             = "../../doc/media"
+INPUT_FILTER           =
+FILTER_PATTERNS        =
+FILTER_SOURCE_FILES    = NO
+FILTER_SOURCE_PATTERNS =
+
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+SOURCE_BROWSER         = NO
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = NO
+REFERENCES_RELATION    = NO
+REFERENCES_LINK_SOURCE = YES
+USE_HTAGS              = NO
+VERBATIM_HEADERS       = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+ALPHABETICAL_INDEX     = YES
+IGNORE_PREFIX          =
+
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+HTML_HEADER            = header.html
+HTML_FOOTER            =
+HTML_STYLESHEET        =
+HTML_COLORSTYLE        = LIGHT
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_DYNAMIC_MENUS     = YES
+HTML_DYNAMIC_SECTIONS  = NO
+HTML_EXTRA_FILES       = doxygen-awesome-darkmode-toggle.js
+HTML_EXTRA_STYLESHEET  = doxygen-awesome.css
+GENERATE_DOCSET        = NO
+DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_NAME  = Publisher
+GENERATE_HTMLHELP      = NO
+CHM_FILE               =
+HHC_LOCATION           =
+GENERATE_CHI           = NO
+CHM_INDEX_ENCODING     =
+BINARY_TOC             = NO
+TOC_EXPAND             = NO
+GENERATE_QHP           = NO
+QCH_FILE               =
+QHP_NAMESPACE          = org.doxygen.Project
+QHP_VIRTUAL_FOLDER     = doc
+QHP_CUST_FILTER_NAME   =
+QHP_CUST_FILTER_ATTRS  =
+QHP_SECT_FILTER_ATTRS  =
+QHG_LOCATION           =
+GENERATE_ECLIPSEHELP   = NO
+ECLIPSE_DOC_ID         = org.doxygen.Project
+DISABLE_INDEX          = NO
+ENUM_VALUES_PER_LINE   = 4
+GENERATE_TREEVIEW      = YES
+FULL_SIDEBAR           = NO
+TREEVIEW_WIDTH         = 250
+EXT_LINKS_IN_WINDOW    = NO
+FORMULA_FONTSIZE       = 16
+USE_MATHJAX            = YES
+MATHJAX_RELPATH        = https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/
+SEARCHENGINE           = YES
+SERVER_BASED_SEARCH    = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+LATEX_OUTPUT           = latex
+LATEX_CMD_NAME         = latex
+MAKEINDEX_CMD_NAME     = makeindex
+COMPACT_LATEX          = NO
+PAPER_TYPE             = a4
+EXTRA_PACKAGES         = {amsmath}
+EXTRA_PACKAGES        += {amssymb}
+LATEX_HEADER           =
+PDF_HYPERLINKS         = YES
+USE_PDFLATEX           = YES
+LATEX_BATCHMODE        = NO
+LATEX_HIDE_INDICES     = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+GENERATE_RTF           = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+GENERATE_MAN           = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+GENERATE_XML           = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the Perl module output
+#---------------------------------------------------------------------------
+GENERATE_PERLMOD       = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+SEARCH_INCLUDES        = YES
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
+SKIP_FUNCTION_MACROS   = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+TAGFILES               =
+GENERATE_TAGFILE       =
+ALLEXTERNALS           = NO
+EXTERNAL_GROUPS        = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to the dot tool
+#---------------------------------------------------------------------------
+HIDE_UNDOC_RELATIONS   = YES
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+DOT_FONTPATH           =
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+UML_LOOK               = NO
+TEMPLATE_RELATIONS     = NO
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = YES
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = png
+DOT_PATH               =
+DOTFILE_DIRS           =
+MSCFILE_DIRS           =
+DOT_GRAPH_MAX_NODES    = 50
+MAX_DOT_GRAPH_DEPTH    = 0
+DOT_MULTI_TARGETS      = NO
+GENERATE_LEGEND        = YES
+DOT_CLEANUP            = YES


### PR DESCRIPTION
- Restore `project/doxygen/Doxyfile` and `doc/mainpage.md` which were accidentally replaced with `git show` output during the PR #49 rebase (commit message + unified diff instead of actual content). This broke the theme, MathJax, and page content on the Doxygen site.
- Replace `\tfrac` with `\frac` in periodic curve and sphere tutorials — MathJax 2.x does not define `\tfrac` by default.