### PR TITLE
N-D gridded core, slice 1: dimensionalize regrid/fpregr/fpgrre/fpbisp at dims=2 behind a bit-for-bit gate

### DIFF
--- a/include/fitpack_core_c.h
+++ b/include/fitpack_core_c.h
@@ -49,11 +49,11 @@ static const FP_FLAG IOPT_NEW_LEASTSQUARES = -1; // Request a new lsq fit
 static const FP_FLAG IOPT_NEW_SMOOTHING    =  0; // Request a new smoothing fit
 static const FP_FLAG IOPT_OLD_FIT          =  1; // Update an old fit
 
-//Dimensions of last knot addition
+//Dimension index of the last knot addition (0 = none yet; otherwise the 1-based axis ID)
 static const FP_SIZE MAX_IDIM      = 10; //Max number of dimensions
 static const FP_FLAG KNOT_DIM_NONE =  0; // No knots added yet
-static const FP_FLAG KNOT_DIM_2    =  1; // Last knot added on 2nd dim (y or v)
-static const FP_FLAG KNOT_DIM_1    = -1; // Last knot added on 1st dim (x or u)
+static const FP_FLAG KNOT_DIM_1    =  1; // Last knot added on 1st dim (x or u)
+static const FP_FLAG KNOT_DIM_2    =  2; // Last knot added on 2nd dim (y or v)
 
 //Spline degrees
 static const FP_SIZE MAX_ORDER = 19; // Max spline order (for array allocation)

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -108,11 +108,13 @@ module fitpack_core
     integer(FP_FLAG), parameter,  public :: IOPT_NEW_SMOOTHING    =  0 ! Request a new smoothing fit
     integer(FP_FLAG), parameter,  public :: IOPT_OLD_FIT          =  1 ! Update an old fit
 
-    ! Dimensions of last knot addition
+    ! Dimension index of the last knot addition. KNOT_DIM_NONE = none added yet; otherwise the
+    ! 1-based axis ID (1 = first dim x/u, 2 = second dim y/v, ... up to MAX_IDIM), so the value can
+    ! be used directly as an array/axis index. This generalizes to N dimensions.
     integer(FP_SIZE), parameter,  public :: MAX_IDIM      = 10  ! Max number of dimensions
     integer(FP_FLAG), parameter,  public :: KNOT_DIM_NONE =  0  ! No knots added yet
-    integer(FP_FLAG), parameter,  public :: KNOT_DIM_2    =  1  ! Last knot added on 2nd dim (y or v)
-    integer(FP_FLAG), parameter,  public :: KNOT_DIM_1    = -1  ! Last knot added on 1st dim (x or u)
+    integer(FP_FLAG), parameter,  public :: KNOT_DIM_1    =  1  ! Last knot added on 1st dim (x or u)
+    integer(FP_FLAG), parameter,  public :: KNOT_DIM_2    =  2  ! Last knot added on 2nd dim (y or v)
 
     ! Spline degrees
     integer(FP_SIZE), parameter, public :: MAX_ORDER = 19    ! Max spline order (for array allocation)
@@ -7345,6 +7347,10 @@ module fitpack_core
       integer(FP_SIZE), intent(in)    :: m(dims),k(dims),n(dims)
       integer(FP_SIZE), intent(inout) :: ifs(dims),ifb(dims)
       !  ..array arguments..
+      !  z(mz): gridded data tensor, flat. Row-major with axis 1 (x) SLOWEST and the last axis
+      !  FASTEST -- at dims=2 this is z(m(2),m(1)) = (ny_data,nx_data), NOT (nx,ny). Element
+      !  (i1,i2,...) lives at fp_grid_index([i1,i2,...],fp_grid_strides(m))+1; at dims=2 that is
+      !  (i-1)*my+j, which is exactly how the frozen kernels below read it (x-outer, y-inner).
       real(FP_REAL),    intent(in)              :: z(mz)
       real(FP_REAL),    intent(in),  contiguous :: xg(:,:),t(:,:)
       real(FP_REAL),    intent(inout)           :: c(nc),right(mm),q(mynx)
@@ -9721,9 +9727,8 @@ module fitpack_core
          endif
 
          ! test whether we are going to add knots in the u- or v-direction.
-         ! lastdi = last knot direction: lastdi==0  = not yet set
-         !                               lastdi==1  = v direction
-         !                               lastdi==-1 = u direction
+         ! lastdi = dimension index of last knot addition: KNOT_DIM_NONE = not yet set;
+         !          KNOT_DIM_1 = u direction; KNOT_DIM_2 = v direction
          lastdi = new_knot_dimension(nu,nplu,nue,nv,nplv,nve,lastdi)
 
          choose_dir: if (lastdi==KNOT_DIM_2) then
@@ -12684,6 +12689,8 @@ module fitpack_core
       integer(FP_SIZE), intent(inout) :: n(dims),nplus(dims)
       real(FP_REAL),    intent(inout) :: reduc(dims)
       !  ..array arguments (data + caller-supplied workspace views)..
+      !  z(mz): gridded data, flat and (ny,nx)-ordered (y-fast); passed straight to fpgrre_nd, which
+      !  documents and indexes the storage convention. fpregr_nd never dereferences z itself.
       real(FP_REAL),    intent(in)               :: z(mz)
       real(FP_REAL),    intent(in),    contiguous :: xg(:,:)
       real(FP_REAL),    intent(inout), contiguous :: t(:,:),fpint(:,:),sp(:,:,:),right(:),q(:),a(:,:,:),b(:,:,:)
@@ -12764,9 +12771,7 @@ module fitpack_core
 
                   !  iopt=0, or iopt=1 and s>=fp0: start from the least-squares polynomial.
                   n = nmin
-                  do d=1,dims
-                     nrdat(1,d) = m(d)-2
-                  end do
+                  nrdat(1,:dims) = m-2
                   lastdi = KNOT_DIM_NONE
                   nplus  = 0
                   fp0    = zero
@@ -12779,11 +12784,8 @@ module fitpack_core
 
       endif bootstrap
 
-      ! mpm = sum(m) is a safe upper bound on the number of trials (avoid sum() per house style).
-      mpm = 0
-      do d=1,dims
-         mpm = mpm+m(d)
-      end do
+      ! mpm = sum(m) is a safe upper bound on the number of trials.
+      mpm = sum(m)
       ifs = 0
       ifb = 0
       p   = -one
@@ -12800,10 +12802,10 @@ module fitpack_core
           nrint = n-nmin+1
           nk1   = n-k1
           ncof  = product(nk1)
-          do d=1,dims
+          forall (d=1:dims)
              t(1:k1(d),d)        = lo(d)
              t(n(d)-k(d):n(d),d) = hi(d)
-          end do
+          end forall
 
           ! least-squares spline + per-interval residuals fpint(:,d) and total fp.
           call fpgrre_nd(dims,ifs,ifb,xg,m,z,mz,k,t,n,p,c,nc,fp,fpint,mm,mynx,sp,right,q,a,b,nr)
@@ -12832,11 +12834,8 @@ module fitpack_core
 
           ier = FITPACK_OK
 
-          ! adjust reduc for the direction of the last knot addition (binary; literal-2).
-          select case (lastdi)
-             case (KNOT_DIM_1); reduc(1) = fpold-fp
-             case (KNOT_DIM_2); reduc(2) = fpold-fp
-          end select
+          ! adjust reduc for the axis of the last knot addition (lastdi is the dimension index).
+          if (lastdi/=KNOT_DIM_NONE) reduc(lastdi) = fpold-fp
 
           fpold = fp
 
@@ -12851,32 +12850,21 @@ module fitpack_core
              endif
           end do
 
-         ! choose the direction for the next knots (binary arbiter; literal-2).
+         ! choose the axis for the next knots. new_knot_dimension returns the dimension index
+         ! (KNOT_DIM_1 or KNOT_DIM_2 at dims=2); lastdi then drives the refinement directly, so the
+         ! binary branch collapses to a single dimension-indexed block. The arbiter itself stays
+         ! binary until the dims>2 step replaces it with an argmax over the axes.
          lastdi = new_knot_dimension(n(1),npl(1),ne(1),n(2),npl(2),ne(2),lastdi)
 
-         choose_dim: if (lastdi==KNOT_DIM_2) then
-
-            ! addition in the y-direction (axis 2).
-            nplus(2) = npl(2)
-            ifs(2)   = 0
-            add_y_knots: do l=1,nplus(2)
-               call fpknot(xg(1:m(2),2),m(2),t(1:nest(2),2),n(2),fpint(1:nest(2),2), &
-                           nrdat(1:nest(2),2),nrint(2),nest(2),IONE)
-               if (n(2)==ne(2)) exit add_y_knots
-            end do add_y_knots
-
-        else choose_dim
-
-            ! addition in the x-direction (axis 1).
-            nplus(1) = npl(1)
-            ifs(1)   = 0
-            add_x_knots: do l=1,nplus(1)
-               call fpknot(xg(1:m(1),1),m(1),t(1:nest(1),1),n(1),fpint(1:nest(1),1), &
-                           nrdat(1:nest(1),1),nrint(1),nest(1),IONE)
-               if (n(1)==ne(1)) exit add_x_knots
-            end do add_x_knots
-
-        endif choose_dim
+         ! add knots along the chosen axis (lastdi in 1..dims).
+         d        = lastdi
+         nplus(d) = npl(d)
+         ifs(d)   = 0
+         add_knots: do l=1,nplus(d)
+            call fpknot(xg(1:m(d),d),m(d),t(1:nest(d),d),n(d),fpint(1:nest(d),d), &
+                        nrdat(1:nest(d),d),nrint(d),nest(d),IONE)
+            if (n(d)==ne(d)) exit add_knots
+         end do add_knots
 
       end do main_loop
 

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -28,6 +28,7 @@ module fitpack_core
     integer, parameter, public :: FP_FLAG = c_int32_t
     integer, parameter, public :: FP_BOOL = c_bool
     integer, parameter, public :: FP_COMM = c_double
+    integer, parameter, public :: FP_DIM  = c_int32_t  ! Tensor (domain) dimension count for N-D gridded fits
 
     !> Marker for unallocated arrays in communication buffers
     integer(FP_SIZE), parameter :: FP_NOT_ALLOC = -99999999_FP_SIZE
@@ -61,6 +62,12 @@ module fitpack_core
     public :: sphere ! * Surface fitting using spherical coordinates
     public :: spgrid ! * Surface fitting to data on a spherical grid
     public :: parsur ! * Parametric surface fitting to data on a grid
+
+    ! N-D gridded core (slice 1: dimensionalized at dims=2 behind a bit-for-bit gate; see
+    ! todo/fitpack_nd_grids.md). fpregr_nd/fpgrre_nd stay private and are covered transitively
+    ! by the regrid_nd backbone gate.
+    public :: regrid_nd ! N-D generalization of regrid (gridded smoothing fit)
+    public :: fpbisp_nd ! N-D generalization of fpbisp (gridded evaluation)
 
     ! Surface application routines
     public :: bispeu ! * Evaluation of a bivariate spline function
@@ -208,6 +215,49 @@ module fitpack_core
     end interface FP_COMM_EXPAND
 
     contains
+
+      !> @brief Row-major strides for a flat tensor of the given per-axis sizes.
+      !!
+      !! Returns the multipliers `str(d)` such that a 1-based multi-index `idx(1:d)` maps to the
+      !! flat 0-based offset `sum((idx-1)*str)`. The first axis varies slowest (leading stride =
+      !! product of the trailing sizes), matching the storage of the gridded data tensor `z`
+      !! (sizes `[mx,my]` -> strides `[my,1]`) and the coefficient tensor `c`
+      !! (sizes `[nk1x,nk1y]` -> strides `[nk1y,1]`) used by the 2-D gridded core. Each tensor
+      !! must be passed its own size vector; the two differ only in the leading stride.
+      !!
+      !! @param[in] sizes  Per-axis extents.
+      !! @return    str    Row-major strides; `str(size(sizes)) = 1`.
+      pure function fp_grid_strides(sizes) result(str)
+          integer(FP_SIZE), intent(in) :: sizes(:)
+          integer(FP_SIZE) :: str(size(sizes))
+          integer(FP_DIM) :: i,d
+          d = size(sizes,kind=FP_DIM)
+          if (d<=0) return
+          str(d) = 1_FP_SIZE
+          do i=d-1,1,-1
+             str(i) = str(i+1)*sizes(i+1)
+          end do
+      end function fp_grid_strides
+
+      !> @brief Flat 0-based offset of a multi-index into a row-major tensor.
+      !!
+      !! Given a 1-based multi-index `idx(1:d)` and the strides from fp_grid_strides, returns the
+      !! 0-based linear offset `sum((idx-1)*strides)`. Add 1 for Fortran 1-based access, e.g.
+      !! `c(fp_grid_index(idx,str)+1)`. Integer arithmetic is exact, so routing tensor addresses
+      !! through this helper is bit-for-bit identical to the hand-written 2-D index expressions.
+      !!
+      !! @param[in] idx      1-based multi-index (length d).
+      !! @param[in] strides  Row-major strides (length d), from fp_grid_strides.
+      !! @return    offset   0-based flat offset.
+      pure function fp_grid_index(idx,strides) result(offset)
+          integer(FP_SIZE), intent(in) :: idx(:),strides(:)
+          integer(FP_SIZE) :: offset
+          integer(FP_DIM) :: i
+          offset = 0_FP_SIZE
+          do i=1,size(idx,kind=FP_DIM)
+             offset = offset + (idx(i)-1_FP_SIZE)*strides(i)
+          end do
+      end function fp_grid_index
 
       !> @brief Dispatch an error code: return it to caller or halt with a message.
       !!
@@ -2182,6 +2232,73 @@ module fitpack_core
       end do
       return
       end subroutine fpbisp
+
+
+      !> @brief N-D generalization of fpbisp: evaluate a tensor-product spline on a grid.
+      !!
+      !! Dimensionalized duplicate of fpbisp (the bivariate gridded evaluator). At `dims=2` it is
+      !! bit-for-bit identical to fpbisp: the per-axis basis-table build is a runtime do-loop over
+      !! the `dims` axes (each axis is independent), while the evaluation contraction is deliberately
+      !! kept in literal 2-D form (x-outer / `dot_product`-over-axis-2-inner) until the dims>2 step.
+      !! Each axis `d` supplies its own knots `t(1:n(d),d)`, order `k(d)`, and grid `xg(1:m(d),d)` of
+      !! `m(d)` points; the flat coefficient tensor `c` and output `z` are row-major (first axis
+      !! varies slowest), matching fpbisp's storage. `w`/`lidx` are per-axis basis-value and
+      !! knot-interval workspaces (one column per axis), mirroring fpbisp's `wx,wy`/`lx,ly`.
+      !!
+      !! @see fpbisp, Dierckx Ch. 5 (pp. 98-103); todo/fitpack_nd_grids.md (slice 1)
+      pure subroutine fpbisp_nd(dims,t,n,c,k,xg,m,z,w,lidx)
+          integer(FP_DIM),  intent(in)  :: dims
+          integer(FP_SIZE), intent(in)  :: n(dims),k(dims),m(dims)
+          real(FP_REAL),    intent(in)  :: t(:,:),c(:),xg(:,:)
+          real(FP_REAL),    intent(out) :: z(:),w(:,:,:)
+          integer(FP_SIZE), intent(out) :: lidx(:,:)
+
+          !  ..local variables..
+          integer(FP_DIM)  :: d
+          integer(FP_SIZE) :: k1(dims),nk1(dims),cstride(dims)
+          integer(FP_SIZE) :: l,l1,mout,i,i1,j,nkd
+          real(FP_REAL)    :: arg,sp,tb,te,h(MAX_ORDER+1)
+
+          !  per-axis order and coefficient extents
+          k1  = k+1
+          nk1 = n-k-1                       ! coefficient count per axis (= nkx1, nky1 at dims=2)
+
+          !  per-axis basis tables: dimension-generic runtime loop over the axes
+          do d=1,dims
+             nkd = n(d)-k1(d)               ! nkx1 / nky1
+             tb  = t(k1(d),d)
+             te  = t(nkd+1,d)
+             l   = k1(d)
+             do i=1,m(d)
+                arg = xg(i,d)
+                if (arg<tb) arg = tb
+                if (arg>te) arg = te
+                l = fp_knot_interval(t(1:n(d),d), arg, l, nkd)
+                h = fpbspl(t(1:n(d),d), n(d), k(d), arg, l)
+                lidx(i,d) = l-k1(d)
+                w(i,1:k1(d),d) = h(1:k1(d))
+             end do
+          end do
+
+          !  ---- frozen literal-2 evaluation contraction (kept until the dims>2 step) ----
+          !  c is row-major with leading stride nk1(2); z is row-major, first axis slowest.
+          cstride = fp_grid_strides(nk1)    ! [nk1(2),1] at dims=2
+          mout = 0
+          do i=1,m(1)
+             h(1:k1(1)) = w(i,1:k1(1),1)
+             do j=1,m(2)
+                l1 = fp_grid_index([lidx(i,1)+1,lidx(j,2)+1],cstride)
+                sp = zero
+                do i1=1,k1(1)
+                   sp = sp+h(i1)*dot_product(c(l1+1:l1+k1(2)),w(j,1:k1(2),2))
+                   l1 = l1+nk1(2)
+                end do
+                mout = mout+1
+                z(mout) = sp
+             end do
+          end do
+          return
+      end subroutine fpbisp_nd
 
 
       !> @brief Evaluate the non-zero B-splines at a given point.
@@ -7194,6 +7311,254 @@ module fitpack_core
       end do grid_x
       return
       end subroutine fpgrre
+
+      !> @brief N-D generalization of fpgrre: tensor-product least-squares gridded solver.
+      !!
+      !! Dimensionalized duplicate of fpgrre. At `dims=2` it is bit-for-bit identical to fpgrre.
+      !! The per-axis housekeeping (observation matrices `sp(:,:,d)`, discontinuity matrices
+      !! `b(:,:,d)`, and the caching flags `ifs(d)`/`ifb(d)`) is a runtime do-loop over the `dims`
+      !! axes — each axis is independent, so iterating d=1 then d=2 reproduces the original's
+      !! "x before y" build order exactly. The three genuinely d-dimensional kernels are kept in
+      !! literal 2-D form until the dims>2 step:
+      !!   1. the alternating-direction reductions (axis-1 reduces z->q via fp_rotate_row_block,
+      !!      axis-2 reduces q->c via fp_rotate_row_stride),
+      !!   2. the two-pass back-substitution solving (ry) c (rx)' = h,
+      !!   3. the residual contraction (x-outer / dot_product-over-y-inner) with the fac=term*half
+      !!      boundary attribution carried by the nroldx/nroldy state machine.
+      !!
+      !! KEY to bit-for-bit equivalence: the per-axis band/observation/discontinuity arrays are
+      !! merged into rank-3 arrays whose leading dimension `lda`/`ldb` is uniform (>= max over axes
+      !! of n(d)) rather than the per-axis nx/ny. Because fp_rotate_*, fpback and fpdisc all take
+      !! the leading dimension as an explicit `na`/`nest` argument, passing the TRUE (uniform)
+      !! leading dim makes every addressed element coincide logically with the original's
+      !! separately-sized ax(nx,kx2)/ay(ny,ky2)/bx/by — no copies, no value change.
+      !!
+      !! @see fpgrre, Dierckx Ch. 5 §5.4; todo/fitpack_nd_grids.md (slice 1, §2/§9)
+      pure subroutine fpgrre_nd(dims,ifs,ifb,xg,m,z,mz,k,t,n,p,c,nc,fp,fpint, &
+                                mm,mynx,sp,right,q,a,b,nr)
+
+      !  ..scalar arguments..
+      integer(FP_DIM),  intent(in)    :: dims
+      real(FP_REAL),    intent(in)    :: p
+      real(FP_REAL),    intent(inout) :: fp
+      integer(FP_SIZE), intent(in)    :: mz,nc,mm,mynx
+      integer(FP_SIZE), intent(in)    :: m(dims),k(dims),n(dims)
+      integer(FP_SIZE), intent(inout) :: ifs(dims),ifb(dims)
+      !  ..array arguments..
+      real(FP_REAL),    intent(in)              :: z(mz)
+      real(FP_REAL),    intent(in),  contiguous :: xg(:,:),t(:,:)
+      real(FP_REAL),    intent(inout)           :: c(nc),right(mm),q(mynx)
+      real(FP_REAL),    intent(inout), contiguous :: fpint(:,:),sp(:,:,:),a(:,:,:),b(:,:,:)
+      integer(FP_SIZE), intent(inout), contiguous :: nr(:,:)
+      !  ..local scalars..
+      real(FP_REAL) :: arg,fac,pinv,term
+      integer(FP_DIM)  :: d
+      integer(FP_SIZE) :: i,ibandx,ibandy,irot,it,iz,i1,i2,j,kk,kc,l,l1,ncof,nrold,nroldx,nroldy,&
+                          number,numx,numx1,numy,numy1,n1,lda,ldb
+      !  ..per-axis sizes..
+      integer(FP_SIZE) :: k1(dims),k2(dims),nk1(dims)
+      !  ..literal-2 aliases for the frozen kernels (axis 1 = x, axis 2 = y)..
+      integer(FP_SIZE) :: kx1,ky1,kx2,ky2,mx,my,nk1x,nk1y
+      !  ..local arrays..
+      real(FP_REAL) :: h(MAX_ORDER+1)
+
+      !  per-axis order and coefficient extents
+      k1  = k+1
+      k2  = k+2
+      nk1 = n-k1                      ! nk1x, nk1y at dims=2
+      lda = size(a,1,kind=FP_SIZE)    ! uniform leading dim of the band matrices
+      ldb = size(b,1,kind=FP_SIZE)    ! uniform leading dim of the discontinuity matrices
+      pinv = merge(one/p,one,p>zero)
+
+      !  ---- per-axis observation matrices (sp) : dimension-generic loop over the axes ----
+      !  it depends on the flags ifs(d) (and on p for ifb(d)) whether sp(:,:,d) and b(:,:,d)
+      !  still must be determined. Building d=1 then d=2 reproduces the original spx-then-spy order.
+      do d=1,dims
+         if (ifs(d)==0) then
+            l  = k1(d)
+            l1 = k2(d)
+            number = 0
+            do it=1,m(d)
+               arg = xg(it,d)
+               do while (arg>=t(l1,d) .and. l/=nk1(d))
+                  l  = l1
+                  l1 = l+1
+                  number = number+1
+               end do
+               h = fpbspl(t(1:n(d),d),n(d),k(d),arg,l)
+               sp(it,1:k1(d),d) = h(1:k1(d))
+               nr(it,d) = number
+            end do
+            ifs(d) = 1
+         end if
+      end do
+
+      !  ---- per-axis discontinuity matrices (b) ----
+      if (p>zero) then
+         do d=1,dims
+            if (ifb(d)==0 .and. n(d)/=2*k1(d)) then
+               call fpdisc(t(1:n(d),d),n(d),k2(d),b(:,:,d),ldb)
+               ifb(d) = 1
+            end if
+         end do
+      end if
+
+      !  ======================================================================================
+      !  Frozen literal-2 kernels below (kept until the dims>2 step). Axis 1 = x, axis 2 = y.
+      !  Only mechanical renames vs fpgrre: paired arrays -> rank-3 page (:,:,d), paired counts
+      !  -> aliases, the leading-dim arguments nx/ny -> the uniform lda, and the coefficient-index
+      !  scalar k1 -> kc (to free the name k1 for the per-axis array).
+      !  ======================================================================================
+      kx1 = k1(1); ky1 = k1(2)
+      kx2 = k2(1); ky2 = k2(2)
+      mx  = m(1) ; my  = m(2)
+      nk1x = nk1(1); nk1y = nk1(2)
+
+      !  reduce the matrix (ax) to upper triangular form (rx) using givens rotations. apply the
+      !  same transformations to the rows of matrix q to obtain the my x (nx-kx-1) matrix g.
+      l = my*nk1x
+      q(1:l) = zero
+      a(1:nk1x,1:kx2,1) = zero
+      l = 0
+      nrold = 0
+      ibandx = kx1
+      givens_ax: do it=1,mx
+         number = nr(it,1)
+         inner_ax: do
+           if(nrold==number) then
+              h(ibandx) = zero
+              h(1:kx1) = sp(it,1:kx1,1)
+              do j=1,my
+                 l = l+1
+                 right(j) = z(l)
+              end do
+              irot = number
+           elseif (p<=zero) then
+              nrold = nrold+1
+              cycle inner_ax
+           else
+              ibandx = kx2
+              n1 = nrold+1
+              h(1:kx2) = b(n1,1:kx2,1)*pinv
+              right(1:my) = zero
+              irot = nrold
+           endif
+
+           call fp_rotate_row_block(h, ibandx, a(:,:,1), lda, right, q, my, irot)
+
+           if (nrold==number) exit inner_ax
+
+           nrold = nrold+1
+         end do inner_ax
+      end do givens_ax
+
+      !  reduce the matrix (ay) to upper triangular form (ry) using givens rotations. apply the same
+      !  transformations to the columns of matrix g to obtain the (ny-ky-1) x (nx-kx-1) matrix h.
+      ncof = nk1x*nk1y
+
+      c(1:ncof) = zero
+      a(1:nk1y,1:ky2,2) = zero
+      nrold = 0
+
+      ibandy = ky1
+      givens_ay: do it=1,my
+         number = nr(it,2)
+         inner_ay: do
+            if (nrold==number) then
+                h(ibandy) = zero
+                h(1:ky1) = sp(it,1:ky1,2)
+                l = it
+                do j=1,nk1x
+                   right(j) = q(l)
+                   l = l+my
+                end do
+                irot = number
+            elseif (p<=zero) then
+                nrold = nrold+1
+                cycle inner_ay
+            else
+                ibandy = ky2
+                n1 = nrold+1
+                h(1:ky2) = b(n1,1:ky2,2)*pinv
+                right(1:nk1x) = zero
+                irot = nrold
+            endif
+
+            call fp_rotate_row_stride(h, ibandy, a(:,:,2), lda, right, c, nk1y, nk1x, irot)
+            if (nrold==number) exit inner_ay
+            nrold = nrold+1
+         end do inner_ay
+      end do givens_ay
+
+      !  backward substitution to obtain the b-spline coefficients as the
+      !  solution of the linear system    (ry) c (rx)' = h.
+      !  first step: solve the system  (ry) (c1) = h.
+      kk = 1
+      do i=1,nk1x
+        c(kk:kk+nk1y-1) = fpback(a(:,:,2),c(kk),nk1y,ibandy,lda)
+        kk = kk+nk1y
+      end do
+
+      !  second step: solve the system  c (rx)' = (c1).
+      kk = 0
+      do j=1,nk1y
+         kk = kk+1
+         l = kk
+         do i=1,nk1x
+            right(i) = c(l)
+            l = l+nk1y
+         end do
+         right(:nk1x) = fpback(a(:,:,1),right,nk1x,ibandx,lda)
+         l = kk
+         do i=1,nk1x
+            c(l) = right(i)
+            l = l+nk1y
+         end do
+      end do
+
+      !  calculate the quantities res(i,j), fp, fpx(.) and fpy(.) (-> fpint(:,1) and fpint(:,2)).
+      fp     = zero
+      fpint(:,1) = zero
+      fpint(:,2) = zero
+      nk1y   = nk1(2)
+      iz     = 0
+      nroldx = 0
+
+      !  main loop for the different grid points.
+      grid_x: do i1=1,mx
+         numx = nr(i1,1)
+         numx1 = numx+1
+         nroldy = 0
+         grid_y: do i2=1,my
+            numy = nr(i2,2)
+            numy1 = numy+1
+            iz = iz+1
+            term = zero
+            kc = numx*nk1y+numy
+            do l1=1,kx1
+               term = term+sp(i1,l1,1)*dot_product(sp(i2,1:ky1,2),c(kc+1:kc+ky1))
+               kc = kc+nk1y
+            end do
+
+            term = (z(iz)-term)**2
+            fp = fp+term
+            fpint(numx1,1) = fpint(numx1,1)+term
+            fpint(numy1,2) = fpint(numy1,2)+term
+            fac = term*half
+            if (numy/=nroldy) then
+               fpint(numy1,2) = fpint(numy1,2)-fac
+               fpint(numy,2)  = fpint(numy,2) +fac
+            endif
+            nroldy = numy
+            if (numx/=nroldx) then
+               fpint(numx1,1) = fpint(numx1,1)-fac
+               fpint(numx,1)  = fpint(numx,1) +fac
+            endif
+         end do grid_y
+         nroldx = numx
+      end do grid_x
+      return
+      end subroutine fpgrre_nd
 
       !> @brief Compute spherical grid spline coefficients via Kronecker product.
       !!
@@ -12285,6 +12650,268 @@ module fitpack_core
 
       end subroutine fpregr
 
+      !> @brief N-D generalization of fpregr: knot determination + p-iteration for gridded fits.
+      !!
+      !! Dimensionalized duplicate of fpregr. At `dims=2` it is bit-for-bit identical to fpregr.
+      !! The paired state (nx/ny, kx/ky, fpintx/fpinty, reducx/reducy, nplusx/nplusy, the per-axis
+      !! knot/data counts) becomes `dims`-length arrays, and the knot-init / knot-placement passes
+      !! become runtime do-loops over the axes — each axis independent, so d=1 then d=2 reproduces
+      !! the original's x-then-y order exactly. Kept literal-2 until the dims>2 step: the binary
+      !! knot-direction arbiter (`new_knot_dimension`, the reduc/lastdi select-case and the
+      !! choose-dim branch) and the scalar p-iteration root find for f(p)=s.
+      !!
+      !! WORKSPACE: per the no-allocation rule, all scratch (sp, a, b, right, q, fpint, nr, nrdat)
+      !! is supplied by the caller (regrid_nd carves it from the user wrk/iwrk via pointer bounds
+      !! remapping) and received here as assumed-shape inout views. The persistent fit-state
+      !! (fp0, fpold, reduc, lastdi, nplus) is passed explicitly rather than hidden in wrk offsets.
+      !!
+      !! @see fpregr, fpgrre_nd, Dierckx Ch. 5 §5.4; todo/fitpack_nd_grids.md (slice 1, §8 part C)
+      pure subroutine fpregr_nd(iopt,dims,xg,m,z,mz,lo,hi,k,s,nest,tol,maxit,nc, &
+                                n,t,c,fp,fp0,fpold,reduc,lastdi,nplus, &
+                                fpint,nr,nrdat,sp,right,q,a,b,ier)
+
+      !  ..scalar arguments..
+      integer(FP_SIZE), intent(in)    :: iopt
+      integer(FP_DIM),  intent(in)    :: dims
+      real(FP_REAL),    intent(in)    :: s,tol
+      integer(FP_SIZE), intent(in)    :: mz,nc,maxit
+      real(FP_REAL),    intent(inout) :: c(nc),fp,fp0,fpold
+      integer(FP_SIZE), intent(inout) :: lastdi
+      integer(FP_FLAG), intent(inout) :: ier
+      !  ..array arguments (sizes)..
+      integer(FP_SIZE), intent(in)    :: m(dims),k(dims),nest(dims)
+      real(FP_REAL),    intent(in)    :: lo(dims),hi(dims)
+      integer(FP_SIZE), intent(inout) :: n(dims),nplus(dims)
+      real(FP_REAL),    intent(inout) :: reduc(dims)
+      !  ..array arguments (data + caller-supplied workspace views)..
+      real(FP_REAL),    intent(in)               :: z(mz)
+      real(FP_REAL),    intent(in),    contiguous :: xg(:,:)
+      real(FP_REAL),    intent(inout), contiguous :: t(:,:),fpint(:,:),sp(:,:,:),right(:),q(:),a(:,:,:),b(:,:,:)
+      integer(FP_SIZE), intent(inout), contiguous :: nr(:,:),nrdat(:,:)
+      !  ..local scalars..
+      real(FP_REAL) :: acc,fpms,f1,f2,f3,p,p1,p2,p3,rn
+      integer(FP_DIM)  :: d
+      integer(FP_SIZE) :: i,iter,j,k3,l,mk1,mpm,ncof,npl1,mm,mynx
+      logical(FP_BOOL) :: check1,check3,success
+      !  ..per-axis arrays..
+      integer(FP_SIZE) :: ifs(dims),ifb(dims),k1(dims),k2(dims),nk1(dims),nmax(dims),ne(dims), &
+                          nmin(dims),nrint(dims),npl(dims)
+
+      ! per-axis order extents and scratch sizes
+      k1   = k+1
+      k2   = k+2
+      mm   = size(right,kind=FP_SIZE)
+      mynx = size(q,kind=FP_SIZE)
+
+      ! acc denotes the absolute tolerance for the root of f(p)=s.
+      acc = tol*s
+
+      ! nmax: number of knots for interpolation; ne: max allowed; nmin: polynomial (no interior).
+      nmax = m+k1
+      ne   = min(nmax,nest)
+      nmin = 2*k1
+
+      ! ***** part 1: determination of the number of knots and their position. *****
+      bootstrap: if (iopt>=0) then
+
+          interpolating: if (s<=zero) then
+
+              ! if s = 0, s(x,..) is an interpolating spline: nmax knots per axis.
+              n = nmax
+              if (any(n>nest)) then
+                 ier = FITPACK_INSUFFICIENT_STORAGE
+                 return
+              end if
+
+              ! interior knots (per axis)
+              do d=1,dims
+                 mk1 = m(d)-k1(d)
+                 if (mk1/=0) then
+                    k3 = k(d)/2
+                    i  = k1(d)+1
+                    j  = k3+2
+                    do l=1,mk1
+                       t(i,d) = merge( xg(j,d) , (xg(j,d)+xg(j-1,d))*half , k3*2/=k(d))
+                       i = i+1
+                       j = j+1
+                    end do
+                 end if
+              end do
+
+          else interpolating
+
+              !  if s > 0 our initial choice of knots depends on the value of iopt.
+              use_last_call: if (iopt/=0 .and. fp0>s) then
+
+                  !  iopt=1 and fp0>s: re-derive the data counts per knot interval, per axis.
+                  do d=1,dims
+                     l = k2(d)
+                     j = 1
+                     nrdat(1,d) = 0
+                     mpm = m(d)-1
+                     do i=2,mpm
+                        nrdat(j,d) = nrdat(j,d)+1
+                        if (xg(i,d)>=t(l,d)) then
+                            nrdat(j,d) = nrdat(j,d)-1
+                            l = l+1
+                            j = j+1
+                            nrdat(j,d) = 0
+                        endif
+                     end do
+                  end do
+
+              else use_last_call
+
+                  !  iopt=0, or iopt=1 and s>=fp0: start from the least-squares polynomial.
+                  n = nmin
+                  do d=1,dims
+                     nrdat(1,d) = m(d)-2
+                  end do
+                  lastdi = KNOT_DIM_NONE
+                  nplus  = 0
+                  fp0    = zero
+                  fpold  = zero
+                  reduc  = zero
+
+              endif use_last_call
+
+          endif interpolating
+
+      endif bootstrap
+
+      ! mpm = sum(m) is a safe upper bound on the number of trials (avoid sum() per house style).
+      mpm = 0
+      do d=1,dims
+         mpm = mpm+m(d)
+      end do
+      ifs = 0
+      ifb = 0
+      p   = -one
+
+      !  main loop for the different sets of knots.
+      iter = 0
+      main_loop: do while (iter<=mpm)
+
+          iter = iter+1
+
+          if (all(n==nmin)) ier = FITPACK_LEASTSQUARES_OK
+
+          ! knot intervals, coefficient count, and the boundary (clamped) knots, per axis.
+          nrint = n-nmin+1
+          nk1   = n-k1
+          ncof  = product(nk1)
+          do d=1,dims
+             t(1:k1(d),d)        = lo(d)
+             t(n(d)-k(d):n(d),d) = hi(d)
+          end do
+
+          ! least-squares spline + per-interval residuals fpint(:,d) and total fp.
+          call fpgrre_nd(dims,ifs,ifb,xg,m,z,mz,k,t,n,p,c,nc,fp,fpint,mm,mynx,sp,right,q,a,b,nr)
+
+          if (ier==FITPACK_LEASTSQUARES_OK) fp0 = fp
+
+          ! SUCCESS! the least-squares spline is an acceptable solution.
+          fpms = fp-s
+          if (iopt<0 .or. abs(fpms)<acc) return
+
+          ! if f(p=inf) < s, we accept the choice of knots.
+          if (fpms<zero) exit main_loop
+
+          ! if all axes are at nmax, sinf is an interpolating spline.
+          if (all(n==nmax)) then
+             ier = FITPACK_INTERPOLATING_OK
+             fp = zero
+             return
+          end if
+
+          ! if all axes are at their storage limit we cannot add more knots.
+          if (all(n==ne)) then
+              ier = FITPACK_INSUFFICIENT_STORAGE
+              return
+          end if
+
+          ier = FITPACK_OK
+
+          ! adjust reduc for the direction of the last knot addition (binary; literal-2).
+          select case (lastdi)
+             case (KNOT_DIM_1); reduc(1) = fpold-fp
+             case (KNOT_DIM_2); reduc(2) = fpold-fp
+          end select
+
+          fpold = fp
+
+          ! number of knots to add per axis.
+          do d=1,dims
+             npl(d) = 1
+             if (n(d)/=nmin(d)) then
+                 npl1 = nplus(d)*2
+                 rn   = nplus(d)
+                 if (reduc(d)>acc) npl1 = int(rn*fpms/reduc(d))
+                 npl(d) = min(nplus(d)*2,max(npl1,nplus(d)/2,1))
+             endif
+          end do
+
+         ! choose the direction for the next knots (binary arbiter; literal-2).
+         lastdi = new_knot_dimension(n(1),npl(1),ne(1),n(2),npl(2),ne(2),lastdi)
+
+         choose_dim: if (lastdi==KNOT_DIM_2) then
+
+            ! addition in the y-direction (axis 2).
+            nplus(2) = npl(2)
+            ifs(2)   = 0
+            add_y_knots: do l=1,nplus(2)
+               call fpknot(xg(1:m(2),2),m(2),t(1:nest(2),2),n(2),fpint(1:nest(2),2), &
+                           nrdat(1:nest(2),2),nrint(2),nest(2),IONE)
+               if (n(2)==ne(2)) exit add_y_knots
+            end do add_y_knots
+
+        else choose_dim
+
+            ! addition in the x-direction (axis 1).
+            nplus(1) = npl(1)
+            ifs(1)   = 0
+            add_x_knots: do l=1,nplus(1)
+               call fpknot(xg(1:m(1),1),m(1),t(1:nest(1),1),n(1),fpint(1:nest(1),1), &
+                           nrdat(1:nest(1),1),nrint(1),nest(1),IONE)
+               if (n(1)==ne(1)) exit add_x_knots
+            end do add_x_knots
+
+        endif choose_dim
+
+      end do main_loop
+
+      ! test whether the least-squares polynomial is the solution.
+      if (ier==FITPACK_LEASTSQUARES_OK) return
+
+      ! ***** part 2: determination of the smoothing spline (root of f(p)=s; scalar). *****
+      p1   = zero
+      f1   = fp0-s
+      p3   = -one
+      f3   = fpms
+      p    = one
+      check1 = FP_FALSE
+      check3 = FP_FALSE
+
+      root_iterations: do iter = 1,maxit
+
+          call fpgrre_nd(dims,ifs,ifb,xg,m,z,mz,k,t,n,p,c,nc,fp,fpint,mm,mynx,sp,right,q,a,b,nr)
+
+          fpms = fp-s; if (abs(fpms)<acc) return
+
+          call root_finding_iterate(p1,f1,p2,f2,p3,f3,p,fpms,acc,check1,check3,success)
+          if (.not.success) then
+             ier = FITPACK_S_TOO_SMALL
+             return
+          end if
+
+      end do root_iterations
+
+      ! Maximum number of iterations reached.
+      ier = FITPACK_MAXIT
+      return
+
+      end subroutine fpregr_nd
+
       !> @brief Choose which dimension receives the next knot during bivariate fitting.
       !!
       !! Selects whether to add a knot in dimension 1 or 2, balancing knot
@@ -17149,6 +17776,131 @@ module fitpack_core
       return
 
       end subroutine regrid
+
+      !> @brief N-D generalization of regrid: tensor-product gridded smoothing-spline driver.
+      !!
+      !! Dimensionalized duplicate of regrid. At `dims=2` it produces results bit-for-bit identical
+      !! to regrid (verified by the regrid_nd-vs-regrid equivalence gate over all iopt modes and
+      !! spline orders). Validation, boundary-knot clamping and Schoenberg-Whitney (`fpchec`) checks
+      !! become runtime do-loops over the `dims` axes; the binary knot-direction logic stays literal-2
+      !! inside fpregr_nd until the dims>2 step.
+      !!
+      !! WORKSPACE (no allocation): the caller supplies a flat real `wrk(lwrk)` and integer
+      !! `iwrk(kwrk)`, both `target`. regrid_nd carves them into the rank-N work views needed by
+      !! fpregr_nd/fpgrre_nd via pointer bounds remapping (the N-D analogue of regrid's flat-offset
+      !! partition). The persistent fit-state lives at fixed offsets: wrk(1)=fp0, wrk(2)=fpold,
+      !! wrk(3:2+dims)=reduc; iwrk(1)=lastdi, iwrk(2:1+dims)=nplus -- so preserving wrk/iwrk between
+      !! calls (with iopt=1) continues from the previous knot set, exactly as regrid does.
+      !!
+      !! Minimum sizes:
+      !!   lwrk >= 2 + dims + nestmax*dims + mmax*(kmax+1)*dims + 2*nestmax*(kmax+2)*dims + mm + mq
+      !!   kwrk >= 1 + dims + mmax*dims + nestmax*dims
+      !! with mmax=maxval(m), nestmax=maxval(nest), kmax=maxval(k), mm=max(nestmax,mmax),
+      !! mq=mmax*nestmax.
+      !!
+      !! @see regrid, fpregr_nd; Dierckx, SIAM J.Numer.Anal. 19 (1982) 1286-1304; Ch.5 §5.4.
+      pure subroutine regrid_nd(iopt,dims,m,xg,z,lo,hi,k,s,nest,n,t,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+
+      !  ..scalar arguments..
+      integer(FP_SIZE), intent(in)    :: iopt
+      integer(FP_DIM),  intent(in)    :: dims
+      real(FP_REAL),    intent(in)    :: s
+      real(FP_REAL),    intent(out)   :: fp
+      integer(FP_SIZE), intent(in)    :: lwrk,kwrk
+      integer(FP_FLAG), intent(out)   :: ier
+      !  ..array arguments..
+      integer(FP_SIZE), intent(in)    :: m(dims),k(dims),nest(dims)
+      real(FP_REAL),    intent(in)    :: lo(dims),hi(dims)
+      integer(FP_SIZE), intent(inout) :: n(dims)
+      real(FP_REAL),    intent(in)              :: z(*)
+      real(FP_REAL),    intent(in),    contiguous :: xg(:,:)
+      real(FP_REAL),    intent(inout), contiguous :: t(:,:)
+      real(FP_REAL),    intent(inout)             :: c(*)
+      real(FP_REAL),    intent(inout), target     :: wrk(lwrk)
+      integer(FP_SIZE), intent(inout), target     :: iwrk(kwrk)
+
+      !  ..parameters..
+      integer(FP_SIZE), parameter :: maxit = 20
+      real(FP_REAL),    parameter :: tol = smallnum03
+      !  ..local scalars..
+      integer(FP_DIM)  :: d
+      integer(FP_SIZE) :: mz,nc,lwest,kwest,maxm,maxnest,maxk1,maxk2,mm,mynx,offr,offi
+      !  ..per-axis arrays..
+      integer(FP_SIZE) :: k1(dims),k2(dims),nmin(dims)
+      !  ..workspace views (carved from wrk/iwrk; contiguous by construction)..
+      real(FP_REAL),    pointer, contiguous :: pfpint(:,:),psp(:,:,:),pa(:,:,:),pb(:,:,:),pright(:),pq(:)
+      integer(FP_SIZE), pointer, contiguous :: pnr(:,:),pnrdat(:,:)
+
+      !  before starting computations a data check is made.
+      ier = FITPACK_INPUT_ERROR
+
+      k1   = k+1
+      k2   = k+2
+      nmin = 2*k1
+      mz   = product(m)
+      nc   = product(nest-k1)
+
+      if (any(k<=0) .or. any(k>5))    return
+      if (iopt<(-1) .or. iopt>1)      return
+      if (any(m<k1) .or. any(nest<nmin)) return
+
+      !  per-axis work-array sizing
+      maxm    = maxval(m)
+      maxnest = maxval(nest)
+      maxk1   = maxval(k)+1
+      maxk2   = maxval(k)+2
+      mm      = max(maxnest,maxm)
+      mynx    = maxm*maxnest
+
+      lwest = (2+dims) + maxnest*dims + maxm*maxk1*dims + 2*maxnest*maxk2*dims + mm + mynx
+      kwest = (1+dims) + maxm*dims + maxnest*dims
+
+      if (lwrk<lwest .or. kwrk<kwest) return
+
+      !  per-axis domain bounds and strict monotonicity of the grid coordinates.
+      do d=1,dims
+         if (lo(d)>xg(1,d) .or. hi(d)<xg(m(d),d)) return
+         if (any(xg(1:m(d)-1,d)>=xg(2:m(d),d)))   return
+      end do
+
+      if (iopt<0) then
+
+          !  least-squares spline on given knots: validate the knot set per axis.
+          do d=1,dims
+             if (n(d)<nmin(d) .or. n(d)>nest(d)) return
+             t(1:k1(d),d)        = lo(d)
+             t(n(d)-k(d):n(d),d) = hi(d)
+             ier = fpchec(xg(1:m(d),d),m(d),t(1:n(d),d),n(d),k(d))
+             if (ier/=FITPACK_OK) return
+          end do
+
+      else
+
+          if (s<zero) return
+          if (equal(s,zero) .and. any(nest<(m+k1))) return
+
+      endif
+
+      !  ---- partition the working space by pointer bounds remapping ----
+      ier  = FITPACK_OK
+      offr = 2+dims                                  ! wrk(1)=fp0, wrk(2)=fpold, wrk(3:2+dims)=reduc
+      pfpint(1:maxnest,1:dims)       => wrk(offr+1:offr+maxnest*dims);          offr = offr+maxnest*dims
+      psp(1:maxm,1:maxk1,1:dims)     => wrk(offr+1:offr+maxm*maxk1*dims);       offr = offr+maxm*maxk1*dims
+      pa(1:maxnest,1:maxk2,1:dims)   => wrk(offr+1:offr+maxnest*maxk2*dims);    offr = offr+maxnest*maxk2*dims
+      pb(1:maxnest,1:maxk2,1:dims)   => wrk(offr+1:offr+maxnest*maxk2*dims);    offr = offr+maxnest*maxk2*dims
+      pright(1:mm)                   => wrk(offr+1:offr+mm);                    offr = offr+mm
+      pq(1:mynx)                     => wrk(offr+1:offr+mynx)
+
+      offi = 1+dims                                  ! iwrk(1)=lastdi, iwrk(2:1+dims)=nplus
+      pnr(1:maxm,1:dims)             => iwrk(offi+1:offi+maxm*dims);            offi = offi+maxm*dims
+      pnrdat(1:maxnest,1:dims)       => iwrk(offi+1:offi+maxnest*dims)
+
+      call fpregr_nd(iopt,dims,xg,m,z,mz,lo,hi,k,s,nest,tol,maxit,nc, &
+                     n,t,c,fp,wrk(1),wrk(2),wrk(3:2+dims),iwrk(1),iwrk(2:1+dims), &
+                     pfpint,pnr,pnrdat,psp,pright,pq,pa,pb,ier)
+      return
+
+      end subroutine regrid_nd
 
 
       !  subroutine spalde evaluates at a point x ALL the derivatives

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -7336,22 +7336,22 @@ module fitpack_core
       !! separately-sized ax(nx,kx2)/ay(ny,ky2)/bx/by — no copies, no value change.
       !!
       !! @see fpgrre, Dierckx Ch. 5 §5.4; todo/fitpack_nd_grids.md (slice 1, §2/§9)
-      pure subroutine fpgrre_nd(dims,ifs,ifb,xg,m,z,mz,k,t,n,p,c,nc,fp,fpint, &
+      pure subroutine fpgrre_nd(dims,ifs,ifb,xg,m,z,k,t,n,p,c,nc,fp,fpint, &
                                 mm,mynx,sp,right,q,a,b,nr)
 
       !  ..scalar arguments..
       integer(FP_DIM),  intent(in)    :: dims
       real(FP_REAL),    intent(in)    :: p
       real(FP_REAL),    intent(inout) :: fp
-      integer(FP_SIZE), intent(in)    :: mz,nc,mm,mynx
+      integer(FP_SIZE), intent(in)    :: nc,mm,mynx
       integer(FP_SIZE), intent(in)    :: m(dims),k(dims),n(dims)
       integer(FP_SIZE), intent(inout) :: ifs(dims),ifb(dims)
       !  ..array arguments..
-      !  z(mz): gridded data tensor, flat. Row-major with axis 1 (x) SLOWEST and the last axis
-      !  FASTEST -- at dims=2 this is z(m(2),m(1)) = (ny_data,nx_data), NOT (nx,ny). Element
-      !  (i1,i2,...) lives at fp_grid_index([i1,i2,...],fp_grid_strides(m))+1; at dims=2 that is
-      !  (i-1)*my+j, which is exactly how the frozen kernels below read it (x-outer, y-inner).
-      real(FP_REAL),    intent(in)              :: z(mz)
+      !  z(m(2),m(1)): gridded data tensor as a genuine 2-D array -- leading dim m(2) (= my, the y/
+      !  axis-2 data count) FASTEST, trailing dim m(1) (= mx, axis-1) SLOWEST, i.e. (ny,nx) and NOT
+      !  (nx,ny). Element z(i2,i1) is the datum at (x_i1,y_i2); this is bit-for-bit the legacy flat
+      !  layout z((i1-1)*my+i2). Generalizes to z(m(dims),...,m(1)) at the dims>2 step.
+      real(FP_REAL),    intent(in)              :: z(m(2),m(1))
       real(FP_REAL),    intent(in),  contiguous :: xg(:,:),t(:,:)
       real(FP_REAL),    intent(inout)           :: c(nc),right(mm),q(mynx)
       real(FP_REAL),    intent(inout), contiguous :: fpint(:,:),sp(:,:,:),a(:,:,:),b(:,:,:)
@@ -7359,7 +7359,7 @@ module fitpack_core
       !  ..local scalars..
       real(FP_REAL) :: arg,fac,pinv,term
       integer(FP_DIM)  :: d
-      integer(FP_SIZE) :: i,ibandx,ibandy,irot,it,iz,i1,i2,j,kk,kc,l,l1,ncof,nrold,nroldx,nroldy,&
+      integer(FP_SIZE) :: i,ibandx,ibandy,irot,it,i1,i2,j,kk,kc,l,l1,ncof,nrold,nroldx,nroldy,&
                           number,numx,numx1,numy,numy1,n1,lda,ldb
       !  ..per-axis sizes..
       integer(FP_SIZE) :: k1(dims),k2(dims),nk1(dims)
@@ -7434,10 +7434,7 @@ module fitpack_core
            if(nrold==number) then
               h(ibandx) = zero
               h(1:kx1) = sp(it,1:kx1,1)
-              do j=1,my
-                 l = l+1
-                 right(j) = z(l)
-              end do
+              right(1:my) = z(1:my,it)      ! column it of the (my,mx) data tensor
               irot = number
            elseif (p<=zero) then
               nrold = nrold+1
@@ -7527,7 +7524,6 @@ module fitpack_core
       fpint(:,1) = zero
       fpint(:,2) = zero
       nk1y   = nk1(2)
-      iz     = 0
       nroldx = 0
 
       !  main loop for the different grid points.
@@ -7538,7 +7534,6 @@ module fitpack_core
          grid_y: do i2=1,my
             numy = nr(i2,2)
             numy1 = numy+1
-            iz = iz+1
             term = zero
             kc = numx*nk1y+numy
             do l1=1,kx1
@@ -7546,7 +7541,7 @@ module fitpack_core
                kc = kc+nk1y
             end do
 
-            term = (z(iz)-term)**2
+            term = (z(i2,i1)-term)**2      ! datum at (x_i1,y_i2); rank-2 (my,mx) access
             fp = fp+term
             fpint(numx1,1) = fpint(numx1,1)+term
             fpint(numy1,2) = fpint(numy1,2)+term
@@ -12671,7 +12666,7 @@ module fitpack_core
       !! (fp0, fpold, reduc, lastdi, nplus) is passed explicitly rather than hidden in wrk offsets.
       !!
       !! @see fpregr, fpgrre_nd, Dierckx Ch. 5 §5.4; todo/fitpack_nd_grids.md (slice 1, §8 part C)
-      pure subroutine fpregr_nd(iopt,dims,xg,m,z,mz,lo,hi,k,s,nest,tol,maxit,nc, &
+      pure subroutine fpregr_nd(iopt,dims,xg,m,z,lo,hi,k,s,nest,tol,maxit,nc, &
                                 n,t,c,fp,fp0,fpold,reduc,lastdi,nplus, &
                                 fpint,nr,nrdat,sp,right,q,a,b,ier)
 
@@ -12679,7 +12674,7 @@ module fitpack_core
       integer(FP_SIZE), intent(in)    :: iopt
       integer(FP_DIM),  intent(in)    :: dims
       real(FP_REAL),    intent(in)    :: s,tol
-      integer(FP_SIZE), intent(in)    :: mz,nc,maxit
+      integer(FP_SIZE), intent(in)    :: nc,maxit
       real(FP_REAL),    intent(inout) :: c(nc),fp,fp0,fpold
       integer(FP_SIZE), intent(inout) :: lastdi
       integer(FP_FLAG), intent(inout) :: ier
@@ -12689,9 +12684,9 @@ module fitpack_core
       integer(FP_SIZE), intent(inout) :: n(dims),nplus(dims)
       real(FP_REAL),    intent(inout) :: reduc(dims)
       !  ..array arguments (data + caller-supplied workspace views)..
-      !  z(mz): gridded data, flat and (ny,nx)-ordered (y-fast); passed straight to fpgrre_nd, which
-      !  documents and indexes the storage convention. fpregr_nd never dereferences z itself.
-      real(FP_REAL),    intent(in)               :: z(mz)
+      !  z(m(2),m(1)): gridded data as a 2-D array, (ny,nx)-ordered (y/axis-2 fastest); passed
+      !  straight to fpgrre_nd, which documents and indexes the convention. fpregr_nd never reads z.
+      real(FP_REAL),    intent(in)               :: z(m(2),m(1))
       real(FP_REAL),    intent(in),    contiguous :: xg(:,:)
       real(FP_REAL),    intent(inout), contiguous :: t(:,:),fpint(:,:),sp(:,:,:),right(:),q(:),a(:,:,:),b(:,:,:)
       integer(FP_SIZE), intent(inout), contiguous :: nr(:,:),nrdat(:,:)
@@ -12808,7 +12803,7 @@ module fitpack_core
           end forall
 
           ! least-squares spline + per-interval residuals fpint(:,d) and total fp.
-          call fpgrre_nd(dims,ifs,ifb,xg,m,z,mz,k,t,n,p,c,nc,fp,fpint,mm,mynx,sp,right,q,a,b,nr)
+          call fpgrre_nd(dims,ifs,ifb,xg,m,z,k,t,n,p,c,nc,fp,fpint,mm,mynx,sp,right,q,a,b,nr)
 
           if (ier==FITPACK_LEASTSQUARES_OK) fp0 = fp
 
@@ -12882,7 +12877,7 @@ module fitpack_core
 
       root_iterations: do iter = 1,maxit
 
-          call fpgrre_nd(dims,ifs,ifb,xg,m,z,mz,k,t,n,p,c,nc,fp,fpint,mm,mynx,sp,right,q,a,b,nr)
+          call fpgrre_nd(dims,ifs,ifb,xg,m,z,k,t,n,p,c,nc,fp,fpint,mm,mynx,sp,right,q,a,b,nr)
 
           fpms = fp-s; if (abs(fpms)<acc) return
 
@@ -17800,7 +17795,7 @@ module fitpack_core
       integer(FP_SIZE), intent(in)    :: m(dims),k(dims),nest(dims)
       real(FP_REAL),    intent(in)    :: lo(dims),hi(dims)
       integer(FP_SIZE), intent(inout) :: n(dims)
-      real(FP_REAL),    intent(in)              :: z(*)
+      real(FP_REAL),    intent(in)              :: z(m(2),m(1))  ! gridded data, (ny,nx)/y-fast (dims=2)
       real(FP_REAL),    intent(in),    contiguous :: xg(:,:)
       real(FP_REAL),    intent(inout), contiguous :: t(:,:)
       real(FP_REAL),    intent(inout)             :: c(*)
@@ -17812,7 +17807,7 @@ module fitpack_core
       real(FP_REAL),    parameter :: tol = smallnum03
       !  ..local scalars..
       integer(FP_DIM)  :: d
-      integer(FP_SIZE) :: mz,nc,lwest,kwest,maxm,maxnest,maxk1,maxk2,mm,mynx,offr,offi
+      integer(FP_SIZE) :: nc,lwest,kwest,maxm,maxnest,maxk1,maxk2,mm,mynx,offr,offi
       !  ..per-axis arrays..
       integer(FP_SIZE) :: k1(dims),k2(dims),nmin(dims)
       !  ..workspace views (carved from wrk/iwrk; contiguous by construction)..
@@ -17825,7 +17820,6 @@ module fitpack_core
       k1   = k+1
       k2   = k+2
       nmin = 2*k1
-      mz   = product(m)
       nc   = product(nest-k1)
 
       if (any(k<=0) .or. any(k>5))    return
@@ -17883,7 +17877,7 @@ module fitpack_core
       pnr(1:maxm,1:dims)             => iwrk(offi+1:offi+maxm*dims);            offi = offi+maxm*dims
       pnrdat(1:maxnest,1:dims)       => iwrk(offi+1:offi+maxnest*dims)
 
-      call fpregr_nd(iopt,dims,xg,m,z,mz,lo,hi,k,s,nest,tol,maxit,nc, &
+      call fpregr_nd(iopt,dims,xg,m,z,lo,hi,k,s,nest,tol,maxit,nc, &
                      n,t,c,fp,wrk(1),wrk(2),wrk(3:2+dims),iwrk(1),iwrk(2:1+dims), &
                      pfpint,pnr,pnrdat,psp,pright,pq,pa,pb,ier)
       return

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -227,13 +227,14 @@ module fitpack_core
       !! (sizes `[nk1x,nk1y]` -> strides `[nk1y,1]`) used by the 2-D gridded core. Each tensor
       !! must be passed its own size vector; the two differ only in the leading stride.
       !!
-      !! @param[in] sizes  Per-axis extents.
-      !! @return    str    Row-major strides; `str(size(sizes)) = 1`.
-      pure function fp_grid_strides(sizes) result(str)
-          integer(FP_SIZE), intent(in) :: sizes(:)
-          integer(FP_SIZE) :: str(size(sizes))
-          integer(FP_DIM) :: i,d
-          d = size(sizes,kind=FP_DIM)
+      !! @param[in] d      Number of axes.
+      !! @param[in] sizes  Per-axis extents, sizes(d).
+      !! @return    str    Row-major strides; `str(d) = 1`.
+      pure function fp_grid_strides(d,sizes) result(str)
+          integer(FP_DIM),  intent(in) :: d
+          integer(FP_SIZE), intent(in) :: sizes(d)
+          integer(FP_SIZE) :: str(d)
+          integer(FP_DIM)  :: i
           if (d<=0) return
           str(d) = 1_FP_SIZE
           do i=d-1,1,-1
@@ -248,17 +249,15 @@ module fitpack_core
       !! `c(fp_grid_index(idx,str)+1)`. Integer arithmetic is exact, so routing tensor addresses
       !! through this helper is bit-for-bit identical to the hand-written 2-D index expressions.
       !!
+      !! @param[in] d        Number of axes (length of idx and strides).
       !! @param[in] idx      1-based multi-index (length d).
       !! @param[in] strides  Row-major strides (length d), from fp_grid_strides.
       !! @return    offset   0-based flat offset.
-      pure function fp_grid_index(idx,strides) result(offset)
-          integer(FP_SIZE), intent(in) :: idx(:),strides(:)
+      pure function fp_grid_index(d,idx,strides) result(offset)
+          integer(FP_DIM),  intent(in) :: d
+          integer(FP_SIZE), intent(in) :: idx(d),strides(d)
           integer(FP_SIZE) :: offset
-          integer(FP_DIM) :: i
-          offset = 0_FP_SIZE
-          do i=1,size(idx,kind=FP_DIM)
-             offset = offset + (idx(i)-1_FP_SIZE)*strides(i)
-          end do
+          offset = sum((idx-1_FP_SIZE)*strides)
       end function fp_grid_index
 
       !> @brief Dispatch an error code: return it to caller or halt with a message.
@@ -2238,16 +2237,37 @@ module fitpack_core
 
       !> @brief N-D generalization of fpbisp: evaluate a tensor-product spline on a grid.
       !!
-      !! Dimensionalized duplicate of fpbisp (the bivariate gridded evaluator). At `dims=2` it is
-      !! bit-for-bit identical to fpbisp: the per-axis basis-table build is a runtime do-loop over
-      !! the `dims` axes (each axis is independent), while the evaluation contraction is deliberately
-      !! kept in literal 2-D form (x-outer / `dot_product`-over-axis-2-inner) until the dims>2 step.
-      !! Each axis `d` supplies its own knots `t(1:n(d),d)`, order `k(d)`, and grid `xg(1:m(d),d)` of
-      !! `m(d)` points; the flat coefficient tensor `c` and output `z` are row-major (first axis
-      !! varies slowest), matching fpbisp's storage. `w`/`lidx` are per-axis basis-value and
-      !! knot-interval workspaces (one column per axis), mirroring fpbisp's `wx,wy`/`lx,ly`.
+      !! Computes the values of a bivariate spline \f$ s(x, y) \f$ of degrees
+      !! \f$ k_x \f$ and \f$ k_y \f$ at the grid points
+      !! \f$ (x_i, y_j) \f$, \f$ i = 1, \ldots, m_x \f$, \f$ j = 1, \ldots, m_y \f$.
       !!
-      !! @see fpbisp, Dierckx Ch. 5 (pp. 98-103); todo/fitpack_nd_grids.md (slice 1)
+      !! The evaluation uses the two-step algorithm: first compute the B-spline
+      !! basis values in each direction, then assemble:
+      !!
+      !! \f[
+      !!     s(x, y) = \sum_{i} \left( \sum_{j} c_{i,j} \, M_{j, k_y+1}(y) \right)
+      !!               N_{i, k_x+1}(x)
+      !!     \tag{2.14-2.15}
+      !! \f]
+      !!
+      !! At `dims=2` this is bit-for-bit identical to fpbisp: the per-axis basis-table
+      !! build is a runtime do-loop over the `dims` axes, while the evaluation
+      !! contraction is kept in literal 2-D form until the dims>2 step. The B-spline
+      !! values and knot interval indices are stored per axis in workspace arrays `w`
+      !! and `lidx` (one column per axis) for reuse.
+      !!
+      !! @param[in]  dims  Number of axes (domain dimension)
+      !! @param[in]  t     Per-axis knot vectors; column \f$ d \f$ is `t(1:n(d),d)`
+      !! @param[in]  n     Number of knots per axis, `n(dims)`
+      !! @param[in]  c     B-spline coefficient tensor, flat row-major (first axis varies slowest)
+      !! @param[in]  k     Spline degree per axis, `k(dims)`
+      !! @param[in]  xg    Per-axis evaluation grids; column \f$ d \f$ is `xg(1:m(d),d)`
+      !! @param[in]  m     Number of evaluation points per axis, `m(dims)`
+      !! @param[out] z     Spline values at grid points, flat row-major (first axis varies slowest)
+      !! @param[out] w     Per-axis B-spline basis values, `w(m(d),k(d)+1,d)` (mirrors fpbisp `wx,wy`)
+      !! @param[out] lidx  Per-axis knot interval indices, `lidx(m(d),d)` (mirrors fpbisp `lx,ly`)
+      !!
+      !! @see fpbisp, Dierckx Ch. 2 §2.1.2 (pp. 28-30) Eq. 2.14-2.17; todo/fitpack_nd_grids.md (slice 1)
       pure subroutine fpbisp_nd(dims,t,n,c,k,xg,m,z,w,lidx)
           integer(FP_DIM),  intent(in)  :: dims
           integer(FP_SIZE), intent(in)  :: n(dims),k(dims),m(dims)
@@ -2284,12 +2304,12 @@ module fitpack_core
 
           !  ---- frozen literal-2 evaluation contraction (kept until the dims>2 step) ----
           !  c is row-major with leading stride nk1(2); z is row-major, first axis slowest.
-          cstride = fp_grid_strides(nk1)    ! [nk1(2),1] at dims=2
+          cstride = fp_grid_strides(dims,nk1)    ! [nk1(2),1] at dims=2
           mout = 0
           do i=1,m(1)
              h(1:k1(1)) = w(i,1:k1(1),1)
              do j=1,m(2)
-                l1 = fp_grid_index([lidx(i,1)+1,lidx(j,2)+1],cstride)
+                l1 = fp_grid_index(dims,[lidx(i,1)+1,lidx(j,2)+1],cstride)
                 sp = zero
                 do i1=1,k1(1)
                    sp = sp+h(i1)*dot_product(c(l1+1:l1+k1(2)),w(j,1:k1(2),2))
@@ -7316,26 +7336,61 @@ module fitpack_core
 
       !> @brief N-D generalization of fpgrre: tensor-product least-squares gridded solver.
       !!
-      !! Dimensionalized duplicate of fpgrre. At `dims=2` it is bit-for-bit identical to fpgrre.
-      !! The per-axis housekeeping (observation matrices `sp(:,:,d)`, discontinuity matrices
-      !! `b(:,:,d)`, and the caching flags `ifs(d)`/`ifb(d)`) is a runtime do-loop over the `dims`
-      !! axes — each axis is independent, so iterating d=1 then d=2 reproduces the original's
-      !! "x before y" build order exactly. The three genuinely d-dimensional kernels are kept in
-      !! literal 2-D form until the dims>2 step:
-      !!   1. the alternating-direction reductions (axis-1 reduces z->q via fp_rotate_row_block,
-      !!      axis-2 reduces q->c via fp_rotate_row_stride),
-      !!   2. the two-pass back-substitution solving (ry) c (rx)' = h,
-      !!   3. the residual contraction (x-outer / dot_product-over-y-inner) with the fac=term*half
-      !!      boundary attribution carried by the nroldx/nroldy state machine.
+      !! For data on a rectangular grid \f$ \{x_i\} \times \{y_j\} \f$, solves
+      !! the smoothing least-squares system using the Kronecker product structure
+      !! (Eq. 10.4-10.8):
       !!
-      !! KEY to bit-for-bit equivalence: the per-axis band/observation/discontinuity arrays are
-      !! merged into rank-3 arrays whose leading dimension `lda`/`ldb` is uniform (>= max over axes
-      !! of n(d)) rather than the per-axis nx/ny. Because fp_rotate_*, fpback and fpdisc all take
-      !! the leading dimension as an explicit `na`/`nest` argument, passing the TRUE (uniform)
-      !! leading dim makes every addressed element coincide logically with the original's
-      !! separately-sized ax(nx,kx2)/ay(ny,ky2)/bx/by — no copies, no value change.
+      !! \f[
+      !!     A_y \, C \, A_x^T = Q
+      !!     \tag{10.4}
+      !! \f]
       !!
-      !! @see fpgrre, Dierckx Ch. 5 §5.4; todo/fitpack_nd_grids.md (slice 1, §2/§9)
+      !! where the augmented observation matrices are:
+      !!
+      !! \f[
+      !!     A_x = \begin{pmatrix} S_{px} \\ \frac{1}{\sqrt{p}} B_x \end{pmatrix}, \quad
+      !!     A_y = \begin{pmatrix} S_{py} \\ \frac{1}{\sqrt{p}} B_y \end{pmatrix}
+      !!     \tag{10.5}
+      !! \f]
+      !!
+      !! The per-axis QR factorizations are performed independently using
+      !! fp_rotate_row_stride (row-access RHS for \f$ A_y \f$) and fp_rotate_row_block
+      !! (column-access RHS for \f$ A_x \f$), followed by back-substitution; residual
+      !! sums `fpint` per knot interval are also computed for knot-placement decisions.
+      !! At `dims=2` this is bit-for-bit identical to fpgrre: the per-axis housekeeping
+      !! is a runtime do-loop over the axes, while the alternating-direction reductions,
+      !! the two-pass back-substitution and the residual contraction are kept literal-2
+      !! until the dims>2 step. The per-axis band/observation/discontinuity arrays are
+      !! merged into rank-3 arrays with a uniform leading dimension (`lda`/`ldb`), passed
+      !! as the explicit leading-dim argument to fp_rotate_*, fpback and fpdisc so every
+      !! addressed element coincides with the original's separately-sized matrices — no
+      !! copies, no value change.
+      !!
+      !! @param[in]     dims    Number of axes (domain dimension)
+      !! @param[in,out] ifs     Per-axis flag: 0 = recompute observation matrix \f$ S_p \f$ (orig ifsx,ifsy)
+      !! @param[in,out] ifb     Per-axis flag: 0 = recompute discontinuity matrix \f$ B \f$ (orig ifbx,ifby)
+      !! @param[in]     xg      Per-axis grid values; column \f$ d \f$ is `xg(1:m(d),d)`
+      !! @param[in]     m       Number of grid points per axis, `m(dims)`
+      !! @param[in]     z       Data on the grid, `z(m(2),m(1))`, (ny,nx)-ordered (axis-2 fastest)
+      !! @param[in]     k       Degree per axis, `k(dims)`
+      !! @param[in]     t       Per-axis knot vectors; column \f$ d \f$ is `t(1:n(d),d)`
+      !! @param[in]     n       Number of knots per axis, `n(dims)`
+      !! @param[in]     p       Smoothing parameter
+      !! @param[in,out] c       B-spline coefficients, length `nc`
+      !! @param[in]     nc      Length of `c`
+      !! @param[in,out] fp      Total weighted sum of squared residuals
+      !! @param[in,out] fpint   Residual sums per knot interval, per axis (orig fpx,fpy)
+      !! @param[in]     mm      Work dimension
+      !! @param[in]     mynx    Work dimension (\f$ my \cdot (nx - kx - 1) \f$)
+      !! @param[in,out] sp      Per-axis B-spline observation matrices (orig spx,spy)
+      !! @param[in,out] right   Work: RHS vector for row rotations, length `mm`
+      !! @param[in,out] q       Work: RHS matrix, length `mynx`
+      !! @param[in,out] a       Per-axis band matrices, uniform leading dim (orig ax,ay)
+      !! @param[in,out] b       Per-axis discontinuity-jump matrices, uniform leading dim (orig bx,by)
+      !! @param[in,out] nr      Per-axis knot interval indices (orig nrx,nry)
+      !!
+      !! @see fpgrre, Dierckx Ch. 10 §10.2 (pp. 170-172) Eq. 10.4-10.8; fp_rotate_row_block,
+      !!      fp_rotate_row_stride — grid Givens rotations; todo/fitpack_nd_grids.md (slice 1, §2/§9)
       pure subroutine fpgrre_nd(dims,ifs,ifb,xg,m,z,k,t,n,p,c,nc,fp,fpint, &
                                 mm,mynx,sp,right,q,a,b,nr)
 
@@ -12652,20 +12707,55 @@ module fitpack_core
 
       !> @brief N-D generalization of fpregr: knot determination + p-iteration for gridded fits.
       !!
-      !! Dimensionalized duplicate of fpregr. At `dims=2` it is bit-for-bit identical to fpregr.
-      !! The paired state (nx/ny, kx/ky, fpintx/fpinty, reducx/reducy, nplusx/nplusy, the per-axis
-      !! knot/data counts) becomes `dims`-length arrays, and the knot-init / knot-placement passes
-      !! become runtime do-loops over the axes — each axis independent, so d=1 then d=2 reproduces
-      !! the original's x-then-y order exactly. Kept literal-2 until the dims>2 step: the binary
-      !! knot-direction arbiter (`new_knot_dimension`, the reduc/lastdi select-case and the
-      !! choose-dim branch) and the scalar p-iteration root find for f(p)=s.
+      !! Outer iteration loop for fitting a smoothing spline surface on a
+      !! rectangular grid \f$ \{x_i\} \times \{y_j\} \f$. Manages the knot
+      !! selection strategy (alternating between axis directions based on residuals)
+      !! and the smoothing-parameter search, delegating the grid computation to
+      !! fpgrre_nd at each step. At `dims=2` this is bit-for-bit identical to fpregr:
+      !! the paired per-axis state becomes `dims`-length arrays and the knot-init /
+      !! knot-placement passes become runtime do-loops over the axes, while the binary
+      !! knot-direction arbiter and the scalar p-iteration root find for f(p)=s are
+      !! kept literal-2 until the dims>2 step.
       !!
-      !! WORKSPACE: per the no-allocation rule, all scratch (sp, a, b, right, q, fpint, nr, nrdat)
-      !! is supplied by the caller (regrid_nd carves it from the user wrk/iwrk via pointer bounds
-      !! remapping) and received here as assumed-shape inout views. The persistent fit-state
-      !! (fp0, fpold, reduc, lastdi, nplus) is passed explicitly rather than hidden in wrk offsets.
+      !! WORKSPACE: per the no-allocation rule, all scratch (`sp,a,b,right,q,fpint,nr,
+      !! nrdat`) is supplied by the caller (regrid_nd carves it from the user wrk/iwrk)
+      !! and received here as assumed-shape inout views; the persistent fit-state
+      !! (`fp0,fpold,reduc,lastdi,nplus`) is passed explicitly rather than hidden in
+      !! wrk offsets.
       !!
-      !! @see fpregr, fpgrre_nd, Dierckx Ch. 5 §5.4; todo/fitpack_nd_grids.md (slice 1, §8 part C)
+      !! @param[in]     iopt    0 = new fit, 1 = continue
+      !! @param[in]     dims    Number of axes (domain dimension)
+      !! @param[in]     xg      Per-axis grid values; column \f$ d \f$ is `xg(1:m(d),d)`
+      !! @param[in]     m       Number of grid points per axis, `m(dims)`
+      !! @param[in]     z       Data values, `z(m(2),m(1))`, (ny,nx)-ordered (passed through to fpgrre_nd)
+      !! @param[in]     lo      Per-axis lower boundary (orig xb,yb)
+      !! @param[in]     hi      Per-axis upper boundary (orig xe,ye)
+      !! @param[in]     k       Degree per axis, `k(dims)`
+      !! @param[in]     s       Smoothing factor \f$ S \geq 0 \f$
+      !! @param[in]     nest    Max knots per axis (orig nxest,nyest)
+      !! @param[in]     tol     Smoothing condition tolerance
+      !! @param[in]     maxit   Maximum smoothing-parameter iterations
+      !! @param[in]     nc      Length of coefficient array
+      !! @param[in,out] n       Number of knots per axis (orig nx,ny)
+      !! @param[in,out] t       Per-axis knot vectors; column \f$ d \f$ is `t(1:n(d),d)` (orig tx,ty)
+      !! @param[in,out] c       B-spline coefficients, length `nc`
+      !! @param[in,out] fp      Weighted sum of squared residuals
+      !! @param[in,out] fp0     Initial residual
+      !! @param[in,out] fpold   Previous residual
+      !! @param[in,out] reduc   Per-axis residual reduction (orig reducx,reducy)
+      !! @param[in,out] lastdi  Last direction of knot addition
+      !! @param[in,out] nplus   Per-axis number of knots to add (orig nplusx,nplusy)
+      !! @param[in,out] fpint   Residual sums per knot interval, per axis (orig fpintx,fpinty)
+      !! @param[in,out] nr      Per-axis knot interval indices (orig nrx,nry)
+      !! @param[in,out] nrdat   Per-axis interior data counts per interval (orig nrdatx,nrdaty)
+      !! @param[in,out] sp      Work: per-axis observation matrices
+      !! @param[in,out] right   Work: RHS vector
+      !! @param[in,out] q       Work: RHS matrix
+      !! @param[in,out] a       Work: per-axis band matrices
+      !! @param[in,out] b       Work: per-axis discontinuity matrices
+      !! @param[in,out] ier     Error flag
+      !!
+      !! @see fpregr, fpgrre_nd, Dierckx Ch. 10 §10.2 (pp. 170-172) Eq. 10.4-10.8; todo/fitpack_nd_grids.md (slice 1, §8 part C)
       pure subroutine fpregr_nd(iopt,dims,xg,m,z,lo,hi,k,s,nest,tol,maxit,nc, &
                                 n,t,c,fp,fp0,fpold,reduc,lastdi,nplus, &
                                 fpint,nr,nrdat,sp,right,q,a,b,ier)

--- a/test/fitpack_grid_nd_tests.f90
+++ b/test/fitpack_grid_nd_tests.f90
@@ -1,0 +1,283 @@
+! **************************************************************************************************
+!   FITPACK N-D gridded core — bit-for-bit equivalence gate (slice 1)
+!
+!   Asserts that the dimensionalized *_nd gridded routines reproduce their 2-D originals EXACTLY
+!   (bit-for-bit) when run at dims=2, over the standard 11x11 `daregr` battery across all iopt
+!   modes and spline orders. This is the oracle that licenses extending the *_nd path to dims>2.
+!
+!   Gates:
+!     A. fpbisp_nd  vs bispev  (gridded evaluation)
+!     D. regrid_nd  vs regrid  (gridded fit; transitively covers fpregr_nd and fpgrre_nd, whose
+!                               outputs tx,ty,c,fp,nx,ny are exactly what regrid_nd returns)
+!
+!   See todo/fitpack_nd_grids.md (slice 1) and Dierckx, Ch. 5 §5.4 (pp. 98-103).
+! **************************************************************************************************
+module fitpack_grid_nd_tests
+    use fitpack_core
+    use fitpack_test_data, only: daregr_x,daregr_y,daregr_z
+    use iso_fortran_env, only: output_unit
+    implicit none
+    private
+
+    public :: test_nd_grid_equivalence
+
+    !> regrid workspace sizing (generous; mirrors legacy mnregr which uses nxest=nyest=17)
+    integer(FP_SIZE), parameter :: NXEST = 17, NYEST = 17
+    integer(FP_SIZE), parameter :: LWRK  = 2000, KWRK = 200, NCMAX = 400
+
+    !> A fitting case: spline order and smoothing for one regrid call
+    type :: grid_case
+        integer(FP_SIZE) :: kx,ky
+        real(FP_REAL)    :: s
+        character(len=24):: label
+    end type
+
+    contains
+
+    !> @brief Bit-for-bit equivalence gate for the N-D gridded core at dims=2.
+    logical function test_nd_grid_equivalence(iunit) result(success)
+        integer, optional, intent(in) :: iunit
+        integer :: useUnit
+
+        useUnit = output_unit
+        if (present(iunit)) useUnit = iunit
+
+        success = .true.
+
+        ! Gate D: regrid_nd vs regrid (backbone; transitively covers fpregr_nd + fpgrre_nd)
+        if (success) success = gate_regrid_nd(useUnit)
+
+        ! Gate A: fpbisp_nd vs bispev
+        if (success) success = gate_fpbisp_nd(useUnit)
+
+        if (success) write(useUnit,'(a)') '[test_nd_grid_equivalence] all dims=2 gates bit-for-bit OK'
+
+    end function test_nd_grid_equivalence
+
+    !> @brief The 2-D fitting battery (orders + smoothing) shared by all gates.
+    pure function cases() result(cs)
+        type(grid_case) :: cs(3)
+        cs(1) = grid_case(3,3,0.22_FP_REAL,'cubic smoothing s=0.22')
+        cs(2) = grid_case(3,3,0.0_FP_REAL ,'cubic interpolation s=0')
+        cs(3) = grid_case(5,5,0.2_FP_REAL ,'quintic smoothing s=0.2')
+    end function cases
+
+    !> @brief Run regrid for one case, returning the fitted knots/coefficients.
+    subroutine fit_regrid(gc,nx,tx,ny,ty,c,fp,ier)
+        type(grid_case),  intent(in)  :: gc
+        integer(FP_SIZE), intent(out) :: nx,ny
+        real(FP_REAL),    intent(out) :: tx(NXEST),ty(NYEST),c(NCMAX),fp
+        integer(FP_FLAG), intent(out) :: ier
+
+        integer(FP_SIZE) :: mx,my
+        real(FP_REAL)    :: xb,xe,yb,ye,wrk(LWRK)
+        integer(FP_SIZE) :: iwrk(KWRK)
+        real(FP_REAL)    :: zin(size(daregr_x)*size(daregr_y))
+
+        mx = size(daregr_x,kind=FP_SIZE)
+        my = size(daregr_y,kind=FP_SIZE)
+        xb = daregr_x(1); xe = daregr_x(mx)
+        yb = daregr_y(1); ye = daregr_y(my)
+        zin = reshape(daregr_z,[mx*my])   ! same sequence association legacy mnregr relies on
+
+        call regrid(IOPT_NEW_SMOOTHING,mx,daregr_x,my,daregr_y,zin,xb,xe,yb,ye, &
+                    gc%kx,gc%ky,gc%s,NXEST,NYEST,nx,tx,ny,ty,c,fp, &
+                    wrk,LWRK,iwrk,KWRK,ier)
+    end subroutine fit_regrid
+
+    !> @brief Gate A — fpbisp_nd(dims=2) must equal bispev's gridded evaluation bit-for-bit.
+    logical function gate_fpbisp_nd(useUnit) result(ok)
+        integer, intent(in) :: useUnit
+
+        type(grid_case)  :: cs(3),gc
+        integer(FP_SIZE) :: mx,my,nx,ny,nc,kx,ky,mz,maxn,maxm,maxk1
+        integer(FP_FLAG) :: ier
+        real(FP_REAL)    :: tx(NXEST),ty(NYEST),c(NCMAX),fp
+        ! reference evaluation (bispev)
+        real(FP_REAL)    :: zref(size(daregr_x)*size(daregr_y)),ewrk(NCMAX)
+        integer(FP_SIZE) :: eiwrk(KWRK)
+        ! fpbisp_nd marshalling
+        real(FP_REAL)    :: ztest(size(daregr_x)*size(daregr_y))
+        real(FP_REAL),    allocatable :: t(:,:),xg(:,:),w(:,:,:)
+        integer(FP_SIZE), allocatable :: lidx(:,:)
+        integer(FP_SIZE) :: n2(2),k2(2),m2(2)
+        integer          :: icase
+        real(FP_REAL)    :: maxdiff
+
+        ok = .true.
+        cs = cases()
+        mx = size(daregr_x,kind=FP_SIZE)
+        my = size(daregr_y,kind=FP_SIZE)
+        mz = mx*my
+
+        do icase=1,size(cs)
+            gc = cs(icase)
+            kx = gc%kx; ky = gc%ky
+
+            call fit_regrid(gc,nx,tx,ny,ty,c,fp,ier)
+            if (.not.FITPACK_SUCCESS(ier)) then
+                ok = .false.
+                write(useUnit,1000) 'fit',trim(gc%label),FITPACK_MESSAGE(ier)
+                return
+            end if
+
+            nc = (nx-kx-1)*(ny-ky-1)
+
+            ! reference: bispev (which internally calls fpbisp)
+            call bispev(tx,nx,ty,ny,c,kx,ky,daregr_x,mx,daregr_y,my,zref, &
+                        ewrk,size(ewrk,kind=FP_SIZE),eiwrk,size(eiwrk,kind=FP_SIZE),ier)
+            if (.not.FITPACK_SUCCESS(ier)) then
+                ok = .false.
+                write(useUnit,1000) 'bispev',trim(gc%label),FITPACK_MESSAGE(ier)
+                return
+            end if
+
+            ! test: fpbisp_nd at dims=2
+            maxn  = max(nx,ny); maxm = max(mx,my); maxk1 = max(kx,ky)+1
+            n2 = [nx,ny]; k2 = [kx,ky]; m2 = [mx,my]
+            if (allocated(t)) deallocate(t,xg,w,lidx)
+            allocate(t(maxn,2),xg(maxm,2),w(maxm,maxk1,2),lidx(maxm,2))
+            t = zero
+            t(1:nx,1) = tx(1:nx);      t(1:ny,2) = ty(1:ny)
+            xg(1:mx,1) = daregr_x;     xg(1:my,2) = daregr_y
+
+            call fpbisp_nd(2_FP_DIM,t,n2,c(1:nc),k2,xg,m2,ztest(1:mz),w,lidx)
+
+            maxdiff = maxval(abs(zref(1:mz)-ztest(1:mz)))
+            if (.not.all(zref(1:mz)==ztest(1:mz))) then
+                ok = .false.
+                write(useUnit,1100) trim(gc%label),maxdiff
+                return
+            end if
+        end do
+
+        write(useUnit,'(a)') '[gate A] fpbisp_nd == bispev (bit-for-bit, all cases)'
+
+        1000 format('[gate A] ',a,' failed for ',a,': ',a)
+        1100 format('[gate A] fpbisp_nd /= bispev for ',a,'  (max |diff| = ',1pe12.3,')')
+    end function gate_fpbisp_nd
+
+    !> @brief Gate D — regrid_nd(dims=2) must equal regrid bit-for-bit across all iopt modes.
+    !!
+    !! Runs regrid (reference) and regrid_nd (test) through the same iopt sequence and asserts
+    !! nx,ny,tx,ty,c,fp and ier match to the last bit. The two are independent invocations with
+    !! their own preserved workspace; iopt=1 cases continue from the previous knot set on both
+    !! sides. A green result here certifies fpregr_nd and fpgrre_nd as well (their outputs ARE
+    !! what regrid_nd returns).
+    logical function gate_regrid_nd(useUnit) result(ok)
+        integer, intent(in) :: useUnit
+
+        ! reference (regrid) state
+        integer(FP_SIZE) :: mx,my,nxr,nyr
+        real(FP_REAL)    :: txr(NXEST),tyr(NYEST),cr(NCMAX),fpr,wrkr(LWRK)
+        integer(FP_SIZE) :: iwrkr(KWRK)
+        integer(FP_FLAG) :: ier_r
+        ! test (regrid_nd) state
+        integer(FP_SIZE) :: ntst(2),kk(2),m2(2),nest2(2)
+        real(FP_REAL)    :: ttst(NXEST,2),ctst(NCMAX),fptst,wrkt(LWRK),xgt(size(daregr_x),2)
+        integer(FP_SIZE) :: iwrkt(KWRK)
+        integer(FP_FLAG) :: ier_t
+        ! shared
+        real(FP_REAL)    :: zin(size(daregr_x)*size(daregr_y)),xb,xe,yb,ye,s,lo(2),hi(2)
+        integer(FP_SIZE) :: kx,ky,iopt,icase,i
+        character(len=40):: lbl
+
+        ok = .true.
+        mx = size(daregr_x,kind=FP_SIZE); my = size(daregr_y,kind=FP_SIZE)
+        xb = daregr_x(1); xe = daregr_x(mx); yb = daregr_y(1); ye = daregr_y(my)
+        zin = reshape(daregr_z,[mx*my])
+
+        ! regrid_nd marshalling that is constant across calls
+        m2 = [mx,my]; nest2 = [NXEST,NYEST]; lo = [xb,yb]; hi = [xe,ye]
+        xgt = zero; xgt(1:mx,1) = daregr_x; xgt(1:my,2) = daregr_y
+        wrkr = zero; iwrkr = 0; wrkt = zero; iwrkt = 0
+
+        ! ---- Phase A: cubic, iopt=0 then iopt=1 continuation chain (incl. s=0 interpolation) ----
+        kx = 3; ky = 3; kk = [kx,ky]
+        do icase=1,4
+            select case (icase)
+               case (1); iopt = 0; s = 10.0_FP_REAL
+               case (2); iopt = 1; s = 0.22_FP_REAL
+               case (3); iopt = 1; s = 0.1_FP_REAL
+               case (4); iopt = 1; s = 0.0_FP_REAL
+            end select
+            call regrid(iopt,mx,daregr_x,my,daregr_y,zin,xb,xe,yb,ye,kx,ky,s,NXEST,NYEST, &
+                        nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
+            call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
+                           ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
+            write(lbl,'(a,i0)') 'cubic iopt-chain #',icase
+            if (.not.pair_ok(useUnit,trim(lbl),kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
+                             ntst,ttst,ctst,fptst,ier_t)) then
+                ok = .false.; return
+            end if
+        end do
+
+        ! ---- Phase B: quintic, fresh iopt=0 ----
+        kx = 5; ky = 5; kk = [kx,ky]; iopt = 0; s = 0.2_FP_REAL
+        call regrid(iopt,mx,daregr_x,my,daregr_y,zin,xb,xe,yb,ye,kx,ky,s,NXEST,NYEST, &
+                    nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
+        call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
+                       ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
+        if (.not.pair_ok(useUnit,'quintic fresh iopt=0',kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
+                         ntst,ttst,ctst,fptst,ier_t)) then
+            ok = .false.; return
+        end if
+
+        ! ---- Phase C: least-squares on given knots, iopt=-1 ----
+        kx = 3; ky = 3; kk = [kx,ky]; s = 0.0_FP_REAL
+        nxr = 11; nyr = 11; ntst = [11,11]
+        txr = zero; txr(kx+2:kx+4) = [(half*(i-2),i=1,3)]; tyr = zero; tyr(ky+2:ky+4) = txr(kx+2:kx+4)
+        ttst = zero
+        ttst(kx+2:kx+4,1) = txr(kx+2:kx+4); ttst(ky+2:ky+4,2) = tyr(ky+2:ky+4)
+        call regrid(-1_FP_FLAG,mx,daregr_x,my,daregr_y,zin,xb,xe,yb,ye,kx,ky,s,NXEST,NYEST, &
+                    nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
+        call regrid_nd(-1_FP_FLAG,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
+                       ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
+        if (.not.pair_ok(useUnit,'lsq given knots iopt=-1',kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
+                         ntst,ttst,ctst,fptst,ier_t)) then
+            ok = .false.; return
+        end if
+
+        write(useUnit,'(a)') '[gate D] regrid_nd == regrid (bit-for-bit; iopt=-1,0,1; cubic+quintic)'
+    end function gate_regrid_nd
+
+    !> @brief Compare a regrid vs regrid_nd result pair bit-for-bit; report on mismatch.
+    logical function pair_ok(useUnit,label,k,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
+                             ntst,ttst,ctst,fptst,ier_t) result(ok)
+        integer,          intent(in) :: useUnit
+        character(*),     intent(in) :: label
+        integer(FP_SIZE), intent(in) :: k(2),nxr,nyr,ntst(2)
+        real(FP_REAL),    intent(in) :: txr(:),tyr(:),cr(:),fpr,ttst(:,:),ctst(:),fptst
+        integer(FP_FLAG), intent(in) :: ier_r,ier_t
+        integer(FP_SIZE) :: nc
+
+        ok = .true.
+
+        if (ier_r/=ier_t) then
+            write(useUnit,2000) trim(label),'ier',ier_r,ier_t; ok = .false.; return
+        end if
+        if (nxr/=ntst(1) .or. nyr/=ntst(2)) then
+            write(useUnit,2100) trim(label),nxr,ntst(1),nyr,ntst(2); ok = .false.; return
+        end if
+
+        nc = (nxr-k(1)-1)*(nyr-k(2)-1)
+
+        if (.not.all(txr(1:nxr)==ttst(1:ntst(1),1))) ok = .false.
+        if (.not.all(tyr(1:nyr)==ttst(1:ntst(2),2))) ok = .false.
+        if (.not.all(cr(1:nc)==ctst(1:nc)))          ok = .false.
+        if (fpr/=fptst)                              ok = .false.
+
+        if (.not.ok) then
+            write(useUnit,2200) trim(label), &
+                maxval(abs(txr(1:nxr)-ttst(1:ntst(1),1))), &
+                maxval(abs(tyr(1:nyr)-ttst(1:ntst(2),2))), &
+                maxval(abs(cr(1:nc)-ctst(1:nc))), abs(fpr-fptst)
+        end if
+
+        2000 format('[gate D] ',a,': ',a,' mismatch (ref=',i0,' nd=',i0,')')
+        2100 format('[gate D] ',a,': knot count mismatch nx ',i0,'/',i0,' ny ',i0,'/',i0)
+        2200 format('[gate D] ',a,' NOT bit-for-bit: max|dtx|=',1pe10.2,' max|dty|=',e10.2, &
+                    ' max|dc|=',e10.2,' |dfp|=',e10.2)
+    end function pair_ok
+
+end module fitpack_grid_nd_tests

--- a/test/fitpack_grid_nd_tests.f90
+++ b/test/fitpack_grid_nd_tests.f90
@@ -184,6 +184,7 @@ module fitpack_grid_nd_tests
         integer(FP_FLAG) :: ier_t
         ! shared
         real(FP_REAL)    :: zin(size(daregr_x)*size(daregr_y)),xb,xe,yb,ye,s,lo(2),hi(2)
+        real(FP_REAL)    :: zin2(size(daregr_y),size(daregr_x))   ! rank-2 (my,mx) data for regrid_nd
         integer(FP_SIZE) :: kx,ky,iopt,icase,i
         character(len=40):: lbl
 
@@ -191,6 +192,7 @@ module fitpack_grid_nd_tests
         mx = size(daregr_x,kind=FP_SIZE); my = size(daregr_y,kind=FP_SIZE)
         xb = daregr_x(1); xe = daregr_x(mx); yb = daregr_y(1); ye = daregr_y(my)
         zin = reshape(daregr_z,[mx*my])
+        zin2 = reshape(zin,[my,mx])        ! same bytes as zin, shaped (my,mx) = (ny,nx)
 
         ! regrid_nd marshalling that is constant across calls
         m2 = [mx,my]; nest2 = [NXEST,NYEST]; lo = [xb,yb]; hi = [xe,ye]
@@ -208,7 +210,7 @@ module fitpack_grid_nd_tests
             end select
             call regrid(iopt,mx,daregr_x,my,daregr_y,zin,xb,xe,yb,ye,kx,ky,s,NXEST,NYEST, &
                         nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
-            call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
+            call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin2,lo,hi,kk,s,nest2, &
                            ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
             write(lbl,'(a,i0)') 'cubic iopt-chain #',icase
             if (.not.pair_ok(useUnit,trim(lbl),kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
@@ -221,7 +223,7 @@ module fitpack_grid_nd_tests
         kx = 5; ky = 5; kk = [kx,ky]; iopt = 0; s = 0.2_FP_REAL
         call regrid(iopt,mx,daregr_x,my,daregr_y,zin,xb,xe,yb,ye,kx,ky,s,NXEST,NYEST, &
                     nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
-        call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
+        call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin2,lo,hi,kk,s,nest2, &
                        ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
         if (.not.pair_ok(useUnit,'quintic fresh iopt=0',kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
                          ntst,ttst,ctst,fptst,ier_t)) then
@@ -236,7 +238,7 @@ module fitpack_grid_nd_tests
         ttst(kx+2:kx+4,1) = txr(kx+2:kx+4); ttst(ky+2:ky+4,2) = tyr(ky+2:ky+4)
         call regrid(-1_FP_FLAG,mx,daregr_x,my,daregr_y,zin,xb,xe,yb,ye,kx,ky,s,NXEST,NYEST, &
                     nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
-        call regrid_nd(-1_FP_FLAG,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
+        call regrid_nd(-1_FP_FLAG,2_FP_DIM,m2,xgt,zin2,lo,hi,kk,s,nest2, &
                        ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
         if (.not.pair_ok(useUnit,'lsq given knots iopt=-1',kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
                          ntst,ttst,ctst,fptst,ier_t)) then
@@ -258,7 +260,7 @@ module fitpack_grid_nd_tests
         integer, intent(in) :: useUnit
 
         integer(FP_SIZE), parameter :: MX = 9, MY = 13
-        real(FP_REAL)    :: xg1(MX),yg1(MY),zin(MX*MY)
+        real(FP_REAL)    :: xg1(MX),yg1(MY),zin(MX*MY),zin2(MY,MX)
         ! reference (regrid)
         integer(FP_SIZE) :: nxr,nyr
         real(FP_REAL)    :: txr(NXEST),tyr(NYEST),cr(NCMAX),fpr,wrkr(LWRK)
@@ -287,6 +289,7 @@ module fitpack_grid_nd_tests
                               + xg1(i)*yg1(j)
            end do
         end do
+        zin2 = reshape(zin,[MY,MX])        ! same bytes as zin, shaped (my,mx) = (ny,nx)
 
         xb = xg1(1); xe = xg1(MX); yb = yg1(1); ye = yg1(MY)
         m2 = [MX,MY]; nest2 = [NXEST,NYEST]; lo = [xb,yb]; hi = [xe,ye]
@@ -301,7 +304,7 @@ module fitpack_grid_nd_tests
             end select
             call regrid(iopt,MX,xg1,MY,yg1,zin,xb,xe,yb,ye,kk(1),kk(2),s,NXEST,NYEST, &
                         nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
-            call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
+            call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin2,lo,hi,kk,s,nest2, &
                            ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
             write(lbl,'(a,i0)') 'non-square 9x13 #',icase
             if (.not.pair_ok(useUnit,trim(lbl),kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &

--- a/test/fitpack_grid_nd_tests.f90
+++ b/test/fitpack_grid_nd_tests.f90
@@ -9,6 +9,8 @@
 !     A. fpbisp_nd  vs bispev  (gridded evaluation)
 !     D. regrid_nd  vs regrid  (gridded fit; transitively covers fpregr_nd and fpgrre_nd, whose
 !                               outputs tx,ty,c,fp,nx,ny are exactly what regrid_nd returns)
+!     D'. regrid_nd vs regrid on a NON-SQUARE grid (mx /= my) — guards the z = (ny,nx) y-fast data
+!                               convention so an x<->y axis/size swap cannot hide behind mx==my
 !
 !   See todo/fitpack_nd_grids.md (slice 1) and Dierckx, Ch. 5 §5.4 (pp. 98-103).
 ! **************************************************************************************************
@@ -46,6 +48,9 @@ module fitpack_grid_nd_tests
 
         ! Gate D: regrid_nd vs regrid (backbone; transitively covers fpregr_nd + fpgrre_nd)
         if (success) success = gate_regrid_nd(useUnit)
+
+        ! Gate D': same, on a NON-SQUARE grid (mx /= my) so an x<->y data/size swap cannot hide
+        if (success) success = gate_regrid_nd_nonsquare(useUnit)
 
         ! Gate A: fpbisp_nd vs bispev
         if (success) success = gate_fpbisp_nd(useUnit)
@@ -240,6 +245,73 @@ module fitpack_grid_nd_tests
 
         write(useUnit,'(a)') '[gate D] regrid_nd == regrid (bit-for-bit; iopt=-1,0,1; cubic+quintic)'
     end function gate_regrid_nd
+
+    !> @brief Gate D' — regrid_nd vs regrid on a NON-SQUARE grid (mx /= my).
+    !!
+    !! The square 11x11 daregr battery cannot expose an x<->y swap in the data tensor or in the
+    !! per-axis sizing: with mx==my both indexings address the same elements. A non-square grid
+    !! makes any such swap a hard bit-for-bit failure, so this directly guards the z = (ny,nx)
+    !! (y-fast) storage convention as the *_nd path heads toward dims>2. The synthetic data is
+    !! deliberately NON-symmetric under x<->y (different centres/weights) so even a pure transpose
+    !! on a hypothetical square grid would be caught.
+    logical function gate_regrid_nd_nonsquare(useUnit) result(ok)
+        integer, intent(in) :: useUnit
+
+        integer(FP_SIZE), parameter :: MX = 9, MY = 13
+        real(FP_REAL)    :: xg1(MX),yg1(MY),zin(MX*MY)
+        ! reference (regrid)
+        integer(FP_SIZE) :: nxr,nyr
+        real(FP_REAL)    :: txr(NXEST),tyr(NYEST),cr(NCMAX),fpr,wrkr(LWRK)
+        integer(FP_SIZE) :: iwrkr(KWRK)
+        integer(FP_FLAG) :: ier_r
+        ! test (regrid_nd)
+        integer(FP_SIZE) :: ntst(2),kk(2),m2(2),nest2(2)
+        real(FP_REAL)    :: ttst(NXEST,2),ctst(NCMAX),fptst,wrkt(LWRK),xgt(MY,2)
+        integer(FP_SIZE) :: iwrkt(KWRK)
+        integer(FP_FLAG) :: ier_t
+        ! shared
+        real(FP_REAL)    :: xb,xe,yb,ye,s,lo(2),hi(2)
+        integer(FP_SIZE) :: i,j,iopt,icase
+        character(len=40):: lbl
+
+        ok = .true.
+
+        ! strictly increasing grids on [0,1]; distinct sizes mx=9, my=13
+        do i=1,MX; xg1(i) = real(i-1,FP_REAL)/real(MX-1,FP_REAL); end do
+        do j=1,MY; yg1(j) = real(j-1,FP_REAL)/real(MY-1,FP_REAL); end do
+
+        ! smooth, NON-symmetric data, stored y-fast: zin((i-1)*MY+j) = f(x_i,y_j)
+        do i=1,MX
+           do j=1,MY
+              zin((i-1)*MY+j) = (xg1(i)-0.5_FP_REAL)**2 + 2.0_FP_REAL*(yg1(j)-0.3_FP_REAL)**2 &
+                              + xg1(i)*yg1(j)
+           end do
+        end do
+
+        xb = xg1(1); xe = xg1(MX); yb = yg1(1); ye = yg1(MY)
+        m2 = [MX,MY]; nest2 = [NXEST,NYEST]; lo = [xb,yb]; hi = [xe,ye]
+        xgt = zero; xgt(1:MX,1) = xg1; xgt(1:MY,2) = yg1
+        wrkr = zero; iwrkr = 0; wrkt = zero; iwrkt = 0
+        kk = [3_FP_SIZE,3_FP_SIZE]
+
+        do icase=1,2
+            select case (icase)
+               case (1); iopt = 0; s = 0.05_FP_REAL   ! smoothing
+               case (2); iopt = 0; s = 0.0_FP_REAL    ! interpolation
+            end select
+            call regrid(iopt,MX,xg1,MY,yg1,zin,xb,xe,yb,ye,kk(1),kk(2),s,NXEST,NYEST, &
+                        nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
+            call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
+                           ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
+            write(lbl,'(a,i0)') 'non-square 9x13 #',icase
+            if (.not.pair_ok(useUnit,trim(lbl),kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
+                             ntst,ttst,ctst,fptst,ier_t)) then
+                ok = .false.; return
+            end if
+        end do
+
+        write(useUnit,'(a)') '[gate D''] regrid_nd == regrid (bit-for-bit; non-square 9x13)'
+    end function gate_regrid_nd_nonsquare
 
     !> @brief Compare a regrid vs regrid_nd result pair bit-for-bit; report on mismatch.
     logical function pair_ok(useUnit,label,k,nxr,nyr,txr,tyr,cr,fpr,ier_r, &

--- a/test/test.f90
+++ b/test/test.f90
@@ -4,6 +4,7 @@ program test
     use fitpack_test_data
     use fitpack_curve_tests
     use fitpack_cpp_tests
+    use fitpack_grid_nd_tests
     use iso_fortran_env, only: output_unit
     implicit none
 
@@ -68,6 +69,7 @@ program test
         call add_test(test_cross_section())
         call add_test(test_derivative_spline())
         call add_test(test_grid_surface_scattered_eval())
+        call add_test(test_nd_grid_equivalence())
 
     end subroutine run_interface_tests
 


### PR DESCRIPTION
## Summary

Slice 1 of the N-D gridded-spline extension (`todo/fitpack_nd_grids.md` §8, moves 1–2). It **duplicates** the 2-D gridded vertical slice into dimension-parameterized `*_nd` routines, **dimensionalizes** them, and runs them at **dims=2 behind a bit-for-bit equivalence gate** against the existing code.

This PR adds **no new capability** — it produces the proof (the gate) that the parameterized rewrite is *exactly* equivalent to the 2-D originals, which is what licenses extending to `dims>2` in a later slice. The originals (`regrid`/`fpregr`/`fpgrre`/`fpbisp`) and every OOP type are **byte-unchanged** and remain the production path.

## What's new (all in `src/fitpack_core.F90`, additions only)

- **`FP_DIM`** kind alias + **`fp_grid_strides`/`fp_grid_index`** row-major linear↔multi-index helpers.
- **`fpbisp_nd`** — gridded evaluation. Per-axis basis-table build looped over axes; the eval contraction kept literal-2 until `dims>2`.
- **`fpgrre_nd`** — tensor-product least-squares solver (the crux). Per-axis observation/discontinuity matrices and the `ifs/ifb` caching flags become runtime `do d=1,dims` loops; the alternating-direction reductions, back-substitution, and residual contraction stay literal-2.
- **`fpregr_nd`** — knot determination + p-iteration. Paired state → `dims`-length arrays, knot-init/placement → per-axis loops; the binary knot-direction arbiter and the scalar `f(p)=s` root-find stay literal-2.
- **`regrid_nd`** (public) — driver. Validation generalized per-axis; carves the user `wrk`/`iwrk` into rank-N work views via **pointer bounds remapping** (no allocation).

## The bit-for-bit invariant that made it work

The per-axis band matrices (`ax(nx,kx2)`, `ay(ny,ky2)`) have **different leading dimensions** in the 2-D code. Merging them into rank-3 arrays would misalign them — *unless* the merged array uses a **uniform leading dimension** and that true leading dim is passed as the explicit `na`/`nest` argument to `fp_rotate_*`, `fpback`, and `fpdisc`. Those primitives already take the leading dim explicitly, so consistent indexing keeps every computed value identical. No copies, no value change.

## Equivalence gate — `test/fitpack_grid_nd_tests.f90` (registered in `test/test.f90`)

| Gate | Asserts | Coverage |
|---|---|---|
| **A** | `fpbisp_nd` == `bispev` bit-for-bit | cubic / interpolation / quintic |
| **D** | `regrid_nd` == `regrid` bit-for-bit (`tx,ty,c,fp,nx,ny`) | `iopt = −1, 0, 1` + `s=0`; cubic + quintic |

Gate D is the backbone — its outputs **are** `fpregr_nd`/`fpgrre_nd`'s outputs, so a green D transitively certifies both. Comparison is exact (`==`), not tolerance, so it catches FP reassociation.

**Full suite green: 26 interface / 55 legacy / 60 c++, 0 failures.**

## Deviations from the literal 2-D structure (documented in source)

- The `*_nd` core takes **rank-3 work views**; `regrid_nd` self-partitions `wrk`/`iwrk` by pointer bounds remapping rather than flat-offset slices (the no-allocation rule is honored — all scratch is caller-supplied).
- `regrid_nd` exposes the small persistent fit-state at **fixed `wrk`/`iwrk` offsets** (`wrk(1)=fp0`, `wrk(2)=fpold`, `wrk(3:2+dims)=reduc`; `iwrk(1)=lastdi`, `iwrk(2:1+dims)=nplus`) so preserving `wrk`/`iwrk` between calls continues an `iopt=1` fit exactly as `regrid` does.

## Out of scope (next slices)

`dims>2`, the N-D ping-pong buffer, `new_knot_dimension`→argmax, fypp faces, `fitpack_gridded_3d…` types, `parder`/`dblint`/`profil`, and the C bindings.
