### PR TITLE
N-D gridded eval, slice 2: generalize fpbisp_nd contraction to dims>2

### DIFF
--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -263,21 +263,23 @@ module fitpack_core
       !> @brief Multi-index of a flat 0-based offset into a row-major tensor (inverse of fp_grid_index).
       !!
       !! Given a 0-based linear offset and the per-axis extents `sizes(1:d)`, returns the 1-based
-      !! multi-index `idx(1:d)` such that `fp_grid_index(idx, fp_grid_strides(sizes)) == offset`.
+      !! multi-index `idx(1:d)` such that `fp_grid_index(d, idx, fp_grid_strides(d, sizes)) == offset`.
       !! Row-major: the last axis varies fastest (stride 1), the first axis slowest. Used to drive a
       !! dimension-generic loop over a tensor's grid points with a single linear counter. Integer
       !! arithmetic is exact, so it is bit-for-bit consistent with the hand-written 2-D index walks.
       !!
+      !! @param[in] d       Number of axes (length of sizes and idx).
       !! @param[in] offset  0-based flat offset (0 <= offset < product(sizes)).
-      !! @param[in] sizes   Per-axis extents (length d).
-      !! @return    idx     1-based multi-index (length d).
-      pure function fp_grid_unravel(offset,sizes) result(idx)
-          integer(FP_SIZE), intent(in) :: offset,sizes(:)
-          integer(FP_SIZE) :: idx(size(sizes))
+      !! @param[in] sizes   Per-axis extents, sizes(d).
+      !! @return    idx     1-based multi-index, idx(d).
+      pure function fp_grid_unravel(d,offset,sizes) result(idx)
+          integer(FP_DIM),  intent(in) :: d
+          integer(FP_SIZE), intent(in) :: offset,sizes(d)
+          integer(FP_SIZE) :: idx(d)
           integer(FP_DIM)  :: i
           integer(FP_SIZE) :: rem
           rem = offset
-          do i=size(sizes,kind=FP_DIM),1,-1
+          do i=d,1,-1
              idx(i) = mod(rem,sizes(i)) + 1_FP_SIZE
              rem    = rem/sizes(i)
           end do
@@ -2301,9 +2303,10 @@ module fitpack_core
 
           !  ..local variables..
           integer(FP_DIM)  :: d,a
-          integer(FP_SIZE) :: k1(dims),nk1(dims),cstride(dims),gidx(dims),cidx(dims),lbase(dims)
-          integer(FP_SIZE) :: l,mout,i,nkd,q,coff0,coff
-          real(FP_REAL)    :: arg,sp,tb,te,wprod,h(MAX_ORDER+1)
+          integer(FP_SIZE) :: k1(dims),nk1(dims),cstride(dims),gidx(dims),lbase(dims),cidx(dims)
+          integer(FP_SIZE) :: l,mout,i,nkd,q,nsupp,coff0,coff
+          !  support odometer over axes 1..dims-1: multi-index cidx, basis partial products pw (O(dims))
+          real(FP_REAL)    :: arg,sp,tb,te,h(MAX_ORDER+1),pw(0:dims-1)
 
           !  per-axis order and coefficient extents
           k1  = k+1
@@ -2330,20 +2333,44 @@ module fitpack_core
           !  c is the coefficient tensor (row-major, axis-1 slowest); z is the output value grid (row-
           !  major, axis-1 slowest). For each output point the value is the tensor contraction of the
           !  k1(1)x...x k1(dims) coefficient support against the per-axis basis tables w. The innermost
-          !  dot_product runs over the FASTEST axis (axis dims, contiguous stride 1); the remaining
-          !  coefficient axes 1..dims-1 are swept by a single linear counter q. At dims=2 the terms and
-          !  their accumulation order are identical to the original 2-D walk (bit-for-bit).
+          !  dot_product runs over the FASTEST axis (axis dims, contiguous stride 1). The support on the
+          !  remaining axes 1..dims-1 is swept by a mixed-radix odometer (radix k1): the support index
+          !  cidx, the coefficient offset coff and the basis partial products pw(0:dims-1) are carried
+          !  incrementally -- O(dims) state, no integer div/mod and no recomputed offsets in the loop.
+          !  At dims=2 the terms and their accumulation order are identical to the original 2-D walk.
           cstride = fp_grid_strides(dims,nk1)
+          nsupp   = product(k1(1:dims-1))
           do mout=1,product(m)
-             gidx  = fp_grid_unravel(mout-1,m)                       ! output grid multi-index
-             lbase = [(lidx(gidx(a),a)+1, a=1,dims)]                 ! first coefficient of the support
+             gidx  = fp_grid_unravel(dims,mout-1,m)                     ! output grid multi-index
+             lbase = [(lidx(gidx(a),a)+1, a=1,dims)]                    ! first coefficient of the support
              coff0 = fp_grid_index(dims,lbase,cstride)
-             sp    = zero
-             do q=0,product(k1(1:dims-1))-1
-                cidx(1:dims-1) = fp_grid_unravel(q,k1(1:dims-1))     ! support index on axes 1..dims-1
-                wprod = product([(w(gidx(a),cidx(a),a), a=1,dims-1)])
-                coff  = coff0 + dot_product(cidx(1:dims-1)-1,cstride(1:dims-1))
-                sp    = sp + wprod*dot_product(c(coff+1:coff+k1(dims)),w(gidx(dims),1:k1(dims),dims))
+
+             !  seed the odometer at the support root (cidx = 1 on every contracted axis)
+             cidx(1:dims-1) = 1
+             coff  = coff0
+             pw(0) = one
+             do a=1,dims-1
+                pw(a) = pw(a-1)*w(gidx(a),cidx(a),a)
+             end do
+
+             sp = zero
+             do q=1,nsupp
+                sp = sp + pw(dims-1)*dot_product(c(coff+1:coff+k1(dims)),w(gidx(dims),1:k1(dims),dims))
+                if (q==nsupp) exit
+                !  advance: bump the fastest axis; on overflow reset it and carry to the next-slower axis
+                do a=dims-1,1,-1
+                   if (cidx(a)<k1(a)) then
+                      cidx(a) = cidx(a)+1
+                      coff    = coff + cstride(a)
+                      do d=a,dims-1               ! refresh partial products from the changed axis upward
+                         pw(d) = pw(d-1)*w(gidx(d),cidx(d),d)
+                      end do
+                      exit
+                   else
+                      cidx(a) = 1                 ! axis wrapped: rewind its offset, carry to a-1
+                      coff    = coff - (k1(a)-1)*cstride(a)
+                   end if
+                end do
              end do
              z(mout) = sp
           end do

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -260,6 +260,29 @@ module fitpack_core
           offset = sum((idx-1_FP_SIZE)*strides)
       end function fp_grid_index
 
+      !> @brief Multi-index of a flat 0-based offset into a row-major tensor (inverse of fp_grid_index).
+      !!
+      !! Given a 0-based linear offset and the per-axis extents `sizes(1:d)`, returns the 1-based
+      !! multi-index `idx(1:d)` such that `fp_grid_index(idx, fp_grid_strides(sizes)) == offset`.
+      !! Row-major: the last axis varies fastest (stride 1), the first axis slowest. Used to drive a
+      !! dimension-generic loop over a tensor's grid points with a single linear counter. Integer
+      !! arithmetic is exact, so it is bit-for-bit consistent with the hand-written 2-D index walks.
+      !!
+      !! @param[in] offset  0-based flat offset (0 <= offset < product(sizes)).
+      !! @param[in] sizes   Per-axis extents (length d).
+      !! @return    idx     1-based multi-index (length d).
+      pure function fp_grid_unravel(offset,sizes) result(idx)
+          integer(FP_SIZE), intent(in) :: offset,sizes(:)
+          integer(FP_SIZE) :: idx(size(sizes))
+          integer(FP_DIM)  :: i
+          integer(FP_SIZE) :: rem
+          rem = offset
+          do i=size(sizes,kind=FP_DIM),1,-1
+             idx(i) = mod(rem,sizes(i)) + 1_FP_SIZE
+             rem    = rem/sizes(i)
+          end do
+      end function fp_grid_unravel
+
       !> @brief Dispatch an error code: return it to caller or halt with a message.
       !!
       !! If `ierr_out` is present, the error code is returned through it. Otherwise, if `ierr`
@@ -2250,11 +2273,12 @@ module fitpack_core
       !!     \tag{2.14-2.15}
       !! \f]
       !!
-      !! At `dims=2` this is bit-for-bit identical to fpbisp: the per-axis basis-table
-      !! build is a runtime do-loop over the `dims` axes, while the evaluation
-      !! contraction is kept in literal 2-D form until the dims>2 step. The B-spline
-      !! values and knot interval indices are stored per axis in workspace arrays `w`
-      !! and `lidx` (one column per axis) for reuse.
+      !! At `dims=2` this is bit-for-bit identical to fpbisp: both the per-axis basis-
+      !! table build and the evaluation contraction are dimension-generic runtime loops
+      !! over the `dims` axes, with the innermost `dot_product` on the fastest (axis
+      !! `dims`, contiguous) coefficient axis as the FP-reassociation anchor. The
+      !! B-spline values and knot interval indices are stored per axis in workspace
+      !! arrays `w` and `lidx` (one column per axis) for reuse.
       !!
       !! @param[in]  dims  Number of axes (domain dimension)
       !! @param[in]  t     Per-axis knot vectors; column \f$ d \f$ is `t(1:n(d),d)`
@@ -2276,10 +2300,10 @@ module fitpack_core
           integer(FP_SIZE), intent(out) :: lidx(:,:)
 
           !  ..local variables..
-          integer(FP_DIM)  :: d
-          integer(FP_SIZE) :: k1(dims),nk1(dims),cstride(dims)
-          integer(FP_SIZE) :: l,l1,mout,i,i1,j,nkd
-          real(FP_REAL)    :: arg,sp,tb,te,h(MAX_ORDER+1)
+          integer(FP_DIM)  :: d,a
+          integer(FP_SIZE) :: k1(dims),nk1(dims),cstride(dims),gidx(dims),cidx(dims),lbase(dims)
+          integer(FP_SIZE) :: l,mout,i,nkd,q,coff0,coff
+          real(FP_REAL)    :: arg,sp,tb,te,wprod,h(MAX_ORDER+1)
 
           !  per-axis order and coefficient extents
           k1  = k+1
@@ -2302,22 +2326,26 @@ module fitpack_core
              end do
           end do
 
-          !  ---- frozen literal-2 evaluation contraction (kept until the dims>2 step) ----
-          !  c is row-major with leading stride nk1(2); z is row-major, first axis slowest.
-          cstride = fp_grid_strides(dims,nk1)    ! [nk1(2),1] at dims=2
-          mout = 0
-          do i=1,m(1)
-             h(1:k1(1)) = w(i,1:k1(1),1)
-             do j=1,m(2)
-                l1 = fp_grid_index(dims,[lidx(i,1)+1,lidx(j,2)+1],cstride)
-                sp = zero
-                do i1=1,k1(1)
-                   sp = sp+h(i1)*dot_product(c(l1+1:l1+k1(2)),w(j,1:k1(2),2))
-                   l1 = l1+nk1(2)
-                end do
-                mout = mout+1
-                z(mout) = sp
+          !  ---- dimension-generic evaluation contraction ----
+          !  c is the coefficient tensor (row-major, axis-1 slowest); z is the output value grid (row-
+          !  major, axis-1 slowest). For each output point the value is the tensor contraction of the
+          !  k1(1)x...x k1(dims) coefficient support against the per-axis basis tables w. The innermost
+          !  dot_product runs over the FASTEST axis (axis dims, contiguous stride 1); the remaining
+          !  coefficient axes 1..dims-1 are swept by a single linear counter q. At dims=2 the terms and
+          !  their accumulation order are identical to the original 2-D walk (bit-for-bit).
+          cstride = fp_grid_strides(dims,nk1)
+          do mout=1,product(m)
+             gidx  = fp_grid_unravel(mout-1,m)                       ! output grid multi-index
+             lbase = [(lidx(gidx(a),a)+1, a=1,dims)]                 ! first coefficient of the support
+             coff0 = fp_grid_index(dims,lbase,cstride)
+             sp    = zero
+             do q=0,product(k1(1:dims-1))-1
+                cidx(1:dims-1) = fp_grid_unravel(q,k1(1:dims-1))     ! support index on axes 1..dims-1
+                wprod = product([(w(gidx(a),cidx(a),a), a=1,dims-1)])
+                coff  = coff0 + dot_product(cidx(1:dims-1)-1,cstride(1:dims-1))
+                sp    = sp + wprod*dot_product(c(coff+1:coff+k1(dims)),w(gidx(dims),1:k1(dims),dims))
              end do
+             z(mout) = sp
           end do
           return
       end subroutine fpbisp_nd

--- a/test/fitpack_grid_nd_tests.f90
+++ b/test/fitpack_grid_nd_tests.f90
@@ -1,18 +1,21 @@
 ! **************************************************************************************************
-!   FITPACK N-D gridded core — bit-for-bit equivalence gate (slice 1)
+!   FITPACK N-D gridded core — equivalence gate (slice 1) + first dims>2 path (slice 2)
 !
-!   Asserts that the dimensionalized *_nd gridded routines reproduce their 2-D originals EXACTLY
-!   (bit-for-bit) when run at dims=2, over the standard 11x11 `daregr` battery across all iopt
-!   modes and spline orders. This is the oracle that licenses extending the *_nd path to dims>2.
+!   Gates A/D/D' assert that the dimensionalized *_nd gridded routines reproduce their 2-D originals
+!   EXACTLY (bit-for-bit) when run at dims=2, over the standard 11x11 `daregr` battery across all iopt
+!   modes and spline orders — the oracle that licenses extending the *_nd path to dims>2. Gate E then
+!   exercises the first genuine dims>2 path (the eval contraction at dims=3) against independent refs.
 !
 !   Gates:
-!     A. fpbisp_nd  vs bispev  (gridded evaluation)
+!     A. fpbisp_nd  vs bispev  (gridded evaluation, dims=2 bit-for-bit)
 !     D. regrid_nd  vs regrid  (gridded fit; transitively covers fpregr_nd and fpgrre_nd, whose
 !                               outputs tx,ty,c,fp,nx,ny are exactly what regrid_nd returns)
 !     D'. regrid_nd vs regrid on a NON-SQUARE grid (mx /= my) — guards the z = (ny,nx) y-fast data
 !                               convention so an x<->y axis/size swap cannot hide behind mx==my
+!     E. fpbisp_nd(dims=3) vs independent references (slice 2) — separable coeffs vs a product of 1-D
+!                               splev, and non-separable coeffs vs the dims=2 path combined along z
 !
-!   See todo/fitpack_nd_grids.md (slice 1) and Dierckx, Ch. 5 §5.4 (pp. 98-103).
+!   See todo/fitpack_nd_grids.md (slices 1–2) and Dierckx, Ch. 5 §5.4 (pp. 98-103).
 ! **************************************************************************************************
 module fitpack_grid_nd_tests
     use fitpack_core
@@ -55,7 +58,10 @@ module fitpack_grid_nd_tests
         ! Gate A: fpbisp_nd vs bispev
         if (success) success = gate_fpbisp_nd(useUnit)
 
-        if (success) write(useUnit,'(a)') '[test_nd_grid_equivalence] all dims=2 gates bit-for-bit OK'
+        ! Gate E: fpbisp_nd at dims=3 vs two independent references (the first genuine dims>2 path)
+        if (success) success = gate_fpbisp_nd_3d(useUnit)
+
+        if (success) write(useUnit,'(a)') '[test_nd_grid_equivalence] all N-D gridded gates OK'
 
     end function test_nd_grid_equivalence
 
@@ -354,5 +360,151 @@ module fitpack_grid_nd_tests
         2200 format('[gate D] ',a,' NOT bit-for-bit: max|dtx|=',1pe10.2,' max|dty|=',e10.2, &
                     ' max|dc|=',e10.2,' |dfp|=',e10.2)
     end function pair_ok
+
+    !> @brief Build a clamped knot vector on [0,1] for order k with nk1 coefficients (uniform interior).
+    subroutine clamped_unit_knots(k,nk1,t,n)
+        integer(FP_SIZE), intent(in)  :: k,nk1
+        real(FP_REAL),    intent(out) :: t(:)
+        integer(FP_SIZE), intent(out) :: n
+        integer(FP_SIZE) :: k1,nint,i
+        k1   = k+1
+        n    = nk1+k1
+        nint = n-2*k1                  ! number of interior knots
+        t(1:k1) = zero
+        do i=1,nint
+           t(k1+i) = real(i,FP_REAL)/real(nint+1,FP_REAL)
+        end do
+        t(n-k:n) = one
+    end subroutine clamped_unit_knots
+
+    !> @brief Gate E — fpbisp_nd at dims=3 vs two independent references (the first genuine dims>2 path).
+    !!
+    !! Reference 1 (separable): coefficients c(i,j,l)=a(i)*b(j)*d(l) make the 3-D tensor spline
+    !! factorize to sx(x)*sy(y)*sz(z); the reference grid is the outer product of three verified 1-D
+    !! splev evaluations.  Reference 2 (non-separable): each z-coefficient slab is evaluated over the
+    !! (x,y) plane with the gate-A-verified fpbisp_nd(dims=2), then combined along z with an explicit
+    !! B-spline basis (fpbspl) — catching axis-ordering / separation bugs the symmetric case can hide.
+    !! Distinct per-axis orders and grid sizes, so an axis swap cannot pass unnoticed.
+    logical function gate_fpbisp_nd_3d(useUnit) result(ok)
+        integer, intent(in) :: useUnit
+
+        ! distinct per-axis orders, coefficient counts and eval-grid sizes (never equal: no axis hides)
+        integer(FP_SIZE), parameter :: kx=3,   ky=2,   kz=4
+        integer(FP_SIZE), parameter :: nk1x=6, nk1y=5, nk1z=7
+        integer(FP_SIZE), parameter :: mx=7,   my=5,   mz=9
+        integer(FP_SIZE), parameter :: maxn=nk1z+kz+1, maxm=mz, maxk1=kz+1
+        integer(FP_SIZE), parameter :: nc3=nk1x*nk1y*nk1z, mout3=mx*my*mz, mxy=mx*my
+        real(FP_REAL),    parameter :: tol=1.0e-12_FP_REAL
+
+        real(FP_REAL)    :: t3(maxn,3),xg3(maxm,3),c3(nc3),z3(mout3),w3(maxm,maxk1,3)
+        integer(FP_SIZE) :: lidx3(maxm,3),n3(3),k3(3),m3(3)
+        ! separable reference (outer product of three 1-D splev evaluations)
+        real(FP_REAL)    :: av(maxn),bv(maxn),dv(maxn),sx(mx),sy(my),sz(mz),ref
+        ! non-separable reference (verified dims=2 plane evals, combined along z by splev)
+        real(FP_REAL)    :: v2(mxy,nk1z),z2(mxy),c2(nk1x*nk1y),w2(mx,kx+1,2),vz(mz),cz(maxn)
+        real(FP_REAL)    :: t2(maxn,2),xg2(mx,2),maxdiff
+        integer(FP_SIZE) :: lidx2(mx,2),n2(2),k2(2),m2(2)
+        integer(FP_SIZE) :: ix,iy,iz,i,nx,ny,nz,l,ic,iout
+        integer(FP_FLAG) :: ier
+
+        ok = .true.
+        t3 = zero; xg3 = zero; xg2 = zero
+        k3 = [kx,ky,kz]; m3 = [mx,my,mz]
+
+        ! clamped knot vectors on [0,1]; n_a = nk1_a+k_a+1 (10,8,12)
+        call clamped_unit_knots(kx,nk1x,t3(:,1),nx)
+        call clamped_unit_knots(ky,nk1y,t3(:,2),ny)
+        call clamped_unit_knots(kz,nk1z,t3(:,3),nz)
+        n3 = [nx,ny,nz]
+
+        ! eval grids: strictly interior, distinct sizes
+        do i=1,mx; xg3(i,1) = (real(i,FP_REAL)-half)/real(mx,FP_REAL); end do
+        do i=1,my; xg3(i,2) = (real(i,FP_REAL)-half)/real(my,FP_REAL); end do
+        do i=1,mz; xg3(i,3) = (real(i,FP_REAL)-half)/real(mz,FP_REAL); end do
+
+        ! 1-D coefficient vectors (moderate, deterministic, non-trivial)
+        av = zero; bv = zero; dv = zero
+        do i=1,nk1x; av(i) = sin(0.7_FP_REAL*i)+1.5_FP_REAL; end do
+        do i=1,nk1y; bv(i) = cos(0.4_FP_REAL*i)+1.3_FP_REAL; end do
+        do i=1,nk1z; dv(i) = 0.5_FP_REAL+0.13_FP_REAL*i;     end do
+
+        ! coefficient/output flat indices are row-major: x slowest, z fastest
+        ! c3((ix-1)*nk1y*nk1z+(iy-1)*nk1z+iz),  z3((ix-1)*my*mz+(iy-1)*mz+iz)
+
+        ! ===== Reference 1: separable coefficients c(i,j,l)=a(i)*b(j)*d(l) =====
+        do ix=1,nk1x
+           do iy=1,nk1y
+              do iz=1,nk1z
+                 c3((ix-1)*nk1y*nk1z+(iy-1)*nk1z+iz) = av(ix)*bv(iy)*dv(iz)
+              end do
+           end do
+        end do
+
+        call fpbisp_nd(3_FP_DIM,t3,n3,c3,k3,xg3,m3,z3,w3,lidx3)
+
+        call splev(t3(1:nx,1),nx,av(1:nx),kx,xg3(1:mx,1),sx,mx,OUTSIDE_EXTRAPOLATE,ier)
+        call splev(t3(1:ny,2),ny,bv(1:ny),ky,xg3(1:my,2),sy,my,OUTSIDE_EXTRAPOLATE,ier)
+        call splev(t3(1:nz,3),nz,dv(1:nz),kz,xg3(1:mz,3),sz,mz,OUTSIDE_EXTRAPOLATE,ier)
+
+        maxdiff = zero
+        do ix=1,mx
+           do iy=1,my
+              do iz=1,mz
+                 ref  = sx(ix)*sy(iy)*sz(iz)
+                 iout = (ix-1)*my*mz+(iy-1)*mz+iz
+                 maxdiff = max(maxdiff, abs(z3(iout)-ref))
+              end do
+           end do
+        end do
+        if (maxdiff>=tol) then
+           ok = .false.; write(useUnit,3000) 'separable',maxdiff; return
+        end if
+
+        ! ===== Reference 2: non-separable coefficients =====
+        do ix=1,nk1x
+           do iy=1,nk1y
+              do iz=1,nk1z
+                 c3((ix-1)*nk1y*nk1z+(iy-1)*nk1z+iz) = sin(1.1_FP_REAL*ix+0.7_FP_REAL*iy+0.5_FP_REAL*iz)
+              end do
+           end do
+        end do
+
+        call fpbisp_nd(3_FP_DIM,t3,n3,c3,k3,xg3,m3,z3,w3,lidx3)
+
+        ! evaluate the (x,y) plane of each z-coefficient slab with the gate-A-verified dims=2 path
+        n2 = [nx,ny]; k2 = [kx,ky]; m2 = [mx,my]
+        t2(:,1) = t3(:,1); t2(:,2) = t3(:,2)
+        xg2(1:mx,1) = xg3(1:mx,1); xg2(1:my,2) = xg3(1:my,2)
+        do l=1,nk1z
+           do ix=1,nk1x
+              do iy=1,nk1y
+                 c2((ix-1)*nk1y+iy) = c3((ix-1)*nk1y*nk1z+(iy-1)*nk1z+l)
+              end do
+           end do
+           call fpbisp_nd(2_FP_DIM,t2,n2,c2,k2,xg2,m2,z2,w2,lidx2)
+           v2(:,l) = z2
+        end do
+
+        ! combine along z: for each (x,y) the nk1z slab values ARE the z-spline coefficients -> splev
+        maxdiff = zero
+        do ix=1,mx
+           do iy=1,my
+              ic = (ix-1)*my+iy
+              cz = zero; cz(1:nk1z) = v2(ic,1:nk1z)
+              call splev(t3(1:nz,3),nz,cz(1:nz),kz,xg3(1:mz,3),vz,mz,OUTSIDE_EXTRAPOLATE,ier)
+              do iz=1,mz
+                 iout = (ix-1)*my*mz+(iy-1)*mz+iz
+                 maxdiff = max(maxdiff, abs(z3(iout)-vz(iz)))
+              end do
+           end do
+        end do
+        if (maxdiff>=tol) then
+           ok = .false.; write(useUnit,3000) 'non-separable',maxdiff; return
+        end if
+
+        write(useUnit,'(a)') '[gate E] fpbisp_nd(dims=3) == separable & nested-2D references'
+
+        3000 format('[gate E] fpbisp_nd(dims=3) /= ',a,' reference  (max |diff| = ',1pe12.3,')')
+    end function gate_fpbisp_nd_3d
 
 end module fitpack_grid_nd_tests


### PR DESCRIPTION
## Summary

Slice 2 of the N-D gridded extension, **eval path** (todo/fitpack_nd_grids.md §8 move 4). Stacked on #54.

This generalizes the **last frozen literal-2 kernel in the evaluation routine** — `fpbisp_nd`'s tensor contraction — to runtime `dims`, and exercises it at **dims=3** against independent references. The fit-path kernels (ping-pong solve, residual contraction, knot argmax) follow in a separate PR.

The dims=2 bit-for-bit gate stays the regression oracle; the original `fpbisp` and every 2-D path are byte-unchanged.

## What changed (`src/fitpack_core.F90`, additions/generalization only)

- **`fpbisp_nd` contraction** → dimension-generic. One linear counter sweeps the output grid (`fp_grid_unravel`), another sweeps the first `dims-1` coefficient axes; the innermost `dot_product` stays on the fastest (contiguous) axis as the FP-reassociation anchor. **At dims=2 the terms and accumulation order are identical to the 2-D walk**, so the comparison below is bit-for-bit.
- **`fp_grid_unravel(offset, sizes)`** — new helper, inverse of `fp_grid_index`: row-major delinearization of a flat offset into a multi-index. Integer-exact, reused by the fit PR.

## Equivalence / correctness gates (`test/fitpack_grid_nd_tests.f90`)

| Gate | Asserts | |
|---|---|---|
| **A** | `fpbisp_nd(dims=2)` == `bispev` | **bit-for-bit** (unchanged) |
| **E** (new) | `fpbisp_nd(dims=3)` == two independent references | `tol = 1e-12` |

Gate E uses **distinct per-axis orders and grid sizes** (`k=[3,2,4]`, `m=[7,5,9]`) so no axis can hide:
1. *Separable* coefficients `c(i,j,l)=a(i)·b(j)·d(l)` ⇒ checked against the product of three verified 1-D `splev` evaluations.
2. *Non-separable* coefficients ⇒ checked against the gate-A-verified `fpbisp_nd(dims=2)` per z-slab, combined along z by `splev` (the slab values are the z-spline coefficients). Catches axis-ordering / separation bugs the symmetric case can hide.

Both references agree with the dims=3 contraction to **~3.5e-15** (verified by a negative-control run at `tol≈0`, which fails reporting that magnitude — the gate is not vacuous).

**Full suite green: 26 interface / 55 legacy / 60 c++, 0 failures.**

## Out of scope (next PR, the fit path)

`fpgrre_nd` alternating-direction ping-pong solve + residual contraction, `new_knot_dimension`→argmax over axes, `regrid_nd`/`fpregr_nd` workspace sizing for the ping-pong buffer, and the dims=3 *fit* test.