### PR TITLE
Add Doxygen documentation to core and OOP wrapper routines

### DIFF
--- a/docs/refactoring/09_doxygen_mathjax_plan.md
+++ b/docs/refactoring/09_doxygen_mathjax_plan.md
@@ -8,59 +8,19 @@ defined in `docs/refactoring/03_doxygen_convention.md`. The goal is a profession
 (like [fortran-lapack](https://perazz.github.io/fortran-lapack/)) with dark mode, MathJax equations,
 and cross-referenced API docs.
 
-This is a large PR — it touches every source file. The plan breaks it into sequential,
-independently-testable steps.
+---
+
+## Phase A: Infrastructure Setup — COMPLETE
+
+All infrastructure is in place:
+- `project/doxygen/` — Doxyfile, theme CSS, dark mode JS, header
+- `doc/mainpage.md` — Landing page
+- `.github/workflows/deploy-docs.yml` — GitHub Pages deployment
+- `.gitignore` — excludes `project/doxygen/html/`
 
 ---
 
-## Phase A: Infrastructure Setup
-
-### A1. Create `project/doxygen/` directory with theme files
-
-Copy from `~/code/fortran-lapack/project/doxygen/`:
-- `Doxyfile` — adapt for fitpack (project name, input paths, warn log path)
-- `header.html` — unchanged (dark mode toggle init)
-- `doxygen-awesome.css` — unchanged (2,681 lines)
-- `doxygen-awesome-darkmode-toggle.js` — unchanged (258 lines)
-
-Key Doxyfile changes from fortran-lapack:
-```
-PROJECT_NAME           = fitpack
-INPUT                  = "../../src/"
-INPUT                 += "../../doc/mainpage.md"
-USE_MDFILE_AS_MAINPAGE = "../../doc/mainpage.md"
-EXTENSION_MAPPING      = .F90=FortranFree
-EXAMPLE_PATH           = "../../example/"
-WARN_LOGFILE           = ""
-EXTRACT_PRIVATE        = NO
-CALL_GRAPH             = YES
-CALLER_GRAPH           = NO
-```
-
-### A2. Create `doc/mainpage.md` — Doxygen landing page
-
-High-level overview page (NOT the README — Doxygen main page is separate):
-- Project description and purpose
-- Links to type hierarchy overview
-- Quick-start code examples
-- Links to book reference
-
-### A3. Create `.github/workflows/deploy-docs.yml`
-
-Copy from fortran-lapack, same structure:
-- Trigger on push to `main`
-- Install doxygen 1.13.2, texlive-full, ghostscript, graphviz
-- Run `cd project/doxygen && doxygen`
-- Create `.nojekyll`
-- Deploy to `gh-pages` via `peaceiris/actions-gh-pages@v3`
-
-### A4. Add `project/doxygen/html/` to `.gitignore`
-
-### A5. Verify: run `doxygen` locally, open HTML, confirm theme renders
-
----
-
-## Phase B: Core Routine Documentation (`fitpack_core.F90`)
+## Phase B: Core Routine Documentation (`fitpack_core.F90`) — COMPLETE
 
 Each routine gets a new Doxygen comment block placed **immediately before** the
 `subroutine`/`function` statement. The existing F77-style comments inside the routine body
@@ -79,102 +39,102 @@ Math syntax: `\f$ inline \f$`, `\f[ display \f]`, `\tag{N.M}` for book equation 
 
 Small, self-contained routines — good warm-up, establish the pattern.
 
-| Routine | Line | Book ref | Key equations |
-|---------|------|----------|---------------|
-| `fpgivs` | 5500 | §4.1.2, pp.55-58 | 4.15, 4.16 |
-| `fprota` | 11402 | §4.1.2, pp.55-58 | 4.15 |
-| `fpback` | 2368 | §4.1.2, pp.55-58 | 4.14 |
-| `fpbacp` | 2406 | §6.1, pp.95-100 | 6.6 |
-| `fpbspl` | 2721 | §1.3, pp.8-11 | 1.22, 1.30 |
-| `fpdisc` | 5356 | §5.2.2, pp.76-79 | 5.5, 5.6 |
-| `fprati` | 10973 | §5.2.4, pp.83-86 | 5.30-5.32 |
-| `fpchec` | (in fpcons area) | §4.1.1, pp.53-55 | 4.5, 4.17 |
-| `fpbisp` | 2648 | §2.1.2, pp.28-30 | 2.14-2.17 |
-| `fporde` | 8121 | §9.1, pp.147-150 | — |
+| Routine | Book ref | Key equations |
+|---------|----------|---------------|
+| `fpgivs` | §4.1.2, pp.55-58 | 4.15, 4.16 |
+| `fprota` | §4.1.2, pp.55-58 | 4.15 |
+| `fpback` | §4.1.2, pp.55-58 | 4.14 |
+| `fpbacp` | §6.1, pp.95-100 | 6.6 |
+| `fpbspl` | §1.3, pp.8-11 | 1.22, 1.30 |
+| `fpdisc` | §5.2.2, pp.76-79 | 5.5, 5.6 |
+| `fprati` | §5.2.4, pp.83-86 | 5.30-5.32 |
+| `fpchec` | §4.1.1, pp.53-55 | 4.5, 4.17 |
+| `fpbisp` | §2.1.2, pp.28-30 | 2.14-2.17 |
+| `fporde` | §9.1, pp.147-150 | — |
 
 ### B2. Refactored Givens rotation helpers (9 routines)
 
 These already have Doxygen comments — review and enhance with book refs:
 
-| Routine | Line | Book ref |
-|---------|------|----------|
-| `fp_rotate_row` | 5537 | §4.1.2, Eq.4.15 |
-| `fp_rotate_row_vec` | 5569 | §4.1.2, Eq.4.15 |
-| `fp_rotate_shifted` | 5608 | §5.2.2, Eq.5.15 |
-| `fp_rotate_shifted_vec` | 5642 | §5.2.2, Eq.5.15 |
-| `fp_rotate_row_2mat_vec` | 5675 | §6.1, Eq.6.4 |
-| `fp_rotate_row_2mat` | 5716 | §6.1, Eq.6.4 |
-| `fp_rotate_row_block` | 5758 | §10.2, Eq.10.4-10.8 |
-| `fp_rotate_row_stride` | 5783 | §10.2, Eq.10.8 |
-| `fp_rotate_2mat_stride` | 5808 | §10.2, Eq.10.8 |
+| Routine | Book ref |
+|---------|----------|
+| `fp_rotate_row` | §4.1.2, Eq.4.15 |
+| `fp_rotate_row_vec` | §4.1.2, Eq.4.15 |
+| `fp_rotate_shifted` | §5.2.2, Eq.5.15 |
+| `fp_rotate_shifted_vec` | §5.2.2, Eq.5.15 |
+| `fp_rotate_row_2mat_vec` | §6.1, Eq.6.4 |
+| `fp_rotate_row_2mat` | §6.1, Eq.6.4 |
+| `fp_rotate_row_block` | §10.2, Eq.10.4-10.8 |
+| `fp_rotate_row_stride` | §10.2, Eq.10.8 |
+| `fp_rotate_2mat_stride` | §10.2, Eq.10.8 |
 
 ### B3. Knot/tree/polynomial utilities (9 routines)
 
-| Routine | Line | Book ref | Key equations |
-|---------|------|----------|---------------|
-| `fpknot` | 7632 | §5.3, pp.87-94 | 5.37-5.43 |
-| `fprank` | 10738 | §9.1.2, pp.150-152 | 9.8-9.10 |
-| `fpinst` | 7426 | §4.2, pp.63-65 | — |
-| `fpintb` | 7494 | §3.2, pp.44-46 | 3.8-3.10 |
-| `fpadno` | 2229 | §7.2, pp.125-130 | — |
-| `fpdeno` | 5266 | §7.2, pp.125-130 | — |
-| `fpfrno` | 5405 | §7.2, pp.125-130 | — |
-| `fpseno` | 11560 | §7.2, pp.125-130 | — |
-| `fpcuro` | 5071 | — | cubic polynomial roots |
+| Routine | Book ref | Key equations |
+|---------|----------|---------------|
+| `fpknot` | §5.3, pp.87-94 | 5.37-5.43 |
+| `fprank` | §9.1.2, pp.150-152 | 9.8-9.10 |
+| `fpinst` | §4.2, pp.63-65 | — |
+| `fpintb` | §3.2, pp.44-46 | 3.8-3.10 |
+| `fpadno` | §7.2, pp.125-130 | — |
+| `fpdeno` | §7.2, pp.125-130 | — |
+| `fpfrno` | §7.2, pp.125-130 | — |
+| `fpseno` | §7.2, pp.125-130 | — |
+| `fpcuro` | — | cubic polynomial roots |
 
 ### B4. Cyclic/polynomial helpers (5 routines)
 
-| Routine | Line | Book ref |
-|---------|------|----------|
-| `fpcyt1` | 5183 | §6.1, pp.95-100, Eq.6.5-6.6 |
-| `fpcyt2` | 5232 | §6.1, pp.95-100 |
-| `fppocu` | 9478 | §7.1, pp.115-120 |
-| `fpcoco` | 3670 | §7.2, pp.125-130 |
-| `fpcosp` | 4275 | §7.1, pp.115-120 |
+| Routine | Book ref |
+|---------|----------|
+| `fpcyt1` | §6.1, pp.95-100, Eq.6.5-6.6 |
+| `fpcyt2` | §6.1, pp.95-100 |
+| `fppocu` | §7.1, pp.115-120 |
+| `fpcoco` | §7.2, pp.125-130 |
+| `fpcosp` | §7.1, pp.115-120 |
 
 ### B5. Core fitting algorithms (9 routines)
 
 The big ones — these need the most detailed documentation with full equation chains.
 
-| Routine | Line | Book ref | Key equations |
-|---------|------|----------|---------------|
-| `fpcurf` | 4717 | §4.1-5.3, pp.53-94 | 4.12, 5.10, 5.37 |
-| `fpcons` | 3864 | §8.2, pp.141-146 | — |
-| `fpclos` | 3031 | §6.1-6.2, pp.95-112 | 6.1-6.8 |
-| `fppara` | 8156 | §6.3, pp.112-114 | 6.9 |
-| `fpperi` | 8906 | §6.1-6.2, pp.95-112 | 6.1-6.8 |
-| `fpsurf` | 12808 | §9.1-9.2, pp.147-167 | 9.2-9.6 |
-| `fppola` | 9954 | §11.1, pp.197-205 | 11.1-11.9 |
-| `fpsphe` | 12044 | §11.2, pp.205-213 | 11.12-11.16 |
-| `fppasu` | 8514 | §10.3, pp.173-178 | 10.9-10.12 |
+| Routine | Book ref | Key equations |
+|---------|----------|---------------|
+| `fpcurf` | §4.1-5.3, pp.53-94 | 4.12, 5.10, 5.37 |
+| `fpcons` | §8.2, pp.141-146 | — |
+| `fpclos` | §6.1-6.2, pp.95-112 | 6.1-6.8 |
+| `fppara` | §6.3, pp.112-114 | 6.9 |
+| `fpperi` | §6.1-6.2, pp.95-112 | 6.1-6.8 |
+| `fpsurf` | §9.1-9.2, pp.147-167 | 9.2-9.6 |
+| `fppola` | §11.1, pp.197-205 | 11.1-11.9 |
+| `fpsphe` | §11.2, pp.205-213 | 11.12-11.16 |
+| `fppasu` | §10.3, pp.173-178 | 10.9-10.12 |
 
 ### B6. Grid fitting algorithms (6 routines)
 
-| Routine | Line | Book ref | Key equations |
-|---------|------|----------|---------------|
-| `fpgrre` | 6655 | §10.2, pp.170-172 | 10.4-10.8 |
-| `fpgrdi` | 5844 | §10.2, pp.170-172 | 10.4-10.8 |
-| `fptrnp` | 13488 | §10.2, pp.170-172 | 10.8 |
-| `fptrpe` | 13574 | §10.2, pp.170-172 | 10.8 (periodic) |
-| `fpgrsp` | 6913 | §11.2, pp.205-213 | — |
-| `fpgrpa` | 6316 | §10.3, pp.173-178 | — |
+| Routine | Book ref | Key equations |
+|---------|----------|---------------|
+| `fpgrre` | §10.2, pp.170-172 | 10.4-10.8 |
+| `fpgrdi` | §10.2, pp.170-172 | 10.4-10.8 |
+| `fptrnp` | §10.2, pp.170-172 | 10.8 |
+| `fptrpe` | §10.2, pp.170-172 | 10.8 (periodic) |
+| `fpgrsp` | §11.2, pp.205-213 | — |
+| `fpgrpa` | §10.3, pp.173-178 | — |
 
-### B7. Specialized helpers (7 routines)
+### B7. Specialized helpers (12 routines)
 
-| Routine | Line | Book ref |
-|---------|------|----------|
-| `fpcsin` | 4664 | §3.3, Fourier integrals |
-| `fpbfou` | 2469 | §3.3, Fourier coefficients |
-| `fpadpo` | 2301 | §7.1, polynomial spline |
-| `fprppo` | 11423 | §11.1, polar representation |
-| `fprpsp` | 11498 | §11.2, spherical representation |
-| `fpopdi` | 7740 | §11.1, polar derivatives |
-| `fpopsp` | 7890 | §11.2, spherical operations |
-| `fpsysy` | 13429 | — symmetric system solve |
-| `sort_xy` | 13386 | — reorder scattered data |
-| `fppogr` | 9548 | §11.1, polar grid fitting |
-| `fpspgr` | 11596 | §11.2, spherical grid setup |
-| `fpregr` | 11005 | §10.2, regression residuals |
+| Routine | Book ref |
+|---------|----------|
+| `fpcsin` | §3.3, Fourier integrals |
+| `fpbfou` | §3.3, Fourier coefficients |
+| `fpadpo` | §7.1, polynomial spline |
+| `fprppo` | §11.1, polar representation |
+| `fprpsp` | §11.2, spherical representation |
+| `fpopdi` | §11.1, polar derivatives |
+| `fpopsp` | §11.2, spherical operations |
+| `fpsysy` | — symmetric system solve |
+| `sort_xy` | — reorder scattered data |
+| `fppogr` | §11.1, polar grid fitting |
+| `fpspgr` | §11.2, spherical grid setup |
+| `fpregr` | §10.2, regression residuals |
 
 ### B8. Public API wrappers (30 routines)
 
@@ -195,164 +155,64 @@ Preserve ALL original content (parameter descriptions, error codes, usage guidan
 
 ### B9. Utility/error/comm routines (~15 routines)
 
-| Routine | Line | Notes |
-|---------|------|-------|
-| `fitpack_error_handling` | 214 | Error handler |
-| `FITPACK_MESSAGE` | 228 | Error code → string |
-| `FITPACK_SUCCESS` | 292 | Check success |
-| `get_smoothing` | 258 | Smoothing parameter logic |
-| `IOPT_MESSAGE` | 280 | iopt → string |
-| `fp_knot_interval` | 2756 | Already has Doxygen — review |
-| `fitpack_argsort` | 18151 | Index sort |
-| `equal`, `not_equal` | 18294 | Float comparison |
-| `swap_data`, `swap_size` | 18255 | Element swap |
-| `FP_*_COMM_*` | 18308+ | Already have Doxygen — review |
+| Routine | Notes |
+|---------|-------|
+| `fitpack_error_handling` | Error handler |
+| `FITPACK_MESSAGE` | Error code → string |
+| `FITPACK_SUCCESS` | Check success |
+| `get_smoothing` | Smoothing parameter logic |
+| `IOPT_MESSAGE` | iopt → string |
+| `fp_knot_interval` | Already has Doxygen — review |
+| `fitpack_argsort` | Index sort |
+| `equal`, `not_equal` | Float comparison |
+| `swap_data`, `swap_size` | Element swap |
+| `FP_*_COMM_*` | Already have Doxygen — review |
 
 ---
 
-## Phase C: OOP API Documentation
+## Phase C: OOP API Documentation — PARTIALLY COMPLETE
 
-Each OOP type gets a Doxygen comment block on the `type` declaration and on each
-public method. These reference the book but focus on **usage**: what the type represents,
-how to use each method, what the parameters mean.
+All OOP modules already have module-level `!> @brief` documentation. Remaining work:
+type-level and method-level Doxygen blocks for each public type-bound procedure.
 
-### C1. Abstract base: `fitpack_fitter` (`src/fitpack_fitters.f90`)
+### C1–C9: Type/method documentation
 
-Document: type overview, `mse()`, `fitting_status()`, `destroy_base()`, comm interfaces.
-
-### C2. Curve types (`src/fitpack_curves.f90`)
-
-- `fitpack_curve` — full documentation: constructor, `new_fit`, `fit`, `interpolate`,
-  `least_squares`, `eval`, `dfdx`, `dfdx_all`, `integral`, `zeros`,
-  `fourier_coefficients`, `insert_knot`, `destroy`, comm methods
-- `fitpack_periodic_curve` — brief (marker type, inherits everything)
-
-### C3. Convex curve (`src/fitpack_convex_curves.f90`)
-
-- `fitpack_convex_curve` — `set_convexity`, `fit` (concon), `least_squares` (cocosp)
-
-### C4. Parametric curves (`src/fitpack_parametric_curves.f90`)
-
-- `fitpack_parametric_curve` — constructor, `eval` (returns multi-dim), `dfdx`, `dfdx_all`
-- `fitpack_closed_curve` — brief
-- `fitpack_constrained_curve` — `set_constraints`, derivative boundary conditions
-
-### C5. Surface types (`src/fitpack_surfaces.f90`, `src/fitpack_grid_surfaces.f90`)
-
-- `fitpack_surface` — full: `eval` (scattered, bispeu), `eval_ongrid` (grid, bispev),
-  `dfdx`, `dfdx_ongrid`, `integral`, `cross_section`, `derivative_spline`
-- `fitpack_grid_surface` — same methods, note eval/eval_ongrid distinction
-
-### C6. Parametric surface (`src/fitpack_parametric_surfaces.f90`)
-
-- `fitpack_parametric_surface` — `eval`, periodicity, `idim`
-
-### C7. Polar types (`src/fitpack_polar.f90`, `src/fitpack_gridded_polar.f90`)
-
-- `fitpack_polar` — boundary function pointer, origin continuity, eval in Cartesian
-- `fitpack_grid_polar` — origin BC, grid structure
-
-### C8. Sphere types (`src/fitpack_spheres.f90`, `src/fitpack_gridded_sphere.f90`)
-
-- `fitpack_sphere` — theta/phi coordinates, pole handling
-- `fitpack_grid_sphere` — pole BC, grid structure
-
-### C9. Umbrella module (`src/fitpack.f90`)
-
-Document the module itself: what it exports, how to use it.
+| Module | Status |
+|--------|--------|
+| `fitpack_fitters.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack_curves.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack_convex_curves.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack_parametric.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack_surfaces.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack_grid_surfaces.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack_parametric_surfaces.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack_polar.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack_gridded_polar.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack_spheres.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack_gridded_sphere.f90` | Module `@brief` done; type/method docs needed |
+| `fitpack.f90` | Module `@brief` done |
 
 ---
 
-## Phase D: Tutorial / Guide Pages
+## Phase D: Tutorial / Guide Pages — COMPLETE
 
-### D1. `doc/mainpage.md` — Landing page (created in A2)
-
-- What is FITPACK?
-- Type hierarchy diagram (text-based)
-- Quick-start: fit a curve in 5 lines
-- Link to tutorials below
-
-### D2. `doc/tutorial_curves.md` — Curve fitting tutorial
-
-- Basic curve fitting workflow
-- Smoothing parameter guidance (from book §5.2.4)
-- Periodic curves
-- Parametric curves
-- Convexity constraints
-- Evaluation, derivatives, integration, roots
-
-### D3. `doc/tutorial_surfaces.md` — Surface fitting tutorial
-
-- Scattered vs gridded data
-- Smoothing, interpolation, least-squares
-- Evaluation (scattered vs grid)
-- Cross-sections, integration, derivative splines
-
-### D4. `doc/tutorial_special.md` — Polar & spherical domains
-
-- Polar coordinates, boundary functions
-- Spherical coordinates, pole handling
-- Grid vs scattered variants
-
-### D5. `doc/book_reference.md` — Book equation index
-
-Quick-reference table mapping FITPACK routines to book chapters/equations.
+All tutorial and reference pages exist:
+- `doc/mainpage.md` — Landing page
+- `doc/tutorial_curve.md` — Curve fitting
+- `doc/tutorial_periodic_curve.md` — Periodic curves
+- `doc/tutorial_parametric_curves.md` — Parametric curves
+- `doc/tutorial_convex_curve.md` — Convex curves
+- `doc/tutorial_surface.md` — Surface fitting
+- `doc/tutorial_grid_surface.md` — Grid surface fitting
+- `doc/tutorial_polar.md` — Polar domains
+- `doc/tutorial_sphere.md` — Spherical domains
+- `doc/book_reference.md` — Book equation index
 
 ---
 
 ## Phase E: Verification
 
-1. `fpm build && fpm test` — all 59 tests pass (no code changes, only comments)
+1. `fpm build && fpm test` — all tests pass (no code changes, only comments)
 2. `cd project/doxygen && doxygen` — builds without errors/warnings
-3. Open `project/doxygen/html/index.html` — verify:
-   - Dark mode toggle works
-   - MathJax equations render
-   - Type hierarchy visible
-   - Cross-references link correctly
-   - Tutorial pages accessible
+3. Open `project/doxygen/html/index.html` — verify rendering
 4. Push to branch, verify GitHub Actions deploys to gh-pages
-
----
-
-## Files Created
-
-| File | Description |
-|------|-------------|
-| `project/doxygen/Doxyfile` | Doxygen configuration |
-| `project/doxygen/header.html` | Custom HTML header (dark mode) |
-| `project/doxygen/doxygen-awesome.css` | Theme CSS |
-| `project/doxygen/doxygen-awesome-darkmode-toggle.js` | Dark mode JS |
-| `.github/workflows/deploy-docs.yml` | GitHub Pages deployment |
-| `doc/mainpage.md` | Landing page |
-| `doc/tutorial_curves.md` | Curve fitting guide |
-| `doc/tutorial_surfaces.md` | Surface fitting guide |
-| `doc/tutorial_special.md` | Polar/sphere guide |
-| `doc/book_reference.md` | Book equation index |
-
-## Files Modified
-
-| File | Changes |
-|------|---------|
-| `src/fitpack_core.F90` | Add Doxygen blocks to ~112 routines |
-| `src/fitpack.f90` | Add module-level Doxygen comment |
-| `src/fitpack_fitters.f90` | Add type/method Doxygen comments |
-| `src/fitpack_curves.f90` | Add type/method Doxygen comments |
-| `src/fitpack_convex_curves.f90` | Add type/method Doxygen comments |
-| `src/fitpack_parametric_curves.f90` | Add type/method Doxygen comments |
-| `src/fitpack_surfaces.f90` | Add type/method Doxygen comments |
-| `src/fitpack_grid_surfaces.f90` | Add type/method Doxygen comments |
-| `src/fitpack_parametric_surfaces.f90` | Add type/method Doxygen comments |
-| `src/fitpack_polar.f90` | Add type/method Doxygen comments |
-| `src/fitpack_gridded_polar.f90` | Add type/method Doxygen comments |
-| `src/fitpack_spheres.f90` | Add type/method Doxygen comments |
-| `src/fitpack_gridded_sphere.f90` | Add type/method Doxygen comments |
-| `.gitignore` | Add `project/doxygen/html/` |
-
-## Execution Order
-
-Phases A → B → C → D → E. Within Phase B, steps B1-B9 are sequential (each
-establishes patterns the next follows). Phase C can partially overlap with late
-Phase B. Phase D can be written in parallel with Phase C.
-
-Given the size (~112 core routines + 13 OOP types + 5 guide pages), this will
-be split into multiple sub-PRs or done as one large documentation PR.

--- a/src/fitpack_grid_surfaces.f90
+++ b/src/fitpack_grid_surfaces.f90
@@ -125,7 +125,9 @@ module fitpack_grid_surfaces
 
     contains
 
-    ! Fit a surface to least squares of the current knots
+    !> @brief Fit a least-squares gridded surface with fixed knots.
+    !!
+    !! @see regrid
     integer function surface_fit_least_squares(this,smoothing,reset_knots) result(ierr)
        class(fitpack_grid_surface), intent(inout) :: this
        real(FP_REAL), optional, intent(in) :: smoothing
@@ -146,7 +148,9 @@ module fitpack_grid_surfaces
 
     end function surface_fit_least_squares
 
-    ! Find interpolating surface
+    !> @brief Fit an interpolating gridded surface (\f$ s = 0 \f$).
+    !!
+    !! @see regrid
     integer function surface_fit_interpolating(this,reset_knots) result(ierr)
         class(fitpack_grid_surface), intent(inout) :: this
         logical, optional, intent(in) :: reset_knots
@@ -160,7 +164,12 @@ module fitpack_grid_surfaces
     end function surface_fit_interpolating
 
 
-    ! Fit a surface z = s(x,y) defined on a meshgrid: x[1:n], y[1:m]
+    !> @brief Fit a smoothing gridded surface with automatic knot placement.
+    !!
+    !! Uses the regrid core routine, which exploits the rectangular grid structure for
+    !! efficiency.
+    !!
+    !! @see regrid
     integer(FP_FLAG) function surface_fit_automatic_knots(this,smoothing,order,keep_knots) result(ierr)
         class(fitpack_grid_surface), intent(inout) :: this
         real(FP_REAL), optional, intent(in) :: smoothing
@@ -209,6 +218,7 @@ module fitpack_grid_surfaces
     end function surface_fit_automatic_knots
 
 
+    !> @brief Destroy a grid surface object and release all allocated memory.
     elemental subroutine surf_destroy(this)
        class(fitpack_grid_surface), intent(inout) :: this
        integer :: ierr
@@ -229,6 +239,14 @@ module fitpack_grid_surfaces
 
     end subroutine surf_destroy
 
+    !> @brief Load new gridded data and allocate workspace.
+    !!
+    !! @param[in,out] this  The grid surface (destroyed and reinitialized).
+    !! @param[in]     x     Grid coordinates in the x direction.
+    !! @param[in]     y     Grid coordinates in the y direction.
+    !! @param[in]     z     Function values `z(j,i)` = \f$ f(x_i, y_j) \f$.
+    !!
+    !! @see regrid
     subroutine surf_new_points(this,x,y,z)
         class(fitpack_grid_surface), intent(inout) :: this
         real(FP_REAL), intent(in) :: x(:),y(:),z(size(y),size(x))
@@ -284,7 +302,9 @@ module fitpack_grid_surfaces
 
     end subroutine surf_new_points
 
-    ! A default constructor
+    !> @brief Construct a grid surface from gridded data and perform a default fit.
+    !!
+    !! @see regrid
     type(fitpack_grid_surface) function surf_new_from_points(x,y,z,ierr) result(this)
         real(FP_REAL), intent(in) :: x(:),y(:),z(size(y),size(x))
         integer(FP_FLAG), optional, intent(out) :: ierr
@@ -298,7 +318,9 @@ module fitpack_grid_surfaces
 
     end function surf_new_from_points
 
-    ! Fit a new curve
+    !> @brief Load new gridded data and perform a fresh fit.
+    !!
+    !! @see regrid
     integer function surf_new_fit(this,x,y,z,smoothing,order)
         class(fitpack_grid_surface), intent(inout) :: this
         real(FP_REAL), intent(in) :: x(:),y(:),z(size(y),size(x))
@@ -311,7 +333,9 @@ module fitpack_grid_surfaces
 
     end function surf_new_fit
 
-    !> Evaluate surface at a list of scattered (x(i),y(i)) points using bispeu
+    !> @brief Evaluate the grid surface at scattered \f$ (x_i, y_i) \f$ points.
+    !!
+    !! @see bispeu
     function gridsurf_eval_many(this,x,y,ierr) result(f)
         class(fitpack_grid_surface), intent(inout) :: this
         real(FP_REAL), intent(in) :: x(:),y(size(x))
@@ -338,7 +362,9 @@ module fitpack_grid_surfaces
 
     end function gridsurf_eval_many
 
-    !> Evaluate surface at a single (x,y) point using bispeu
+    !> @brief Evaluate the grid surface at a single \f$ (x, y) \f$ point.
+    !!
+    !! @see bispeu
     real(FP_REAL) function gridsurf_eval_one(this,x,y,ierr) result(f)
         class(fitpack_grid_surface), intent(inout) :: this
         real(FP_REAL), intent(in) :: x,y
@@ -351,7 +377,11 @@ module fitpack_grid_surfaces
 
     end function gridsurf_eval_one
 
-    !> Evaluate surface on a grid of x(:) x y(:) points using bispev
+    !> @brief Evaluate the grid surface on a rectangular evaluation grid.
+    !!
+    !! Returns `f(j,i)` = \f$ s(x_i, y_j) \f$.
+    !!
+    !! @see bispev
     function gridded_eval_many(this,x,y,ierr) result(f)
         class(fitpack_grid_surface), intent(inout)  :: this
         real(FP_REAL), intent(in) :: x(:),y(:)  ! Evaluation points
@@ -379,7 +409,7 @@ module fitpack_grid_surfaces
 
     end function gridded_eval_many
 
-    ! Curve evaluation driver
+    !> @brief Evaluate the grid surface at a single grid point via bispev.
     real(FP_REAL) function gridded_eval_one(this,x,y,ierr) result(f)
         class(fitpack_grid_surface), intent(inout)  :: this
         real(FP_REAL),               intent(in)      :: x,y ! Evaluation point
@@ -391,7 +421,9 @@ module fitpack_grid_surfaces
 
     end function gridded_eval_one
 
-    !> Evaluate derivatives on a grid domain
+    !> @brief Evaluate partial derivatives on a rectangular grid.
+    !!
+    !! @see parder
     function gridded_derivatives_gridded(this,x,y,dx,dy,ierr) result(f)
         class(fitpack_grid_surface), intent(inout)  :: this
         
@@ -449,7 +481,9 @@ module fitpack_grid_surfaces
 
     end function gridded_derivatives_gridded
 
-    !> Evaluate derivatives on a list of (x(i),y(i)) points
+    !> @brief Evaluate partial derivatives at scattered \f$ (x_i, y_i) \f$ points.
+    !!
+    !! @see pardeu
     function gridded_derivatives_many(this,x,y,dx,dy,ierr) result(f)
         class(fitpack_grid_surface), intent(inout)  :: this
         
@@ -515,6 +549,9 @@ module fitpack_grid_surfaces
 
     end function gridded_derivatives_many
 
+    !> @brief Evaluate a partial derivative at a single \f$ (x, y) \f$ point.
+    !!
+    !! @see pardeu
     real(FP_REAL) function gridded_derivatives_one(this,x,y,dx,dy,ierr) result(f)
         class(fitpack_grid_surface), intent(inout) :: this
         
@@ -537,7 +574,9 @@ module fitpack_grid_surfaces
 
     end function gridded_derivatives_one
 
-    !> Double integration of the surface over a rectangular domain [lower(1),upper(1)] x [lower(2),upper(2)]
+    !> @brief Compute the double integral of the grid surface over a rectangular domain.
+    !!
+    !! @see dblint
     real(FP_REAL) function gridsurf_integral(this, lower, upper)
         class(fitpack_grid_surface), intent(in) :: this
         real(FP_REAL), intent(in) :: lower(2), upper(2)
@@ -552,8 +591,11 @@ module fitpack_grid_surfaces
 
     end function gridsurf_integral
 
-    !> Extract a 1D cross-section from the surface.
-    !> If along_y=.true., returns f(y) = s(u,y); if along_y=.false., returns g(x) = s(x,u).
+    !> @brief Extract a 1D cross-section curve from the grid surface.
+    !!
+    !! If `along_y=.true.`, returns \f$ f(y) = s(u, y) \f$; otherwise \f$ g(x) = s(x, u) \f$.
+    !!
+    !! @see profil
     function gridsurf_cross_section(this, u, along_y, ierr) result(curve)
         class(fitpack_grid_surface), intent(in) :: this
         real(FP_REAL), intent(in) :: u
@@ -602,8 +644,11 @@ module fitpack_grid_surfaces
 
     end function gridsurf_cross_section
 
-    !> Compute the derivative spline d^(nux+nuy)s / dx^nux dy^nuy.
-    !> Returns a new grid surface with reduced order and trimmed knots.
+    !> @brief Compute the B-spline representation of a partial derivative surface.
+    !!
+    !! Returns a new grid surface with reduced degrees and trimmed knots.
+    !!
+    !! @see pardtc
     function gridsurf_derivative_spline(this, nux, nuy, ierr) result(dsurf)
         class(fitpack_grid_surface), intent(in) :: this
         integer(FP_SIZE), intent(in) :: nux, nuy
@@ -661,6 +706,7 @@ module fitpack_grid_surfaces
     ! PARALLEL COMMUNICATION
     ! =================================================================================================
 
+    !> @brief Return the communication buffer size for the grid surface.
     elemental integer(FP_SIZE) function gridsurf_comm_size(this)
         class(fitpack_grid_surface), intent(in) :: this
         ! Base fields + grid-surface-specific scalars:
@@ -673,6 +719,7 @@ module fitpack_grid_surfaces
                            + FP_COMM_SIZE(this%t)
     end function gridsurf_comm_size
 
+    !> @brief Pack grid surface data into a communication buffer.
     pure subroutine gridsurf_comm_pack(this, buffer)
         class(fitpack_grid_surface), intent(in) :: this
         real(FP_COMM), intent(out) :: buffer(:)
@@ -699,6 +746,7 @@ module fitpack_grid_surfaces
         call FP_COMM_PACK(this%t, buffer(pos:))
     end subroutine gridsurf_comm_pack
 
+    !> @brief Expand grid surface data from a communication buffer.
     pure subroutine gridsurf_comm_expand(this, buffer)
         class(fitpack_grid_surface), intent(inout) :: this
         real(FP_COMM), intent(in) :: buffer(:)

--- a/src/fitpack_polar.f90
+++ b/src/fitpack_polar.f90
@@ -116,7 +116,9 @@ module fitpack_polar_domains
 
     contains
 
-    ! Fit a surface to least squares of the current knots
+    !> @brief Fit a least-squares polar surface with fixed knots.
+    !!
+    !! @see polar
     integer function surface_fit_least_squares(this,smoothing,reset_knots) result(ierr)
        class(fitpack_polar), intent(inout) :: this
        real(FP_REAL), optional, intent(in) :: smoothing
@@ -137,7 +139,9 @@ module fitpack_polar_domains
 
     end function surface_fit_least_squares
 
-    ! Find interpolating surface
+    !> @brief Fit an interpolating polar surface (\f$ s = 0 \f$).
+    !!
+    !! @see polar
     integer function surface_fit_interpolating(this,reset_knots) result(ierr)
         class(fitpack_polar), intent(inout) :: this
         logical, optional, intent(in) :: reset_knots
@@ -150,7 +154,13 @@ module fitpack_polar_domains
 
     end function surface_fit_interpolating
 
-    ! Fit a surface z = s(x,y) defined on a meshgrid: x[1:n], y[1:m]
+    !> @brief Fit a smoothing polar surface with automatic knot placement.
+    !!
+    !! The fitting uses normalized polar coordinates \f$ (u, v) \f$ with a user-supplied
+    !! boundary function \f$ r(\theta) \f$. Continuity at the origin is controlled by
+    !! `bc_continuity_origin`.
+    !!
+    !! @see polar
     integer function surface_fit_automatic_knots(this,smoothing,keep_knots) result(ierr)
         class(fitpack_polar), intent(inout) :: this
         real(FP_REAL), optional, intent(in) :: smoothing
@@ -199,6 +209,7 @@ module fitpack_polar_domains
     end function surface_fit_automatic_knots
 
 
+    !> @brief Destroy a polar surface object and release all allocated memory.
     elemental subroutine polar_destroy(this)
        class(fitpack_polar), intent(inout) :: this
        integer :: ierr
@@ -222,6 +233,17 @@ module fitpack_polar_domains
 
     end subroutine polar_destroy
 
+    !> @brief Load new scattered data and a boundary function for polar fitting.
+    !!
+    !! @param[in,out] this         The polar surface (destroyed and reinitialized).
+    !! @param[in]     x            Cartesian x coordinates.
+    !! @param[in]     y            Cartesian y coordinates, same size as `x`.
+    !! @param[in]     z            Function values, same size as `x`.
+    !! @param[in]     boundary     Boundary function \f$ r(\theta) \f$ defining the polar domain.
+    !! @param[in]     w            Optional positive weights.
+    !! @param[in]     boundary_bc  Optional boundary extrapolation flag.
+    !!
+    !! @see polar
     subroutine polar_new_points(this,x,y,z,boundary,w,boundary_bc)
         class(fitpack_polar), intent(inout) :: this
         real(FP_REAL), intent(in) :: x(:),y(size(x)),z(size(x))
@@ -298,7 +320,9 @@ module fitpack_polar_domains
 
     end subroutine polar_new_points
 
-    ! A default constructor
+    !> @brief Construct a polar surface from scattered data and perform a default fit.
+    !!
+    !! @see polar
     type(fitpack_polar) function polr_new_from_points(x,y,z,boundary,w,boundary_bc,ierr) result(this)
         real(FP_REAL), intent(in) :: x(:),y(size(x)),z(size(x))
         procedure(fitpack_polar_boundary) :: boundary
@@ -315,6 +339,11 @@ module fitpack_polar_domains
 
     end function polr_new_from_points
 
+    !> @brief Evaluate the polar surface at a single Cartesian \f$ (x, y) \f$ point.
+    !!
+    !! Internally transforms to normalized polar coordinates before evaluation.
+    !!
+    !! @see evapol
     real(FP_REAL) function polr_eval_one(this,x,y,ierr) result(z)
         class(fitpack_polar), intent(inout)  :: this
         real(FP_REAL),          intent(in)     :: x,y    ! Evaluation point
@@ -330,7 +359,9 @@ module fitpack_polar_domains
 
     end function polr_eval_one
 
-    ! Curve evaluation driver
+    !> @brief Evaluate the polar surface at multiple Cartesian points.
+    !!
+    !! @see evapol
     function polr_eval_many(this,x,y,ierr) result(z)
         class(fitpack_polar), intent(inout)  :: this
         real(FP_REAL),          intent(in)     :: x(:),y(size(x)) ! Evaluation points
@@ -345,7 +376,9 @@ module fitpack_polar_domains
 
     end function polr_eval_many
 
-    ! Fit a new curve
+    !> @brief Load new data and perform a fresh polar surface fit.
+    !!
+    !! @see polar
     integer function polr_new_fit(this,x,y,z,boundary,w,boundary_bc,smoothing)
         class(fitpack_polar), intent(inout) :: this
         real(FP_REAL), intent(in) :: x(:),y(size(x)),z(size(x))
@@ -360,7 +393,7 @@ module fitpack_polar_domains
 
     end function polr_new_fit
 
-    ! Communication: buffer size
+    !> @brief Return the communication buffer size for the polar surface.
     elemental integer(FP_SIZE) function polar_comm_size(this)
         class(fitpack_polar), intent(in) :: this
         polar_comm_size = this%core_comm_size() &
@@ -375,7 +408,7 @@ module fitpack_polar_domains
                         + FP_COMM_SIZE(this%t)
     end function polar_comm_size
 
-    ! Communication: pack into buffer
+    !> @brief Pack polar surface data into a communication buffer.
     pure subroutine polar_comm_pack(this, buffer)
         class(fitpack_polar), intent(in) :: this
         real(FP_COMM), intent(out) :: buffer(:)
@@ -404,7 +437,7 @@ module fitpack_polar_domains
         call FP_COMM_PACK(this%t, buffer(pos:))
     end subroutine polar_comm_pack
 
-    ! Communication: expand from buffer
+    !> @brief Expand polar surface data from a communication buffer.
     pure subroutine polar_comm_expand(this, buffer)
         class(fitpack_polar), intent(inout) :: this
         real(FP_COMM), intent(in) :: buffer(:)


### PR DESCRIPTION
## Summary

- **Phase B**: Add Doxygen `@brief` blocks to all previously undocumented routines in `fitpack_core.F90` and clean up the Doxygen plan document
- **Phase C**: Add Doxygen `@brief` blocks with `@param`, `@return`, and `@see` cross-references to 152 OOP wrapper methods across 10 domain modules (curves, convex curves, parametric, surfaces, grid surfaces, parametric surfaces, polar, gridded polar, spheres, gridded sphere)
- Total `@brief` count in OOP files rises from 32 to 184; 12 files changed, +1018/−408 lines

## Test plan

- [x] `fpm build` compiles successfully
- [x] `fpm test` — all 59 tests pass
- [x] `grep -c '!> @brief'` confirms coverage increase across all 10 OOP files