### PR TITLE
N-D gridded fit: generalize fitpack_gridded_surface

### DIFF
--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -7431,7 +7431,7 @@ module fitpack_core
       !! @param[in,out] ifb     Per-axis flag: 0 = recompute discontinuity matrix \f$ B \f$ (orig ifbx,ifby)
       !! @param[in]     xg      Per-axis grid values; column \f$ d \f$ is `xg(1:m(d),d)`
       !! @param[in]     m       Number of grid points per axis, `m(dims)`
-      !! @param[in]     z       Data on the grid, flat `z(product(m))`, row-major (axis 1 slowest)
+      !! @param[in]     z       Gridded data, flat row-major `z(*)` (axis 1 slowest)
       !! @param[in]     k       Degree per axis, `k(dims)`
       !! @param[in]     t       Per-axis knot vectors; column \f$ d \f$ is `t(1:n(d),d)`
       !! @param[in]     n       Number of knots per axis, `n(dims)`
@@ -7462,11 +7462,9 @@ module fitpack_core
       integer(FP_SIZE), intent(in)    :: m(dims),k(dims),n(dims)
       integer(FP_SIZE), intent(inout) :: ifs(dims),ifb(dims)
       !  ..array arguments..
-      !  z(product(m)): gridded data tensor, flat row-major over the dims axes -- axis 1 SLOWEST,
-      !  axis dims FASTEST (stride 1). The datum at multi-index (i1,...,id) is z(fp_grid_index+1).
-      !  At dims=2 element z((i1-1)*my+i2) is the datum at (x_i1,y_i2) -- bit-for-bit the legacy
-      !  layout (the old rank-2 z(m(2),m(1)) had identical bytes: y/axis-2 fastest).
-      real(FP_REAL),    intent(in)              :: z(product(m))
+      !  z(*): flat row-major data tensor (axis 1 slowest, axis dims fastest). The datum at
+      !  (i1,...,id) is z(fp_grid_index+1); at dims=2 z((i1-1)*my+i2) matches the legacy z(my,mx) bytes.
+      real(FP_REAL),    intent(in)              :: z(*)
       real(FP_REAL),    intent(in),  contiguous :: xg(:,:),t(:,:)
       real(FP_REAL),    intent(inout)           :: c(nc),right(mm),q(mynx)
       real(FP_REAL),    intent(inout), contiguous :: fpint(:,:),sp(:,:,:),a(:,:,:),b(:,:,:)
@@ -7529,13 +7527,10 @@ module fitpack_core
       end if
 
       !  ======================================================================================
-      !  Dimension-generic alternating-direction solve. Every coefficient/data buffer is canonical
-      !  row-major over the dims axes (axis 1 slowest, axis dims fastest, stride 1). Pass d reduces
-      !  axis d; the partially-reduced RHS lives in a ping-pong buffer that, after pass i, stores
-      !  (coefficients along axes 1..i) x (data along axes i+1..dims). The leading passes 1..dims-1
-      !  use the column-access block rotation; the final pass dims uses the row-access stride
-      !  rotation, writing the coefficient tensor c. At dims=2 this is the literal A_x then A_y
-      !  reduction, bit-for-bit.
+      !  Dimension-generic alternating-direction solve (row-major buffers, axis 1 slowest). Pass d
+      !  reduces axis d into a ping-pong buffer holding coeffs along axes 1..d, data along d+1..dims.
+      !  Passes 1..dims-1 use the block rotation; the final pass uses the stride rotation, writing c.
+      !  At dims=2 this is the literal A_x then A_y reduction, bit-for-bit.
       !  ======================================================================================
       cstr  = fp_grid_strides(dims,nk1)            ! cstr(d) = product(nk1(d+1:dims)); cstr(dims)=1
       hhalf = mynx/2                               ! ping-pong half size (only dims>2 uses both halves)
@@ -7548,8 +7543,7 @@ module fitpack_core
          if (d<dims) then
 
             !  ---- block reduction of axis d: RHS = the td_trail contiguous trailing entries ----
-            !  reduce a(:,:,d) to upper triangular form, applying the same rotations to the trailing
-            !  data block to obtain the next ping-pong buffer. b_{d-1} (= z at d=1) -> b_d.
+            !  triangularize a(:,:,d), rotating the trailing data block into the next buffer (z at d=1).
             obuf = merge(0_FP_SIZE, hhalf, mod(d,2)==1)
             q(obuf+1:obuf+pd_lead*nk1(d)*td_trail) = zero
             do pp=1,pd_lead                        ! one independent reduction per leading slab
@@ -7592,8 +7586,7 @@ module fitpack_core
          else
 
             !  ---- stride reduction of the final axis: RHS = the pd_lead leading coeff combos ----
-            !  reduce a(:,:,dims), applying the rotations to the columns of the last buffer to obtain
-            !  the (nk1(dims)) x (pd_lead) coefficient tensor c.
+            !  triangularize a(:,:,dims), rotating the last buffer's columns into the coeff tensor c.
             ncof = product(nk1)
             c(1:ncof) = zero
             a(1:nk1(dims),1:k2(dims),dims) = zero
@@ -7629,11 +7622,9 @@ module fitpack_core
          end if
       end do forward
 
-      !  ---- back-substitution: solve the per-axis triangular systems, axis dims down to axis 1 ----
-      !  (the R_d^{-1} operators do not commute in floating point, so the order is the reverse of the
-      !  forward reduction). For each axis d, solve every line along axis d through the coeff tensor:
-      !  contiguous (stride 1) in place, strided via gather/solve/scatter. At dims=2 this is the
-      !  literal (R_y) then (R_x) two-step solve.
+      !  ---- back-substitution: per-axis triangular solves, axis dims down to 1 (R_d^{-1} don't
+      !  commute in FP, so reverse of the forward order). Each line along axis d: in place if
+      !  contiguous, else gather/solve/scatter. At dims=2 the literal (R_y) then (R_x) solve.
       do d=dims,1,-1
          nlead  = product(nk1(1:d-1))
          ntrail = cstr(d)
@@ -7643,24 +7634,19 @@ module fitpack_core
                if (ntrail==1) then
                   c(base+1:base+nk1(d)) = fpback(a(:,:,d),c(base+1),nk1(d),iband(d),lda)
                else
-                  do i=1,nk1(d)
-                     right(i) = c(base+(i-1)*ntrail+1)
-                  end do
+                  forall (i=1:nk1(d)) right(i) = c(base+(i-1)*ntrail+1)
                   right(1:nk1(d)) = fpback(a(:,:,d),right,nk1(d),iband(d),lda)
-                  do i=1,nk1(d)
-                     c(base+(i-1)*ntrail+1) = right(i)
-                  end do
+                  forall (i=1:nk1(d)) c(base+(i-1)*ntrail+1) = right(i)
                end if
             end do
          end do
       end do
 
-      !  ---- residual: fp and the per-axis interval residual sums fpint(:,d) (orig fpx,fpy) ----
-      !  walk the output grid row-major; for each cell contract the k1(1)x...x k1(dims) coefficient
-      !  support against the per-axis basis tables sp via a mixed-radix odometer (innermost
-      !  dot_product over the fastest axis = reassociation anchor), then accumulate fp and split each
-      !  axis's boundary residual half-and-half on its interval transitions. At dims=2 the terms,
-      !  their accumulation order and the half-splits are identical to the original grid_x/grid_y walk.
+      !  ---- residual: fp and the per-axis interval sums fpint(:,d) (orig fpx,fpy) ----
+      !  walk the grid row-major; contract each cell's coeff support against sp via a mixed-radix
+      !  odometer (innermost dot_product over the fastest axis), then accumulate fp and half-split
+      !  each axis's boundary residual on its interval transitions. Bit-for-bit with grid_x/grid_y
+      !  at dims=2.
       fp = zero
       fpint(:,1:dims) = zero
       nsupp = product(k1(1:dims-1))
@@ -7701,8 +7687,7 @@ module fitpack_core
          do d=1,dims
             num = nr(gidx(d),d)
             fpint(num+1,d) = fpint(num+1,d) + term
-            !  "did axis d's knot interval change vs the previous cell along axis d?" -- a pure
-            !  function of gidx(d) (avoid evaluating nr(0,d) at the axis origin).
+            !  did axis d's interval change vs the previous cell? (avoid reading nr(0,d) at the origin)
             if (gidx(d)>=2) then
                nrold_d = nr(gidx(d)-1,d)
             else
@@ -12828,7 +12813,7 @@ module fitpack_core
       !! @param[in]     dims    Number of axes (domain dimension)
       !! @param[in]     xg      Per-axis grid values; column \f$ d \f$ is `xg(1:m(d),d)`
       !! @param[in]     m       Number of grid points per axis, `m(dims)`
-      !! @param[in]     z       Data values, flat `z(product(m))`, row-major (passed through to fpgrre_nd)
+      !! @param[in]     z       Data values, flat row-major `z(*)` (passed through to fpgrre_nd)
       !! @param[in]     lo      Per-axis lower boundary (orig xb,yb)
       !! @param[in]     hi      Per-axis upper boundary (orig xe,ye)
       !! @param[in]     k       Degree per axis, `k(dims)`
@@ -12875,9 +12860,8 @@ module fitpack_core
       integer(FP_SIZE), intent(inout) :: n(dims),nplus(dims)
       real(FP_REAL),    intent(inout) :: reduc(dims)
       !  ..array arguments (data + caller-supplied workspace views)..
-      !  z(product(m)): flat row-major gridded data (axis 1 slowest); passed straight to fpgrre_nd,
-      !  which documents and indexes the convention. fpregr_nd never reads z.
-      real(FP_REAL),    intent(in)               :: z(product(m))
+      !  z(*): flat row-major gridded data, passed straight to fpgrre_nd; fpregr_nd never reads it.
+      real(FP_REAL),    intent(in)               :: z(*)
       real(FP_REAL),    intent(in),    contiguous :: xg(:,:)
       real(FP_REAL),    intent(inout), contiguous :: t(:,:),fpint(:,:),sp(:,:,:),right(:),q(:),a(:,:,:),b(:,:,:)
       integer(FP_SIZE), intent(inout), contiguous :: nr(:,:),nrdat(:,:)
@@ -17969,10 +17953,9 @@ module fitpack_core
       !! Minimum sizes:
       !!   lwrk >= 2 + dims + nestmax*dims + mmax*(kmax+1)*dims + 2*nestmax*(kmax+2)*dims + mm + mq
       !!   kwrk >= 1 + dims + mmax*dims + nestmax*dims
-      !! with mmax=maxval(m), nestmax=maxval(nest), kmax=maxval(k). At dims=2, mm=max(nestmax,mmax)
-      !! and mq=mmax*nestmax. At dims>2 the two ping-pong buffers grow: with nk1max=nest-(k+1),
-      !! mq = 2*max_{i=1..dims-1} [ product(nk1max(1:i)) * product(m(i+1:dims)) ] and
-      !! mm = max(nestmax, mmax, product(m(2:dims)), product(nk1max(1:dims-1))).
+      !! with mmax=maxval(m), nestmax=maxval(nest), kmax=maxval(k), nk1max=nest-(k+1):
+      !!   mq = 2*max_{i=1..dims-1} [ product(nk1max(1:i)) * product(m(i+1:dims)) ]
+      !!   mm = max(nestmax, mmax, product(m(2:dims)), product(nk1max(1:dims-1)))
       !!
       !! @see regrid, fpregr_nd; Dierckx, SIAM J.Numer.Anal. 19 (1982) 1286-1304; Ch.5 §5.4.
       pure subroutine regrid_nd(iopt,dims,m,xg,z,lo,hi,k,s,nest,n,t,c,fp,wrk,lwrk,iwrk,kwrk,ier)
@@ -17988,7 +17971,7 @@ module fitpack_core
       integer(FP_SIZE), intent(in)    :: m(dims),k(dims),nest(dims)
       real(FP_REAL),    intent(in)    :: lo(dims),hi(dims)
       integer(FP_SIZE), intent(inout) :: n(dims)
-      real(FP_REAL),    intent(in)              :: z(product(m))  ! flat row-major gridded data (axis 1 slowest)
+      real(FP_REAL),    intent(in)              :: z(*)           ! flat row-major gridded data (axis 1 slowest)
       real(FP_REAL),    intent(in),    contiguous :: xg(:,:)
       real(FP_REAL),    intent(inout), contiguous :: t(:,:)
       real(FP_REAL),    intent(inout)             :: c(*)
@@ -18000,9 +17983,9 @@ module fitpack_core
       real(FP_REAL),    parameter :: tol = smallnum03
       !  ..local scalars..
       integer(FP_DIM)  :: d
-      integer(FP_SIZE) :: nc,lwest,kwest,maxm,maxnest,maxk1,maxk2,mm,mynx,offr,offi
+      integer(FP_SIZE) :: nc,lwest,kwest,maxm,maxnest,maxk1,maxk2,mm,mynx,offr,offi,i,bufmax
       !  ..per-axis arrays..
-      integer(FP_SIZE) :: k1(dims),k2(dims),nmin(dims)
+      integer(FP_SIZE) :: k1(dims),k2(dims),nmin(dims),nk1max(MAX_IDIM)
       !  ..workspace views (carved from wrk/iwrk; contiguous by construction)..
       real(FP_REAL),    pointer, contiguous :: pfpint(:,:),psp(:,:,:),pa(:,:,:),pb(:,:,:),pright(:),pq(:)
       integer(FP_SIZE), pointer, contiguous :: pnr(:,:),pnrdat(:,:)
@@ -18024,25 +18007,15 @@ module fitpack_core
       maxnest = maxval(nest)
       maxk1   = maxval(k)+1
       maxk2   = maxval(k)+2
-      mm      = max(maxnest,maxm)
-      mynx    = maxm*maxnest
-
-      !  dims>2: grow the two literal-2 buffers to the N-D requirement. right (mm) holds the widest
-      !  gathered RHS fiber; q (mynx) holds the two ping-pong buffers, each big enough for the largest
-      !  intermediate tensor max_i [ product(nk1max(1:i)) * product(m(i+1:dims)) ]. dims=2 is untouched
-      !  (the formula reduces to the single buffer maxm*maxnest), so the dims=2 gate path never moves.
-      if (dims>2) then
-         block
-            integer(FP_SIZE) :: nk1max(dims),bufmax,i
-            nk1max = nest-k1
-            bufmax = 0
-            do i=1,dims-1
-               bufmax = max(bufmax, product(nk1max(1:i))*product(m(i+1:dims)))
-            end do
-            mm   = max(mm, product(m(2:dims)), product(nk1max(1:dims-1)), maxval(nk1max))
-            mynx = 2*bufmax
-         end block
-      end if
+      !  q holds two ping-pong buffers (one per intermediate tensor); right holds the widest gathered
+      !  fiber. At dims=2 only the first half is referenced, so the bit-for-bit gate path is unchanged.
+      nk1max(1:dims) = nest-k1
+      bufmax = 0
+      do i=1,dims-1
+         bufmax = max(bufmax, product(nk1max(1:i))*product(m(i+1:dims)))
+      end do
+      mm   = max(maxnest, maxm, product(m(2:dims)), product(nk1max(1:dims-1)), maxval(nk1max(1:dims)))
+      mynx = 2*bufmax
 
       lwest = (2+dims) + maxnest*dims + maxm*maxk1*dims + 2*maxnest*maxk2*dims + mm + mynx
       kwest = (1+dims) + maxm*dims + maxnest*dims

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -13020,11 +13020,9 @@ module fitpack_core
              endif
           end do
 
-         ! choose the axis for the next knots. new_knot_dimension returns the dimension index
-         ! (KNOT_DIM_1 or KNOT_DIM_2 at dims=2); lastdi then drives the refinement directly, so the
-         ! binary branch collapses to a single dimension-indexed block. The arbiter itself stays
-         ! binary until the dims>2 step replaces it with an argmax over the axes.
-         lastdi = new_knot_dimension(n(1),npl(1),ne(1),n(2),npl(2),ne(2),lastdi)
+         ! choose the axis for the next knots: the uncapped axis with the smallest pending count
+         ! npl(d) (ties to the highest index). lastdi then drives the placement below.
+         lastdi = new_knot_dimension_nd(dims,n,npl,ne)
 
          ! add knots along the chosen axis (lastdi in 1..dims).
          d        = lastdi
@@ -13100,6 +13098,34 @@ module fitpack_core
          end if
 
       end function new_knot_dimension
+
+      !> @brief Choose which axis gets the next knots (N-D form of new_knot_dimension).
+      !!
+      !! Among the uncapped axes (n(d)<ne(d)) picks the one with the smallest pending knot count
+      !! npl(d); ties resolve to the highest axis index. At dims=2 this is bit-for-bit identical to
+      !! new_knot_dimension. The caller guarantees at least one uncapped axis, so dir ends in 1..dims.
+      !!
+      !! @param[in] dims  Number of axes
+      !! @param[in] n     Current knot count per axis
+      !! @param[in] npl   Pending knots to add per axis this iteration
+      !! @param[in] ne    Knot cap per axis (min(nmax,nest))
+      !! @return Dimension index (1..dims) of the axis to refine
+      pure integer(FP_SIZE) function new_knot_dimension_nd(dims,n,npl,ne) result(dir)
+         integer(FP_DIM),  intent(in) :: dims
+         integer(FP_SIZE), intent(in) :: n(dims),npl(dims),ne(dims)
+         integer(FP_DIM) :: d
+
+         dir = KNOT_DIM_NONE
+         do d=1,dims
+            if (n(d)>=ne(d)) cycle              ! axis d is at its cap: skip
+            if (dir==KNOT_DIM_NONE) then
+               dir = d                          ! first uncapped axis
+            elseif (npl(d)<=npl(dir)) then      ! '<=' makes ties favor the higher index
+               dir = d
+            end if
+         end do
+
+      end function new_knot_dimension_nd
 
       !> @brief Apply a Givens plane rotation to two scalars.
       !!

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -7409,24 +7409,29 @@ module fitpack_core
       !! \f]
       !!
       !! The per-axis QR factorizations are performed independently using
-      !! fp_rotate_row_stride (row-access RHS for \f$ A_y \f$) and fp_rotate_row_block
-      !! (column-access RHS for \f$ A_x \f$), followed by back-substitution; residual
-      !! sums `fpint` per knot interval are also computed for knot-placement decisions.
-      !! At `dims=2` this is bit-for-bit identical to fpgrre: the per-axis housekeeping
-      !! is a runtime do-loop over the axes, while the alternating-direction reductions,
-      !! the two-pass back-substitution and the residual contraction are kept literal-2
-      !! until the dims>2 step. The per-axis band/observation/discontinuity arrays are
-      !! merged into rank-3 arrays with a uniform leading dimension (`lda`/`ldb`), passed
-      !! as the explicit leading-dim argument to fp_rotate_*, fpback and fpdisc so every
-      !! addressed element coincides with the original's separately-sized matrices — no
-      !! copies, no value change.
+      !! fp_rotate_row_block (column-access RHS) for the leading axes `1..dims-1` and
+      !! fp_rotate_row_stride (row-access RHS) for the final axis, followed by per-axis
+      !! back-substitution; residual sums `fpint` per knot interval are also computed for
+      !! knot-placement decisions. This is the dimension-generic form: each pass reduces
+      !! one axis, with the partially-reduced right-hand side held in a row-major
+      !! "ping-pong" buffer that, after pass `i`, stores (coefficients along axes `1..i`)
+      !! x (data along axes `i+1..dims`). At `dims=2` it is bit-for-bit identical to
+      !! fpgrre: the leading pass is the single `A_x` block reduction (RHS width `my`),
+      !! the final pass the `A_y` stride reduction, the back-substitution solves `R_dims`
+      !! then descends to `R_1`, and the residual contraction is the same per-cell walk
+      !! (the support sweep is a mixed-radix odometer whose innermost `dot_product` runs
+      !! over the fastest axis — the floating-point reassociation anchor). The per-axis
+      !! band/observation/discontinuity arrays are merged into rank-3 arrays with a
+      !! uniform leading dimension (`lda`/`ldb`), passed as the explicit leading-dim
+      !! argument to fp_rotate_*, fpback and fpdisc so every addressed element coincides
+      !! with the original's separately-sized matrices — no copies, no value change.
       !!
       !! @param[in]     dims    Number of axes (domain dimension)
       !! @param[in,out] ifs     Per-axis flag: 0 = recompute observation matrix \f$ S_p \f$ (orig ifsx,ifsy)
       !! @param[in,out] ifb     Per-axis flag: 0 = recompute discontinuity matrix \f$ B \f$ (orig ifbx,ifby)
       !! @param[in]     xg      Per-axis grid values; column \f$ d \f$ is `xg(1:m(d),d)`
       !! @param[in]     m       Number of grid points per axis, `m(dims)`
-      !! @param[in]     z       Data on the grid, `z(m(2),m(1))`, (ny,nx)-ordered (axis-2 fastest)
+      !! @param[in]     z       Data on the grid, flat `z(product(m))`, row-major (axis 1 slowest)
       !! @param[in]     k       Degree per axis, `k(dims)`
       !! @param[in]     t       Per-axis knot vectors; column \f$ d \f$ is `t(1:n(d),d)`
       !! @param[in]     n       Number of knots per axis, `n(dims)`
@@ -7435,11 +7440,11 @@ module fitpack_core
       !! @param[in]     nc      Length of `c`
       !! @param[in,out] fp      Total weighted sum of squared residuals
       !! @param[in,out] fpint   Residual sums per knot interval, per axis (orig fpx,fpy)
-      !! @param[in]     mm      Work dimension
-      !! @param[in]     mynx    Work dimension (\f$ my \cdot (nx - kx - 1) \f$)
+      !! @param[in]     mm      Work dimension: widest gathered RHS fiber
+      !! @param[in]     mynx    Work dimension: two ping-pong buffers (\f$ my \cdot (nx-kx-1) \f$ at dims=2)
       !! @param[in,out] sp      Per-axis B-spline observation matrices (orig spx,spy)
       !! @param[in,out] right   Work: RHS vector for row rotations, length `mm`
-      !! @param[in,out] q       Work: RHS matrix, length `mynx`
+      !! @param[in,out] q       Work: ping-pong RHS buffer (two halves at dims>2), length `mynx`
       !! @param[in,out] a       Per-axis band matrices, uniform leading dim (orig ax,ay)
       !! @param[in,out] b       Per-axis discontinuity-jump matrices, uniform leading dim (orig bx,by)
       !! @param[in,out] nr      Per-axis knot interval indices (orig nrx,nry)
@@ -7457,26 +7462,30 @@ module fitpack_core
       integer(FP_SIZE), intent(in)    :: m(dims),k(dims),n(dims)
       integer(FP_SIZE), intent(inout) :: ifs(dims),ifb(dims)
       !  ..array arguments..
-      !  z(m(2),m(1)): gridded data tensor as a genuine 2-D array -- leading dim m(2) (= my, the y/
-      !  axis-2 data count) FASTEST, trailing dim m(1) (= mx, axis-1) SLOWEST, i.e. (ny,nx) and NOT
-      !  (nx,ny). Element z(i2,i1) is the datum at (x_i1,y_i2); this is bit-for-bit the legacy flat
-      !  layout z((i1-1)*my+i2). Generalizes to z(m(dims),...,m(1)) at the dims>2 step.
-      real(FP_REAL),    intent(in)              :: z(m(2),m(1))
+      !  z(product(m)): gridded data tensor, flat row-major over the dims axes -- axis 1 SLOWEST,
+      !  axis dims FASTEST (stride 1). The datum at multi-index (i1,...,id) is z(fp_grid_index+1).
+      !  At dims=2 element z((i1-1)*my+i2) is the datum at (x_i1,y_i2) -- bit-for-bit the legacy
+      !  layout (the old rank-2 z(m(2),m(1)) had identical bytes: y/axis-2 fastest).
+      real(FP_REAL),    intent(in)              :: z(product(m))
       real(FP_REAL),    intent(in),  contiguous :: xg(:,:),t(:,:)
       real(FP_REAL),    intent(inout)           :: c(nc),right(mm),q(mynx)
       real(FP_REAL),    intent(inout), contiguous :: fpint(:,:),sp(:,:,:),a(:,:,:),b(:,:,:)
       integer(FP_SIZE), intent(inout), contiguous :: nr(:,:)
       !  ..local scalars..
-      real(FP_REAL) :: arg,fac,pinv,term
-      integer(FP_DIM)  :: d
-      integer(FP_SIZE) :: i,ibandx,ibandy,irot,it,i1,i2,j,kk,kc,l,l1,ncof,nrold,nroldx,nroldy,&
-                          number,numx,numx1,numy,numy1,n1,lda,ldb
-      !  ..per-axis sizes..
-      integer(FP_SIZE) :: k1(dims),k2(dims),nk1(dims)
-      !  ..literal-2 aliases for the frozen kernels (axis 1 = x, axis 2 = y)..
-      integer(FP_SIZE) :: kx1,ky1,kx2,ky2,mx,my,nk1x,nk1y
+      real(FP_REAL) :: arg,fac,pinv,term,sp_val
+      integer(FP_DIM)  :: d,a_ax,dd
+      integer(FP_SIZE) :: i,j,l,l1,irot,it,ncof,nrold,number,n1,lda,ldb
+      !  forward-solve / ping-pong bookkeeping
+      integer(FP_SIZE) :: pp,ibase,obase,ibuf,obuf,hhalf,td_trail,pd_lead
+      !  back-substitution bookkeeping
+      integer(FP_SIZE) :: nlead,ntrail,pl,tl,base
+      !  residual-contraction odometer
+      integer(FP_SIZE) :: coff0,coff,nsupp,mout,qq,num,nrold_d
+      !  ..per-axis sizes / state..
+      integer(FP_SIZE) :: k1(dims),k2(dims),nk1(dims),iband(dims),cstr(dims)
+      integer(FP_SIZE) :: gidx(dims),cidx(dims),lbase(dims)
       !  ..local arrays..
-      real(FP_REAL) :: h(MAX_ORDER+1)
+      real(FP_REAL) :: h(MAX_ORDER+1),pw(0:dims-1)
 
       !  per-axis order and coefficient extents
       k1  = k+1
@@ -7520,154 +7529,191 @@ module fitpack_core
       end if
 
       !  ======================================================================================
-      !  Frozen literal-2 kernels below (kept until the dims>2 step). Axis 1 = x, axis 2 = y.
-      !  Only mechanical renames vs fpgrre: paired arrays -> rank-3 page (:,:,d), paired counts
-      !  -> aliases, the leading-dim arguments nx/ny -> the uniform lda, and the coefficient-index
-      !  scalar k1 -> kc (to free the name k1 for the per-axis array).
+      !  Dimension-generic alternating-direction solve. Every coefficient/data buffer is canonical
+      !  row-major over the dims axes (axis 1 slowest, axis dims fastest, stride 1). Pass d reduces
+      !  axis d; the partially-reduced RHS lives in a ping-pong buffer that, after pass i, stores
+      !  (coefficients along axes 1..i) x (data along axes i+1..dims). The leading passes 1..dims-1
+      !  use the column-access block rotation; the final pass dims uses the row-access stride
+      !  rotation, writing the coefficient tensor c. At dims=2 this is the literal A_x then A_y
+      !  reduction, bit-for-bit.
       !  ======================================================================================
-      kx1 = k1(1); ky1 = k1(2)
-      kx2 = k2(1); ky2 = k2(2)
-      mx  = m(1) ; my  = m(2)
-      nk1x = nk1(1); nk1y = nk1(2)
+      cstr  = fp_grid_strides(dims,nk1)            ! cstr(d) = product(nk1(d+1:dims)); cstr(dims)=1
+      hhalf = mynx/2                               ! ping-pong half size (only dims>2 uses both halves)
 
-      !  reduce the matrix (ax) to upper triangular form (rx) using givens rotations. apply the
-      !  same transformations to the rows of matrix q to obtain the my x (nx-kx-1) matrix g.
-      l = my*nk1x
-      q(1:l) = zero
-      a(1:nk1x,1:kx2,1) = zero
-      l = 0
-      nrold = 0
-      ibandx = kx1
-      givens_ax: do it=1,mx
-         number = nr(it,1)
-         inner_ax: do
-           if(nrold==number) then
-              h(ibandx) = zero
-              h(1:kx1) = sp(it,1:kx1,1)
-              right(1:my) = z(1:my,it)      ! column it of the (my,mx) data tensor
-              irot = number
-           elseif (p<=zero) then
-              nrold = nrold+1
-              cycle inner_ax
-           else
-              ibandx = kx2
-              n1 = nrold+1
-              h(1:kx2) = b(n1,1:kx2,1)*pinv
-              right(1:my) = zero
-              irot = nrold
-           endif
+      forward: do d=1,dims
+         td_trail = product(m(d+1:dims))           ! trailing (not-yet-reduced) data axes; =1 at d=dims
+         pd_lead  = product(nk1(1:d-1))            ! leading (already-reduced) coeff axes; =1 at d=1
+         iband(d) = k1(d)
 
-           call fp_rotate_row_block(h, ibandx, a(:,:,1), lda, right, q, my, irot)
+         if (d<dims) then
 
-           if (nrold==number) exit inner_ax
-
-           nrold = nrold+1
-         end do inner_ax
-      end do givens_ax
-
-      !  reduce the matrix (ay) to upper triangular form (ry) using givens rotations. apply the same
-      !  transformations to the columns of matrix g to obtain the (ny-ky-1) x (nx-kx-1) matrix h.
-      ncof = nk1x*nk1y
-
-      c(1:ncof) = zero
-      a(1:nk1y,1:ky2,2) = zero
-      nrold = 0
-
-      ibandy = ky1
-      givens_ay: do it=1,my
-         number = nr(it,2)
-         inner_ay: do
-            if (nrold==number) then
-                h(ibandy) = zero
-                h(1:ky1) = sp(it,1:ky1,2)
-                l = it
-                do j=1,nk1x
-                   right(j) = q(l)
-                   l = l+my
-                end do
-                irot = number
-            elseif (p<=zero) then
-                nrold = nrold+1
-                cycle inner_ay
-            else
-                ibandy = ky2
-                n1 = nrold+1
-                h(1:ky2) = b(n1,1:ky2,2)*pinv
-                right(1:nk1x) = zero
-                irot = nrold
-            endif
-
-            call fp_rotate_row_stride(h, ibandy, a(:,:,2), lda, right, c, nk1y, nk1x, irot)
-            if (nrold==number) exit inner_ay
-            nrold = nrold+1
-         end do inner_ay
-      end do givens_ay
-
-      !  backward substitution to obtain the b-spline coefficients as the
-      !  solution of the linear system    (ry) c (rx)' = h.
-      !  first step: solve the system  (ry) (c1) = h.
-      kk = 1
-      do i=1,nk1x
-        c(kk:kk+nk1y-1) = fpback(a(:,:,2),c(kk),nk1y,ibandy,lda)
-        kk = kk+nk1y
-      end do
-
-      !  second step: solve the system  c (rx)' = (c1).
-      kk = 0
-      do j=1,nk1y
-         kk = kk+1
-         l = kk
-         do i=1,nk1x
-            right(i) = c(l)
-            l = l+nk1y
-         end do
-         right(:nk1x) = fpback(a(:,:,1),right,nk1x,ibandx,lda)
-         l = kk
-         do i=1,nk1x
-            c(l) = right(i)
-            l = l+nk1y
-         end do
-      end do
-
-      !  calculate the quantities res(i,j), fp, fpx(.) and fpy(.) (-> fpint(:,1) and fpint(:,2)).
-      fp     = zero
-      fpint(:,1) = zero
-      fpint(:,2) = zero
-      nk1y   = nk1(2)
-      nroldx = 0
-
-      !  main loop for the different grid points.
-      grid_x: do i1=1,mx
-         numx = nr(i1,1)
-         numx1 = numx+1
-         nroldy = 0
-         grid_y: do i2=1,my
-            numy = nr(i2,2)
-            numy1 = numy+1
-            term = zero
-            kc = numx*nk1y+numy
-            do l1=1,kx1
-               term = term+sp(i1,l1,1)*dot_product(sp(i2,1:ky1,2),c(kc+1:kc+ky1))
-               kc = kc+nk1y
+            !  ---- block reduction of axis d: RHS = the td_trail contiguous trailing entries ----
+            !  reduce a(:,:,d) to upper triangular form, applying the same rotations to the trailing
+            !  data block to obtain the next ping-pong buffer. b_{d-1} (= z at d=1) -> b_d.
+            obuf = merge(0_FP_SIZE, hhalf, mod(d,2)==1)
+            q(obuf+1:obuf+pd_lead*nk1(d)*td_trail) = zero
+            do pp=1,pd_lead                        ! one independent reduction per leading slab
+               a(1:nk1(d),1:k2(d),d) = zero
+               nrold    = 0
+               iband(d) = k1(d)
+               obase = obuf + (pp-1)*nk1(d)*td_trail
+               do it=1,m(d)
+                  number = nr(it,d)
+                  inner_block: do
+                     if (nrold==number) then
+                        h(iband(d)) = zero
+                        h(1:k1(d))  = sp(it,1:k1(d),d)
+                        if (d==1) then
+                           ibase = (it-1)*td_trail
+                           right(1:td_trail) = z(ibase+1:ibase+td_trail)
+                        else
+                           ibuf  = merge(0_FP_SIZE, hhalf, mod(d-1,2)==1)
+                           ibase = ibuf + (pp-1)*m(d)*td_trail + (it-1)*td_trail
+                           right(1:td_trail) = q(ibase+1:ibase+td_trail)
+                        end if
+                        irot = number
+                     elseif (p<=zero) then
+                        nrold = nrold+1
+                        cycle inner_block
+                     else
+                        iband(d)   = k2(d)
+                        n1         = nrold+1
+                        h(1:k2(d)) = b(n1,1:k2(d),d)*pinv
+                        right(1:td_trail) = zero
+                        irot = nrold
+                     end if
+                     call fp_rotate_row_block(h, iband(d), a(:,:,d), lda, right, q(obase+1), td_trail, irot)
+                     if (nrold==number) exit inner_block
+                     nrold = nrold+1
+                  end do inner_block
+               end do
             end do
 
-            term = (z(i2,i1)-term)**2      ! datum at (x_i1,y_i2); rank-2 (my,mx) access
-            fp = fp+term
-            fpint(numx1,1) = fpint(numx1,1)+term
-            fpint(numy1,2) = fpint(numy1,2)+term
-            fac = term*half
-            if (numy/=nroldy) then
-               fpint(numy1,2) = fpint(numy1,2)-fac
-               fpint(numy,2)  = fpint(numy,2) +fac
-            endif
-            nroldy = numy
-            if (numx/=nroldx) then
-               fpint(numx1,1) = fpint(numx1,1)-fac
-               fpint(numx,1)  = fpint(numx,1) +fac
-            endif
-         end do grid_y
-         nroldx = numx
-      end do grid_x
+         else
+
+            !  ---- stride reduction of the final axis: RHS = the pd_lead leading coeff combos ----
+            !  reduce a(:,:,dims), applying the rotations to the columns of the last buffer to obtain
+            !  the (nk1(dims)) x (pd_lead) coefficient tensor c.
+            ncof = product(nk1)
+            c(1:ncof) = zero
+            a(1:nk1(dims),1:k2(dims),dims) = zero
+            nrold    = 0
+            iband(dims) = k1(dims)
+            ibuf = merge(0_FP_SIZE, hhalf, mod(dims-1,2)==1)
+            do it=1,m(dims)
+               number = nr(it,dims)
+               inner_stride: do
+                  if (nrold==number) then
+                     h(iband(dims)) = zero
+                     h(1:k1(dims))  = sp(it,1:k1(dims),dims)
+                     do j=1,pd_lead
+                        right(j) = q(ibuf + (j-1)*m(dims) + it)
+                     end do
+                     irot = number
+                  elseif (p<=zero) then
+                     nrold = nrold+1
+                     cycle inner_stride
+                  else
+                     iband(dims)   = k2(dims)
+                     n1            = nrold+1
+                     h(1:k2(dims)) = b(n1,1:k2(dims),dims)*pinv
+                     right(1:pd_lead) = zero
+                     irot = nrold
+                  end if
+                  call fp_rotate_row_stride(h, iband(dims), a(:,:,dims), lda, right, c, nk1(dims), pd_lead, irot)
+                  if (nrold==number) exit inner_stride
+                  nrold = nrold+1
+               end do inner_stride
+            end do
+
+         end if
+      end do forward
+
+      !  ---- back-substitution: solve the per-axis triangular systems, axis dims down to axis 1 ----
+      !  (the R_d^{-1} operators do not commute in floating point, so the order is the reverse of the
+      !  forward reduction). For each axis d, solve every line along axis d through the coeff tensor:
+      !  contiguous (stride 1) in place, strided via gather/solve/scatter. At dims=2 this is the
+      !  literal (R_y) then (R_x) two-step solve.
+      do d=dims,1,-1
+         nlead  = product(nk1(1:d-1))
+         ntrail = cstr(d)
+         do pl=1,nlead
+            do tl=1,ntrail
+               base = (pl-1)*nk1(d)*ntrail + (tl-1)
+               if (ntrail==1) then
+                  c(base+1:base+nk1(d)) = fpback(a(:,:,d),c(base+1),nk1(d),iband(d),lda)
+               else
+                  do i=1,nk1(d)
+                     right(i) = c(base+(i-1)*ntrail+1)
+                  end do
+                  right(1:nk1(d)) = fpback(a(:,:,d),right,nk1(d),iband(d),lda)
+                  do i=1,nk1(d)
+                     c(base+(i-1)*ntrail+1) = right(i)
+                  end do
+               end if
+            end do
+         end do
+      end do
+
+      !  ---- residual: fp and the per-axis interval residual sums fpint(:,d) (orig fpx,fpy) ----
+      !  walk the output grid row-major; for each cell contract the k1(1)x...x k1(dims) coefficient
+      !  support against the per-axis basis tables sp via a mixed-radix odometer (innermost
+      !  dot_product over the fastest axis = reassociation anchor), then accumulate fp and split each
+      !  axis's boundary residual half-and-half on its interval transitions. At dims=2 the terms,
+      !  their accumulation order and the half-splits are identical to the original grid_x/grid_y walk.
+      fp = zero
+      fpint(:,1:dims) = zero
+      nsupp = product(k1(1:dims-1))
+      grid_points: do mout=1,product(m)
+         gidx  = fp_grid_unravel(dims,mout-1,m)                ! output grid multi-index
+         lbase = [(nr(gidx(a_ax),a_ax)+1, a_ax=1,dims)]        ! first coefficient of the support
+         coff0 = fp_grid_index(dims,lbase,cstr)                ! = numx*nk1y+numy at dims=2
+
+         cidx(1:dims-1) = 1
+         coff  = coff0
+         pw(0) = one
+         do a_ax=1,dims-1
+            pw(a_ax) = pw(a_ax-1)*sp(gidx(a_ax),cidx(a_ax),a_ax)
+         end do
+
+         sp_val = zero
+         do qq=1,nsupp
+            sp_val = sp_val + pw(dims-1)*dot_product(sp(gidx(dims),1:k1(dims),dims),c(coff+1:coff+k1(dims)))
+            if (qq==nsupp) exit
+            do a_ax=dims-1,1,-1
+               if (cidx(a_ax)<k1(a_ax)) then
+                  cidx(a_ax) = cidx(a_ax)+1
+                  coff       = coff + cstr(a_ax)
+                  do dd=a_ax,dims-1
+                     pw(dd) = pw(dd-1)*sp(gidx(dd),cidx(dd),dd)
+                  end do
+                  exit
+               else
+                  cidx(a_ax) = 1
+                  coff       = coff - (k1(a_ax)-1)*cstr(a_ax)
+               end if
+            end do
+         end do
+
+         term = (z(mout)-sp_val)**2
+         fp   = fp + term
+         fac  = term*half
+         do d=1,dims
+            num = nr(gidx(d),d)
+            fpint(num+1,d) = fpint(num+1,d) + term
+            !  "did axis d's knot interval change vs the previous cell along axis d?" -- a pure
+            !  function of gidx(d) (avoid evaluating nr(0,d) at the axis origin).
+            if (gidx(d)>=2) then
+               nrold_d = nr(gidx(d)-1,d)
+            else
+               nrold_d = 0_FP_SIZE
+            end if
+            if (num/=nrold_d) then
+               fpint(num+1,d) = fpint(num+1,d) - fac
+               fpint(num,  d) = fpint(num,  d) + fac
+            end if
+         end do
+      end do grid_points
       return
       end subroutine fpgrre_nd
 
@@ -12782,7 +12828,7 @@ module fitpack_core
       !! @param[in]     dims    Number of axes (domain dimension)
       !! @param[in]     xg      Per-axis grid values; column \f$ d \f$ is `xg(1:m(d),d)`
       !! @param[in]     m       Number of grid points per axis, `m(dims)`
-      !! @param[in]     z       Data values, `z(m(2),m(1))`, (ny,nx)-ordered (passed through to fpgrre_nd)
+      !! @param[in]     z       Data values, flat `z(product(m))`, row-major (passed through to fpgrre_nd)
       !! @param[in]     lo      Per-axis lower boundary (orig xb,yb)
       !! @param[in]     hi      Per-axis upper boundary (orig xe,ye)
       !! @param[in]     k       Degree per axis, `k(dims)`
@@ -12829,9 +12875,9 @@ module fitpack_core
       integer(FP_SIZE), intent(inout) :: n(dims),nplus(dims)
       real(FP_REAL),    intent(inout) :: reduc(dims)
       !  ..array arguments (data + caller-supplied workspace views)..
-      !  z(m(2),m(1)): gridded data as a 2-D array, (ny,nx)-ordered (y/axis-2 fastest); passed
-      !  straight to fpgrre_nd, which documents and indexes the convention. fpregr_nd never reads z.
-      real(FP_REAL),    intent(in)               :: z(m(2),m(1))
+      !  z(product(m)): flat row-major gridded data (axis 1 slowest); passed straight to fpgrre_nd,
+      !  which documents and indexes the convention. fpregr_nd never reads z.
+      real(FP_REAL),    intent(in)               :: z(product(m))
       real(FP_REAL),    intent(in),    contiguous :: xg(:,:)
       real(FP_REAL),    intent(inout), contiguous :: t(:,:),fpint(:,:),sp(:,:,:),right(:),q(:),a(:,:,:),b(:,:,:)
       integer(FP_SIZE), intent(inout), contiguous :: nr(:,:),nrdat(:,:)
@@ -17923,8 +17969,10 @@ module fitpack_core
       !! Minimum sizes:
       !!   lwrk >= 2 + dims + nestmax*dims + mmax*(kmax+1)*dims + 2*nestmax*(kmax+2)*dims + mm + mq
       !!   kwrk >= 1 + dims + mmax*dims + nestmax*dims
-      !! with mmax=maxval(m), nestmax=maxval(nest), kmax=maxval(k), mm=max(nestmax,mmax),
-      !! mq=mmax*nestmax.
+      !! with mmax=maxval(m), nestmax=maxval(nest), kmax=maxval(k). At dims=2, mm=max(nestmax,mmax)
+      !! and mq=mmax*nestmax. At dims>2 the two ping-pong buffers grow: with nk1max=nest-(k+1),
+      !! mq = 2*max_{i=1..dims-1} [ product(nk1max(1:i)) * product(m(i+1:dims)) ] and
+      !! mm = max(nestmax, mmax, product(m(2:dims)), product(nk1max(1:dims-1))).
       !!
       !! @see regrid, fpregr_nd; Dierckx, SIAM J.Numer.Anal. 19 (1982) 1286-1304; Ch.5 §5.4.
       pure subroutine regrid_nd(iopt,dims,m,xg,z,lo,hi,k,s,nest,n,t,c,fp,wrk,lwrk,iwrk,kwrk,ier)
@@ -17940,7 +17988,7 @@ module fitpack_core
       integer(FP_SIZE), intent(in)    :: m(dims),k(dims),nest(dims)
       real(FP_REAL),    intent(in)    :: lo(dims),hi(dims)
       integer(FP_SIZE), intent(inout) :: n(dims)
-      real(FP_REAL),    intent(in)              :: z(m(2),m(1))  ! gridded data, (ny,nx)/y-fast (dims=2)
+      real(FP_REAL),    intent(in)              :: z(product(m))  ! flat row-major gridded data (axis 1 slowest)
       real(FP_REAL),    intent(in),    contiguous :: xg(:,:)
       real(FP_REAL),    intent(inout), contiguous :: t(:,:)
       real(FP_REAL),    intent(inout)             :: c(*)
@@ -17978,6 +18026,23 @@ module fitpack_core
       maxk2   = maxval(k)+2
       mm      = max(maxnest,maxm)
       mynx    = maxm*maxnest
+
+      !  dims>2: grow the two literal-2 buffers to the N-D requirement. right (mm) holds the widest
+      !  gathered RHS fiber; q (mynx) holds the two ping-pong buffers, each big enough for the largest
+      !  intermediate tensor max_i [ product(nk1max(1:i)) * product(m(i+1:dims)) ]. dims=2 is untouched
+      !  (the formula reduces to the single buffer maxm*maxnest), so the dims=2 gate path never moves.
+      if (dims>2) then
+         block
+            integer(FP_SIZE) :: nk1max(dims),bufmax,i
+            nk1max = nest-k1
+            bufmax = 0
+            do i=1,dims-1
+               bufmax = max(bufmax, product(nk1max(1:i))*product(m(i+1:dims)))
+            end do
+            mm   = max(mm, product(m(2:dims)), product(nk1max(1:dims-1)), maxval(nk1max))
+            mynx = 2*bufmax
+         end block
+      end if
 
       lwest = (2+dims) + maxnest*dims + maxm*maxk1*dims + 2*maxnest*maxk2*dims + mm + mynx
       kwest = (1+dims) + maxm*dims + maxnest*dims

--- a/test/fitpack_grid_nd_tests.f90
+++ b/test/fitpack_grid_nd_tests.f90
@@ -66,6 +66,9 @@ module fitpack_grid_nd_tests
         ! Gate F: regrid_nd at dims=3 — the first genuine dims>2 FIT (generalized fpgrre_nd solve)
         if (success) success = gate_regrid_nd_3d(useUnit)
 
+        ! Gate G: regrid_nd at dims=3 SMOOTHING (s>0) — the generalized knot-direction arbiter
+        if (success) success = gate_regrid_nd_3d_smoothing(useUnit)
+
         if (success) write(useUnit,'(a)') '[test_nd_grid_equivalence] all N-D gridded gates OK'
 
     end function test_nd_grid_equivalence
@@ -627,5 +630,105 @@ module fitpack_grid_nd_tests
         end function poly_w
 
     end function gate_regrid_nd_3d
+
+    !> @brief Gate G — regrid_nd at dims=3 SMOOTHING (s>0): the generalized knot-direction arbiter.
+    !!
+    !! The first dims>2 smoothing fit, so the first runtime exercise of the N-D argmax arbiter
+    !! (new_knot_dimension_nd) AND of the p>0 discontinuity branch at dims>2. No legacy dims=3
+    !! reference exists, so the oracle is independent: data is a separable Runge product (NOT in the
+    !! spline space, so smoothing genuinely adds knots). After fitting: (1) success, (2) the smoothing
+    !! identity |fp-s|<=tol*s, (3) knots distributed -- in particular axis 3 received knots, which the
+    !! old literal-2 arbiter could never do, and (4) fp equals the unit-weight SSR recomputed through
+    !! the gate-A/E/F-verified fpbisp_nd.
+    logical function gate_regrid_nd_3d_smoothing(useUnit) result(ok)
+        integer, intent(in) :: useUnit
+
+        integer(FP_SIZE), parameter :: kx=3, ky=3, kw=3
+        integer(FP_SIZE), parameter :: mx=9, my=8, mw=7, mz=mx*my*mw
+        integer(FP_SIZE), parameter :: nest=17, maxm=mx, maxk1=kx+1
+        integer(FP_SIZE), parameter :: maxc=(nest-kx-1)**3, lwrk3=4000, kwrk3=200
+
+        real(FP_REAL)    :: t3(nest,3),xg3(maxm,3),c3(maxc),z3(mz),zfit(mz),w3(maxm,maxk1,3)
+        real(FP_REAL)    :: fp0cal,fp,s,lo(3),hi(3),ssr,wrk(lwrk3)
+        integer(FP_SIZE) :: iwrk(kwrk3),n3(3),k3(3),m3(3),nest3(3),nmin3(3),lidx3(maxm,3)
+        integer(FP_FLAG) :: ier
+        integer(FP_SIZE) :: ix,iy,iw,i,iout
+
+        ok = .true.
+        t3 = zero; xg3 = zero
+        k3 = [kx,ky,kw]; m3 = [mx,my,mw]; nest3 = nest; nmin3 = 2*(k3+1); n3 = nmin3
+        lo = zero; hi = one
+
+        ! strictly-increasing data grids on [0,1] (endpoints included)
+        do i=1,mx; xg3(i,1) = real(i-1,FP_REAL)/real(mx-1,FP_REAL); end do
+        do i=1,my; xg3(i,2) = real(i-1,FP_REAL)/real(my-1,FP_REAL); end do
+        do i=1,mw; xg3(i,3) = real(i-1,FP_REAL)/real(mw-1,FP_REAL); end do
+
+        ! data: separable Runge product (not in the spline space), row-major (x slowest, w fastest)
+        do ix=1,mx
+           do iy=1,my
+              do iw=1,mw
+                 iout = (ix-1)*my*mw + (iy-1)*mw + iw
+                 z3(iout) = runge(xg3(ix,1))*runge(xg3(iy,2))*runge(xg3(iw,3))
+              end do
+           end do
+        end do
+
+        ! calibrate: a huge s returns the least-squares polynomial residual fp0
+        wrk = zero; iwrk = 0
+        call regrid_nd(0_FP_FLAG,3_FP_DIM,m3,xg3,z3,lo,hi,k3,1.0e30_FP_REAL,nest3, &
+                       n3,t3,c3,fp0cal,wrk,lwrk3,iwrk,kwrk3,ier)
+        if (.not.FITPACK_SUCCESS(ier) .or. fp0cal<=zero) then
+           ok = .false.; write(useUnit,3000) 'calibration failed (ier/fp0)', fp0cal; return
+        end if
+
+        ! smoothing fit at s = 1% of the polynomial residual: forces knot addition on every axis
+        s = 1.0e-2_FP_REAL*fp0cal
+        t3 = zero; wrk = zero; iwrk = 0
+        call regrid_nd(0_FP_FLAG,3_FP_DIM,m3,xg3,z3,lo,hi,k3,s,nest3, &
+                       n3,t3,c3,fp,wrk,lwrk3,iwrk,kwrk3,ier)
+        if (.not.FITPACK_SUCCESS(ier)) then
+           ok = .false.; write(useUnit,'(a,i0)') '[gate G] regrid_nd(dims=3) smoothing failed, ier=',ier; return
+        end if
+
+        ! check 1: smoothing identity -- the solver converges to |fp-s| < tol*s (tol = 1e-3)
+        if (abs(fp-s) > 1.0e-3_FP_REAL*s) then
+           ok = .false.; write(useUnit,3000) '|fp-s| exceeds tol*s', abs(fp-s); return
+        end if
+
+        ! check 2: the new arbiter distributed knots -- axis 3 was refined (impossible for the old
+        ! literal-2 arbiter), and at least two axes received interior knots
+        if (n3(3)<=nmin3(3) .or. count(n3>nmin3)<2) then
+           ok = .false.; write(useUnit,3100) n3(1),n3(2),n3(3); return
+        end if
+
+        ! check 3: fp equals the unit-weight SSR recomputed through the independent fpbisp_nd
+        call fpbisp_nd(3_FP_DIM,t3,n3,c3,k3,xg3,m3,zfit,w3,lidx3)
+        ssr = zero
+        do ix=1,mx
+           do iy=1,my
+              do iw=1,mw
+                 iout = (ix-1)*my*mw + (iy-1)*mw + iw
+                 ssr  = ssr + (z3(iout)-zfit(iout))**2
+              end do
+           end do
+        end do
+        if (abs(ssr-fp) > 1.0e-9_FP_REAL*max(fp,one)) then
+           ok = .false.; write(useUnit,3000) 'fp /= SSR via fpbisp_nd', abs(ssr-fp); return
+        end if
+
+        write(useUnit,'(a)') '[gate G] regrid_nd(dims=3) smoothing converges, distributes knots, fp==SSR'
+
+        3000 format('[gate G] regrid_nd(dims=3) smoothing ',a,' = ',1pe12.3)
+        3100 format('[gate G] regrid_nd(dims=3) knots not distributed: n = ',i0,1x,i0,1x,i0)
+
+    contains
+
+        pure real(FP_REAL) function runge(t)
+            real(FP_REAL), intent(in) :: t
+            runge = one/(one + 20.0_FP_REAL*(t-half)**2)
+        end function runge
+
+    end function gate_regrid_nd_3d_smoothing
 
 end module fitpack_grid_nd_tests

--- a/test/fitpack_grid_nd_tests.f90
+++ b/test/fitpack_grid_nd_tests.f90
@@ -14,8 +14,10 @@
 !                               convention so an x<->y axis/size swap cannot hide behind mx==my
 !     E. fpbisp_nd(dims=3) vs independent references (slice 2) — separable coeffs vs a product of 1-D
 !                               splev, and non-separable coeffs vs the dims=2 path combined along z
+!     F. regrid_nd(dims=3) least-squares FIT on given knots (slice 3) — the generalized fpgrre_nd solve
+!                               recovers an in-space polynomial; checked vs the closed-form (fpbisp_nd)
 !
-!   See todo/fitpack_nd_grids.md (slices 1–2) and Dierckx, Ch. 5 §5.4 (pp. 98-103).
+!   See todo/fitpack_nd_grids.md (slices 1–3) and Dierckx, Ch. 5 §5.4 (pp. 98-103).
 ! **************************************************************************************************
 module fitpack_grid_nd_tests
     use fitpack_core
@@ -60,6 +62,9 @@ module fitpack_grid_nd_tests
 
         ! Gate E: fpbisp_nd at dims=3 vs two independent references (the first genuine dims>2 path)
         if (success) success = gate_fpbisp_nd_3d(useUnit)
+
+        ! Gate F: regrid_nd at dims=3 — the first genuine dims>2 FIT (generalized fpgrre_nd solve)
+        if (success) success = gate_regrid_nd_3d(useUnit)
 
         if (success) write(useUnit,'(a)') '[test_nd_grid_equivalence] all N-D gridded gates OK'
 
@@ -190,15 +195,13 @@ module fitpack_grid_nd_tests
         integer(FP_FLAG) :: ier_t
         ! shared
         real(FP_REAL)    :: zin(size(daregr_x)*size(daregr_y)),xb,xe,yb,ye,s,lo(2),hi(2)
-        real(FP_REAL)    :: zin2(size(daregr_y),size(daregr_x))   ! rank-2 (my,mx) data for regrid_nd
         integer(FP_SIZE) :: kx,ky,iopt,icase,i
         character(len=40):: lbl
 
         ok = .true.
         mx = size(daregr_x,kind=FP_SIZE); my = size(daregr_y,kind=FP_SIZE)
         xb = daregr_x(1); xe = daregr_x(mx); yb = daregr_y(1); ye = daregr_y(my)
-        zin = reshape(daregr_z,[mx*my])
-        zin2 = reshape(zin,[my,mx])        ! same bytes as zin, shaped (my,mx) = (ny,nx)
+        zin = reshape(daregr_z,[mx*my])    ! flat row-major (x slowest, y fastest) = regrid_nd's z contract
 
         ! regrid_nd marshalling that is constant across calls
         m2 = [mx,my]; nest2 = [NXEST,NYEST]; lo = [xb,yb]; hi = [xe,ye]
@@ -216,7 +219,7 @@ module fitpack_grid_nd_tests
             end select
             call regrid(iopt,mx,daregr_x,my,daregr_y,zin,xb,xe,yb,ye,kx,ky,s,NXEST,NYEST, &
                         nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
-            call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin2,lo,hi,kk,s,nest2, &
+            call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
                            ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
             write(lbl,'(a,i0)') 'cubic iopt-chain #',icase
             if (.not.pair_ok(useUnit,trim(lbl),kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
@@ -229,7 +232,7 @@ module fitpack_grid_nd_tests
         kx = 5; ky = 5; kk = [kx,ky]; iopt = 0; s = 0.2_FP_REAL
         call regrid(iopt,mx,daregr_x,my,daregr_y,zin,xb,xe,yb,ye,kx,ky,s,NXEST,NYEST, &
                     nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
-        call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin2,lo,hi,kk,s,nest2, &
+        call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
                        ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
         if (.not.pair_ok(useUnit,'quintic fresh iopt=0',kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
                          ntst,ttst,ctst,fptst,ier_t)) then
@@ -244,7 +247,7 @@ module fitpack_grid_nd_tests
         ttst(kx+2:kx+4,1) = txr(kx+2:kx+4); ttst(ky+2:ky+4,2) = tyr(ky+2:ky+4)
         call regrid(-1_FP_FLAG,mx,daregr_x,my,daregr_y,zin,xb,xe,yb,ye,kx,ky,s,NXEST,NYEST, &
                     nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
-        call regrid_nd(-1_FP_FLAG,2_FP_DIM,m2,xgt,zin2,lo,hi,kk,s,nest2, &
+        call regrid_nd(-1_FP_FLAG,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
                        ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
         if (.not.pair_ok(useUnit,'lsq given knots iopt=-1',kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
                          ntst,ttst,ctst,fptst,ier_t)) then
@@ -266,7 +269,7 @@ module fitpack_grid_nd_tests
         integer, intent(in) :: useUnit
 
         integer(FP_SIZE), parameter :: MX = 9, MY = 13
-        real(FP_REAL)    :: xg1(MX),yg1(MY),zin(MX*MY),zin2(MY,MX)
+        real(FP_REAL)    :: xg1(MX),yg1(MY),zin(MX*MY)
         ! reference (regrid)
         integer(FP_SIZE) :: nxr,nyr
         real(FP_REAL)    :: txr(NXEST),tyr(NYEST),cr(NCMAX),fpr,wrkr(LWRK)
@@ -295,7 +298,6 @@ module fitpack_grid_nd_tests
                               + xg1(i)*yg1(j)
            end do
         end do
-        zin2 = reshape(zin,[MY,MX])        ! same bytes as zin, shaped (my,mx) = (ny,nx)
 
         xb = xg1(1); xe = xg1(MX); yb = yg1(1); ye = yg1(MY)
         m2 = [MX,MY]; nest2 = [NXEST,NYEST]; lo = [xb,yb]; hi = [xe,ye]
@@ -310,7 +312,7 @@ module fitpack_grid_nd_tests
             end select
             call regrid(iopt,MX,xg1,MY,yg1,zin,xb,xe,yb,ye,kk(1),kk(2),s,NXEST,NYEST, &
                         nxr,txr,nyr,tyr,cr,fpr,wrkr,LWRK,iwrkr,KWRK,ier_r)
-            call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin2,lo,hi,kk,s,nest2, &
+            call regrid_nd(iopt,2_FP_DIM,m2,xgt,zin,lo,hi,kk,s,nest2, &
                            ntst,ttst,ctst,fptst,wrkt,LWRK,iwrkt,KWRK,ier_t)
             write(lbl,'(a,i0)') 'non-square 9x13 #',icase
             if (.not.pair_ok(useUnit,trim(lbl),kk,nxr,nyr,txr,tyr,cr,fpr,ier_r, &
@@ -506,5 +508,124 @@ module fitpack_grid_nd_tests
 
         3000 format('[gate E] fpbisp_nd(dims=3) /= ',a,' reference  (max |diff| = ',1pe12.3,')')
     end function gate_fpbisp_nd_3d
+
+    !> @brief Gate F — regrid_nd at dims=3 (least-squares fit on given knots) vs a closed-form oracle.
+    !!
+    !! The first genuine dims>2 FIT path: the generalized fpgrre_nd solve (alternating-direction
+    !! reduction + ping-pong buffer + back-substitution + residual contraction). Data is a separable
+    !! in-space polynomial f(x,y,w)=Px(x)*Py(y)*Pw(w) with deg Px/Py/Pw = kx/ky/kw, which lies EXACTLY
+    !! in the tensor B-spline space for any clamped knots. Fit via regrid_nd(dims=3, iopt=-1) on
+    !! hand-built clamped knots with nk1(d)<m(d) (genuinely over-determined, so the residual path runs);
+    !! the binary knot-direction arbiter is provably untouched on the iopt<0 path. Two independent
+    !! checks: the residual fp must vanish, and the fitted spline -- evaluated by the gate-A/E-verified
+    !! fpbisp_nd(dims=3) at strictly-interior probe points off the data grid -- must reproduce the
+    !! closed-form f. Distinct per-axis orders and grid sizes, so an axis swap cannot pass unnoticed.
+    logical function gate_regrid_nd_3d(useUnit) result(ok)
+        integer, intent(in) :: useUnit
+
+        integer(FP_SIZE), parameter :: kx=3, ky=2, kw=4
+        integer(FP_SIZE), parameter :: nk1x=6, nk1y=5, nk1w=7
+        integer(FP_SIZE), parameter :: mx=8, my=6, mw=10
+        integer(FP_SIZE), parameter :: nxk=nk1x+kx+1, nyk=nk1y+ky+1, nwk=nk1w+kw+1   ! 10,8,12
+        integer(FP_SIZE), parameter :: maxn=nwk, maxk1=kw+1, nc3=nk1x*nk1y*nk1w, mz3=mx*my*mw
+        integer(FP_SIZE), parameter :: mpx=5, mpy=4, mpw=6, maxmp=mpw   ! interior probe grid
+        real(FP_REAL),    parameter :: tol=1.0e-10_FP_REAL
+
+        real(FP_REAL)    :: t3(maxn,3),xg3(mw,3),c3(nc3),z3(mz3),fpf,lo(3),hi(3),s
+        real(FP_REAL)    :: wrk(LWRK)
+        integer(FP_SIZE) :: iwrk(KWRK),n3(3),k3(3),m3(3),nest3(3)
+        integer(FP_FLAG) :: ier
+        ! probe / closed-form oracle
+        real(FP_REAL)    :: xgp(maxmp,3),zp(mpx*mpy*mpw),wp(maxmp,maxk1,3)
+        integer(FP_SIZE) :: lidxp(maxmp,3),mp3(3)
+        real(FP_REAL)    :: x,y,w,maxdiff
+        integer(FP_SIZE) :: ix,iy,iw,i,iout
+
+        ok = .true.
+        t3 = zero; xg3 = zero; xgp = zero
+        k3 = [kx,ky,kw]; m3 = [mx,my,mw]; lo = zero; hi = one
+
+        ! clamped knot vectors on [0,1]; nest = exact knot counts (least-squares on given knots)
+        call clamped_unit_knots(kx,nk1x,t3(:,1),n3(1))
+        call clamped_unit_knots(ky,nk1y,t3(:,2),n3(2))
+        call clamped_unit_knots(kw,nk1w,t3(:,3),n3(3))
+        nest3 = n3
+
+        ! strictly-increasing data grids on [0,1] (endpoints included)
+        do i=1,mx; xg3(i,1) = real(i-1,FP_REAL)/real(mx-1,FP_REAL); end do
+        do i=1,my; xg3(i,2) = real(i-1,FP_REAL)/real(my-1,FP_REAL); end do
+        do i=1,mw; xg3(i,3) = real(i-1,FP_REAL)/real(mw-1,FP_REAL); end do
+
+        ! data: separable in-space polynomial, row-major (x slowest, w fastest)
+        do ix=1,mx
+           x = xg3(ix,1)
+           do iy=1,my
+              y = xg3(iy,2)
+              do iw=1,mw
+                 w = xg3(iw,3)
+                 iout = (ix-1)*my*mw + (iy-1)*mw + iw
+                 z3(iout) = poly_x(x)*poly_y(y)*poly_w(w)
+              end do
+           end do
+        end do
+
+        ! least-squares fit on the given clamped knots (iopt=-1): the arbiter-free dims=3 solve
+        s = zero; wrk = zero; iwrk = 0
+        call regrid_nd(-1_FP_FLAG,3_FP_DIM,m3,xg3,z3,lo,hi,k3,s,nest3, &
+                       n3,t3,c3,fpf,wrk,LWRK,iwrk,KWRK,ier)
+        if (ier/=FITPACK_OK) then
+           ok = .false.; write(useUnit,'(a,i0)') '[gate F] regrid_nd(dims=3) fit failed, ier=',ier; return
+        end if
+
+        ! check 1: data exactly in space -> least-squares residual must vanish
+        if (fpf>=1.0e-9_FP_REAL) then
+           ok = .false.; write(useUnit,3000) 'nonzero residual fp', fpf; return
+        end if
+
+        ! check 2: reconstruction at strictly-interior probe points off the data grid vs closed-form f
+        mp3 = [mpx,mpy,mpw]
+        do i=1,mpx; xgp(i,1) = (real(i,FP_REAL)-half)/real(mpx,FP_REAL); end do
+        do i=1,mpy; xgp(i,2) = (real(i,FP_REAL)-half)/real(mpy,FP_REAL); end do
+        do i=1,mpw; xgp(i,3) = (real(i,FP_REAL)-half)/real(mpw,FP_REAL); end do
+
+        call fpbisp_nd(3_FP_DIM,t3,n3,c3,k3,xgp,mp3,zp,wp,lidxp)
+
+        maxdiff = zero
+        do ix=1,mpx
+           x = xgp(ix,1)
+           do iy=1,mpy
+              y = xgp(iy,2)
+              do iw=1,mpw
+                 w = xgp(iw,3)
+                 iout = (ix-1)*mpy*mpw + (iy-1)*mpw + iw
+                 maxdiff = max(maxdiff, abs(zp(iout)-poly_x(x)*poly_y(y)*poly_w(w)))
+              end do
+           end do
+        end do
+        if (maxdiff>=tol) then
+           ok = .false.; write(useUnit,3100) maxdiff; return
+        end if
+
+        write(useUnit,'(a)') '[gate F] regrid_nd(dims=3) least-squares fit reproduces in-space polynomial'
+
+        3000 format('[gate F] regrid_nd(dims=3) ',a,' = ',1pe12.3)
+        3100 format('[gate F] regrid_nd(dims=3) fit /= closed-form f  (max |diff| = ',1pe12.3,')')
+
+    contains
+
+        pure real(FP_REAL) function poly_x(x)
+            real(FP_REAL), intent(in) :: x
+            poly_x = 1.0_FP_REAL + 0.5_FP_REAL*x - 0.3_FP_REAL*x**2 + 0.2_FP_REAL*x**3
+        end function poly_x
+        pure real(FP_REAL) function poly_y(y)
+            real(FP_REAL), intent(in) :: y
+            poly_y = 0.8_FP_REAL - 0.4_FP_REAL*y + 0.6_FP_REAL*y**2
+        end function poly_y
+        pure real(FP_REAL) function poly_w(w)
+            real(FP_REAL), intent(in) :: w
+            poly_w = 1.2_FP_REAL + 0.3_FP_REAL*w - 0.5_FP_REAL*w**2 + 0.1_FP_REAL*w**3 + 0.15_FP_REAL*w**4
+        end function poly_w
+
+    end function gate_regrid_nd_3d
 
 end module fitpack_grid_nd_tests


### PR DESCRIPTION
Stacked on #55 (`nd-grids-slice1`). Third slice of the N-D gridded-spline effort (`todo/fitpack_nd_grids.md` §8/§9): takes the gridded fit solver `fpgrre_nd` from its literal-2 kernels to a runtime `dims` loop — the last of the three genuinely d-dimensional kernels (the eval contraction was slice 2).

## What changes

**`fpgrre_nd` — three kernels generalized (bit-for-bit at dims=2):**
- **Forward alternating-direction reduction** — one banded Givens pass per axis. Leading axes `1..dims-1` use the column-access block rotation; the final axis uses the row-access stride rotation, writing the coefficient tensor `c`. The partially-reduced RHS lives in a row-major **ping-pong buffer** that, after pass `i`, holds (coefficients along axes `1..i`) × (data along axes `i+1..dims`) — the §9 "single most error-prone piece".
- **Back-substitution** over axes `dims..1` (reverse of the reduction; the per-axis inverse operators don't commute in FP). Contiguous lines solved in place, strided lines via gather/solve/scatter.
- **Residual / `fp` / per-axis `fpint`** via the slice-2 mixed-radix odometer (innermost `dot_product` over the fastest axis = the reassociation anchor), with the boundary half-split generalized to a pure per-axis function of the cell index.

**`z` flattened** rank-2 `z(m(2),m(1))` → flat row-major `z(product(m))` through `regrid_nd → fpregr_nd → fpgrre_nd`. Test-only ripple — the public module and C binding still call legacy `regrid`.

**`regrid_nd` workspaces** — the two literal-2 buffers (ping-pong `q`, gathered fiber `right`) grow for `dims>2`; the dims=2 sizing and code path are untouched.

## Tests

- **Gates D / D' / A stay bit-for-bit** (`==`) at dims=2 across `iopt=-1/0/1`, cubic+quintic, square and non-square — any FP reassociation in the five rewritten kernels would surface here.
- **New Gate F**: fits an in-space separable polynomial at dims=3 via `regrid_nd(iopt=-1)`, checks the residual vanishes and the fitted spline reproduces the closed form (via `fpbisp_nd` dims=3) to `1e-10`.
- Full suite green (26 interface / 55 legacy / 60 c++, 0 failed); bounds-checked build clean.

## Deferred to slice 4

The binary knot-direction arbiter `new_knot_dimension` in `fpregr_nd` stays literal-2 (the `iopt<0` path used by Gate F provably never reaches it). Slice 4 generalizes it to an argmax over axes and adds a dims=3 smoothing gate — which will also be the first test of the `p>0` discontinuity branch at `dims>2`.