### PR TITLE
fpknot: fix out-of-bounds knot insertion when all interval residuals are zero

### DIFF
--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -3129,7 +3129,8 @@ module fitpack_core
 
           ! determine the number of knots nplus we are going to add.
           rn    = nplus
-          npl1  = merge(int(rn*fpms/(fpold-fp)),nplus*ITWO,fpold-fp>acc)
+          npl1  = nplus*ITWO
+          if (fpold-fp>acc) npl1 = int(rn*fpms/(fpold-fp))  ! guard the division: skip it when fpold-fp<=acc
           nplus = min(nplus*2,max(npl1,nplus/2,1))
           fpold = fp
 
@@ -5613,8 +5614,14 @@ module fitpack_core
           real(FP_REAL) :: dd,store
 
           store = abs(piv)
-          dd  = merge(store*sqrt(one+(ww/piv)**2), &
-                      ww   *sqrt(one+(piv/ww)**2), store>=ww)
+          !  evaluate only the taken branch: an if (not merge) avoids a spurious
+          !  divide-by-zero in the unselected expression (ww/piv or piv/ww) when
+          !  the other operand is zero, which would raise IEEE_INVALID under FPE traps.
+          if (store>=ww) then
+             dd = store*sqrt(one+(ww/piv)**2)
+          else
+             dd = ww   *sqrt(one+(piv/ww)**2)
+          end if
           cos = ww/dd
           sin = piv/dd
           ww  = dd
@@ -8473,22 +8480,29 @@ module fitpack_core
       maxbeg = 0
       k      = (n-nrint-1)/2
       !  search for knot interval t(number+k) <= x <= t(number+k+1) where fpint(number) is maximal on the
-      !  condition that nrdata(number)/=0 .
+      !  condition that nrdata(number)/=0. An interval is eligible only if it holds at least one interior
+      !  data point (jpoint/=0); the first eligible interval seeds the search (number==0), after which any
+      !  interval with a strictly larger residual takes over. Seeding on the first eligible interval, rather
+      !  than only on fpmax<fpint(j), guarantees a valid selection even when every residual is exactly zero
+      !  (an all-zero fpint would otherwise leave number==0 and fall through to use of uninitialized am).
       fpmax  = zero
-      jbegin = istart      
+      jbegin = istart
       do j=1,nrint
         jpoint = nrdata(j)
 
-        if (fpmax<fpint(j) .and. jpoint/=0) then
-           fpmax = fpint(j)
+        if (jpoint/=0 .and. (number==0 .or. fpint(j)>fpmax)) then
+           fpmax  = fpint(j)
            number = j
-           maxpt = jpoint
+           maxpt  = jpoint
            maxbeg = jbegin
         endif
 
         jbegin = jbegin+jpoint+1
       end do
-      
+
+      !  no interval carries an interior data point: there is nothing to refine, so leave the knot set as is
+      if (number==0) return
+
       !  let coincide the new knot t(number+k+1) with a data point x(nrx)
       !  inside the old knot interval t(number+k) <= x <= t(number+k+1).
       ihalf = maxpt/2+1
@@ -8506,14 +8520,14 @@ module fitpack_core
          end do
       endif
       
-      if (number>0) then 
-          nrdata(number) = ihalf-1
-          nrdata(next)   = maxpt-ihalf
-          am = maxpt
-          an = nrdata(number)
-          fpint(number) = fpmax*an/am
-      endif
-      
+      !  split the selected interval in two, apportioning its residual between the halves.
+      !  number>0 is guaranteed by the early return above, so am is always initialized here.
+      nrdata(number) = ihalf-1
+      nrdata(next)   = maxpt-ihalf
+      am = maxpt
+      an = nrdata(number)
+      fpint(number) = fpmax*an/am
+
       an = nrdata(next)
       fpint(next) = fpmax*an/am
       jk = next+k
@@ -10220,7 +10234,8 @@ module fitpack_core
         end if
 
         ! determine the number of knots nplus we are going to add.
-        npl1  = merge(int((nplus*fpms)/(fpold-fp),FP_SIZE),nplus*ITWO,fpold-fp>acc)
+        npl1  = nplus*ITWO
+        if (fpold-fp>acc) npl1 = int((nplus*fpms)/(fpold-fp),FP_SIZE)  ! guard the division: skip it when fpold-fp<=acc
         nplus = min(nplus*2,max(npl1,nplus/2,1))
         fpold = fp
 
@@ -10865,6 +10880,8 @@ module fitpack_core
                   fpold     = zero
                   reducu    = zero
                   reducv    = zero
+                  lasttu    = 0     ! force step (zmax-zmin) to be computed on the first pass;
+                  step      = zero  ! both are inout persistent state, uninitialized on a fresh fit
               endif
 
           endif
@@ -13520,7 +13537,9 @@ module fitpack_core
                   fpold     = zero
                   reducu    = zero
                   reducv    = zero
-
+                  lastu0    = 0     ! force step(1)/step(2) (rmax-rmin per pole) to be computed on
+                  lastu1    = 0     ! the first pass; step and the last* caches are inout persistent
+                  step      = zero  ! state, uninitialized on a fresh fit (F77 relied on zeroed statics)
 
               else
 
@@ -13672,7 +13691,8 @@ module fitpack_core
             nplu = 1
             if (nu/=8) then
                rn   = nplusu
-               npl1 = merge(int(rn*fpms/reducu),nplusu*2,reducu>acc)
+               npl1 = nplusu*2
+               if (reducu>acc) npl1 = int(rn*fpms/reducu)  ! guard the division: skip it when reducu<=acc
                nplu = min(nplusu*2,max(npl1,nplusu/2,1))
             endif
 
@@ -13680,7 +13700,8 @@ module fitpack_core
             nplv = 3
             if (nv/=8) then
                rn   = nplusv
-               npl1 = merge(int(rn*fpms/reducv),nplusv*2,reducv>acc)
+               npl1 = nplusv*2
+               if (reducv>acc) npl1 = int(rn*fpms/reducv)  ! guard the division: skip it when reducv<=acc
                nplv = min(nplusv*2,max(npl1,nplusv/2,1))
             endif
 


### PR DESCRIPTION
## Summary

Fixes a latent out-of-bounds array access in `fpknot`, the knot-insertion routine shared by every automatic-knot fit (curve, surface, polar, sphere). The bug is **ancient** — present unchanged back to the earliest `fpknot` in the repo — and dormant on normal builds; it surfaces under `-fcheck=bounds` and under memory poisoning (`-finit-real=inf`) in the periodic-grid solvers `pogrid`/`spgrid`.

## Root cause

`fpknot` selected the interval to refine with `if (fpmax<fpint(j) .and. jpoint/=0)`, seeding `fpmax` at zero. When every eligible interval had a residual of *exactly* zero, no interval was ever selected:

- `number` stayed `0`, so `am` (set only inside the `if (number>0)` block) was **used uninitialized** in `fpint(next)=fpmax*an/am`;
- a degenerate knot was inserted with `maxbeg=maxpt=0`, **over-counting** the `nrdata` partition. On a later iteration the over-count drove `nrx` past `m`, indexing `x(nrx)` out of bounds.

## Fix

- Seed the search on the **first eligible interval** (`number==0`), then let any interval with a strictly larger residual take over. Selection is byte-identical to the old code in every non-degenerate case.
- **Return early** when no interval carries an interior data point — there is genuinely nothing to refine, so the knot set is left unchanged (the mathematically correct response, instead of inserting a degenerate knot).
- With the early return, the `number>0` guard downstream is unreachable and is flattened, so `am` is structurally always initialized before use.

## Hardening (same class of uninitialized arithmetic that made the OOB reproducible under FPE traps)

- Replace `merge(x/d, …, d>acc)` with an `if` in `fpcurf`, `fpregr`/`fpgrre`, `fpspgr`, and the Givens guard in `fpgivs`, so the unselected `x/d` branch (which `merge` always evaluates) is never computed when `d<=acc`.
- Reset the persistent knot-search state (`step` and the `last*` caches) on a fresh fit in `fppogr`/`fpspgr`; the F77 originals relied on zero-initialized statics.

## Verification

Full suite (60 tests) green:

- Normal build: **60/60**.
- `-finit-real=inf -finit-integer=0 -fcheck=bounds -fno-inline` (the deterministic reproduction of the crash): **60/60** (was: OOB abort in `fpknot`).