### PR TITLE
splder/curfit: guard derivative orders and zero-weight data

### DIFF
--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -1213,7 +1213,8 @@ module fitpack_core
       !! @param[in]     m     Number of data points. Must satisfy \f$ m > k \f$.
       !! @param[in]     x     Abscissae \f$ x_1 < x_2 < \cdots < x_m \f$ (strictly ascending).
       !! @param[in]     y     Ordinates \f$ y_1, y_2, \ldots, y_m \f$.
-      !! @param[in]     w     Weights \f$ w_i > 0 \f$.
+      !! @param[in]     w     Weights \f$ w_i \ge 0 \f$. Setting \f$ w_i = 0 \f$ excludes point \f$ i \f$,
+      !!   so at least \f$ k+1 \f$ weights must be strictly positive.
       !! @param[in]     xb    Left boundary of the approximation interval. \f$ x_b \le x_1 \f$.
       !! @param[in]     xe    Right boundary of the approximation interval. \f$ x_e \ge x_m \f$.
       !! @param[in]     k     Spline degree, \f$ 1 \le k \le 5 \f$. Cubic (\f$ k=3 \f$) recommended.
@@ -1266,6 +1267,7 @@ module fitpack_core
       if (k<=0 .or. k>5)         return
       if (iopt<(-1) .or. iopt>1) return
       if (m<k1 .or. nest<nmin)   return
+      if (count(w>zero)<k1)      return ! w=0 excludes a point, so m>k is not enough on its own
       lwest = m*k1+nest*(7+3*k)
       if (lwrk<lwest)             return
       if (xb>x(1) .or. xe<x(m))  return
@@ -3159,7 +3161,7 @@ module fitpack_core
           ! determine the number of knots nplus we are going to add.
           rn    = nplus
           npl1  = nplus*ITWO
-          if (fpold-fp>acc) npl1 = int(rn*fpms/(fpold-fp))  ! guard the division: skip it when fpold-fp<=acc
+          if (fpold-fp>acc) npl1 = fp_knots_to_add(rn,fpms,fpold-fp) ! guard the division: skip it when fpold-fp<=acc
           nplus = min(nplus*2,max(npl1,nplus/2,1))
           fpold = fp
 
@@ -4001,7 +4003,7 @@ module fitpack_core
         if (ier==FITPACK_OK) then
            npl1 = nplus*2
            rn = nplus
-           if (fpold-fp>acc) npl1 = int(rn*fpms/(fpold-fp))
+           if (fpold-fp>acc) npl1 = fp_knots_to_add(rn,fpms,fpold-fp)
            nplus = min(nplus*2,max(npl1,nplus/2,1))
         else
            nplus = 1
@@ -4927,7 +4929,7 @@ module fitpack_core
         if (ier==FITPACK_OK) then
             npl1 = nplus*2
             rn = nplus
-            if (fpold-fp>acc) npl1 = int(rn*fpms/(fpold-fp))
+            if (fpold-fp>acc) npl1 = fp_knots_to_add(rn,fpms,fpold-fp)
             nplus = min(nplus*2,max(npl1,nplus/2,1))
         else
             nplus = 1
@@ -8274,6 +8276,32 @@ module fitpack_core
 
       end subroutine fpknot
 
+      !> @brief Estimated number of knots to add next, clamped to the integer range.
+      !!
+      !! Evaluates \f$ rn \cdot fpms / reduc \f$ and truncates it to an integer. On large,
+      !! high-variance data sets the ratio can exceed `huge(0_FP_SIZE)`, where the real-to-integer
+      !! conversion is undefined; the result is saturated instead. Callers apply this estimate only
+      !! when `reduc>acc>0`, so the quotient is finite and non-negative for well-behaved residuals.
+      !!
+      !! @param[in] rn     Number of knots added on the previous iteration
+      !! @param[in] fpms   Residual excess of the current spline, \f$ f_p - s \f$
+      !! @param[in] reduc  Residual reduction achieved by the previous knot addition
+      !! @return    Estimated number of knots to add
+      elemental integer(FP_SIZE) function fp_knots_to_add(rn,fpms,reduc) result(npl1)
+         real(FP_REAL), intent(in) :: rn,fpms,reduc
+
+         real(FP_REAL), parameter :: NPL_MAX = real(huge(0_FP_SIZE),FP_REAL)
+         real(FP_REAL) :: ratio
+
+         ratio = rn*fpms/reduc
+         if (ratio<NPL_MAX) then
+            npl1 = int(max(ratio,zero),FP_SIZE)
+         else
+            npl1 = huge(0_FP_SIZE) ! saturate; a NaN ratio lands here too
+         end if
+
+      end function fp_knots_to_add
+
       !> @brief Compute smoothing spline on a polar grid with origin constraints.
       !!
       !! Given data on a \f$ (u, v) \f$ grid (radial \f$ \times \f$ angular),
@@ -9006,7 +9034,7 @@ module fitpack_core
         if (ier==FITPACK_OK) then
            npl1 = nplus*2
            rn = nplus
-           if (fpold-fp>acc) npl1 = int(rn*fpms/(fpold-fp))
+           if (fpold-fp>acc) npl1 = fp_knots_to_add(rn,fpms,fpold-fp)
            nplus = min(nplus*2,max(npl1,nplus/2,1))
         else
            nplus = 1
@@ -9513,7 +9541,7 @@ module fitpack_core
          if (nu/=nminu) then
             npl1 = nplusu*2
             rn = nplusu
-            if (reducu>acc) npl1 = int(rn*fpms/reducu)
+            if (reducu>acc) npl1 = fp_knots_to_add(rn,fpms,reducu)
             nplu = min(nplusu*2,max(npl1,nplusu/2,1))
          endif
 
@@ -9522,7 +9550,7 @@ module fitpack_core
          if (nv/=nminv) then
             npl1 = nplusv*2
             rn = nplusv
-            if (reducv>acc) npl1 = int(rn*fpms/reducv)
+            if (reducv>acc) npl1 = fp_knots_to_add(rn,fpms,reducv)
             nplv = min(nplusv*2,max(npl1,nplusv/2,1))
          endif
 
@@ -9971,7 +9999,7 @@ module fitpack_core
 
         ! determine the number of knots nplus we are going to add.
         npl1  = nplus*ITWO
-        if (fpold-fp>acc) npl1 = int((nplus*fpms)/(fpold-fp),FP_SIZE)  ! guard the division: skip it when fpold-fp<=acc
+        if (fpold-fp>acc) npl1 = fp_knots_to_add(real(nplus,FP_REAL),fpms,fpold-fp) ! guard the division: skip it when fpold-fp<=acc
         nplus = min(nplus*2,max(npl1,nplus/2,1))
         fpold = fp
 
@@ -10707,7 +10735,7 @@ module fitpack_core
                  if (nu/=8) then
                     npl1 = nplusu*2
                     rn = nplusu
-                    if (reducu>acc) npl1 = int(rn*fpms/reducu)
+                    if (reducu>acc) npl1 = fp_knots_to_add(rn,fpms,reducu)
                     nplu = min(nplusu*2,max(npl1,nplusu/2,1))
                  endif
 
@@ -10716,7 +10744,7 @@ module fitpack_core
                  if (nv/=8) then
                     npl1 = nplusv*2
                     rn = nplusv
-                    if (reducv>acc) npl1 = int(rn*fpms/reducv)
+                    if (reducv>acc) npl1 = fp_knots_to_add(rn,fpms,reducv)
                     nplv = min(nplusv*2,max(npl1,nplusv/2,1))
                  endif
 
@@ -12249,7 +12277,7 @@ module fitpack_core
              if (n(d)/=nmin(d)) then
                  npl1 = nplus(d)*2
                  rn   = nplus(d)
-                 if (reduc(d)>acc) npl1 = int(rn*fpms/reduc(d))
+                 if (reduc(d)>acc) npl1 = fp_knots_to_add(rn,fpms,reduc(d))
                  npl(d) = min(nplus(d)*2,max(npl1,nplus(d)/2,1))
              endif
           end do
@@ -13020,7 +13048,7 @@ module fitpack_core
             if (nu/=8) then
                rn   = nplusu
                npl1 = nplusu*2
-               if (reducu>acc) npl1 = int(rn*fpms/reducu)  ! guard the division: skip it when reducu<=acc
+               if (reducu>acc) npl1 = fp_knots_to_add(rn,fpms,reducu) ! guard the division: skip it when reducu<=acc
                nplu = min(nplusu*2,max(npl1,nplusu/2,1))
             endif
 
@@ -13029,7 +13057,7 @@ module fitpack_core
             if (nv/=8) then
                rn   = nplusv
                npl1 = nplusv*2
-               if (reducv>acc) npl1 = int(rn*fpms/reducv)  ! guard the division: skip it when reducv<=acc
+               if (reducv>acc) npl1 = fp_knots_to_add(rn,fpms,reducv) ! guard the division: skip it when reducv<=acc
                nplv = min(nplusv*2,max(npl1,nplusv/2,1))
             endif
 
@@ -17684,7 +17712,8 @@ module fitpack_core
       !! @param[in]     n    Total number of knots.
       !! @param[in]     c    B-spline coefficients (length \f$ n \f$).
       !! @param[in]     k    Degree of the spline.
-      !! @param[in]     nu   Order of derivative, \f$ 0 \le \nu \le k \f$.
+      !! @param[in]     nu   Order of derivative, \f$ \nu \ge 0 \f$. For \f$ \nu > k \f$ the derivative
+      !!   vanishes identically and `y` is returned as zero.
       !! @param[in]     x    Evaluation points (length \f$ m \f$).
       !! @param[out]    y    Derivative values \f$ s^{(\nu)}(x_i) \f$ (length \f$ m \f$).
       !! @param[in]     m    Number of evaluation points, \f$ m \ge 1 \f$.
@@ -17716,12 +17745,19 @@ module fitpack_core
       !  before starting computations a data check is made. if the input data
       !  are invalid control is immediately repassed to the calling program.
       ier = FITPACK_INPUT_ERROR
-      if (nu<0 .or. nu>k) return
+      if (nu<0) return
       if (m<1) return
 
-      kk  = k-nu
-
       ier = FITPACK_OK
+
+      !  the nu-th derivative of a degree-k spline vanishes identically for nu>k. Return it
+      !  explicitly: driving the de Boor recursion past its last level reads outside wrk.
+      if (nu>k) then
+         y = zero
+         return
+      end if
+
+      kk  = k-nu
 
       !  fetch tb and te, the boundaries of the approximation interval.
       k1 = k+1

--- a/src/fitpack_curves.f90
+++ b/src/fitpack_curves.f90
@@ -491,7 +491,7 @@ module fitpack_curves
     !!
     !! @param[in,out] this   The fitted curve object.
     !! @param[in]     x      Array of evaluation points.
-    !! @param[in]     order  Derivative order (\f$ 0 \leq \text{order} \leq k \f$).
+    !! @param[in]     order  Derivative order (\f$ \text{order} > k \f$ evaluates to zero).
     !! @param[out]    ierr   Optional error flag.
     !! @return Array of derivative values \f$ s^{(\text{order})}(x_i) \f$.
     !!
@@ -598,7 +598,7 @@ module fitpack_curves
     !!
     !! @param[in,out] this   The fitted curve object.
     !! @param[in]     x      Scalar evaluation point.
-    !! @param[in]     order  Derivative order (\f$ 0 \leq \text{order} \leq k \f$).
+    !! @param[in]     order  Derivative order (\f$ \text{order} > k \f$ evaluates to zero).
     !! @param[out]    ierr   Optional error flag.
     !! @return Scalar derivative value \f$ s^{(\text{order})}(x) \f$.
     !!

--- a/test/fitpack_curve_tests.f90
+++ b/test/fitpack_curve_tests.f90
@@ -53,6 +53,9 @@ module fitpack_curve_tests
     public :: test_cross_section
     public :: test_derivative_spline
     public :: test_grid_surface_scattered_eval
+    public :: test_derivative_order_guard
+    public :: test_fit_weight_guard
+    public :: test_fit_degree_guard
 
 
     contains
@@ -2536,6 +2539,231 @@ module fitpack_curve_tests
         success = .true.
 
     end function test_grid_surface_scattered_eval
+
+    ! Derivative orders beyond the spline degree: s^(nu) vanishes identically for nu>k, so splder
+    ! must return zeros instead of leaving `y` untouched behind an input-error flag.
+    ! Regression test for https://github.com/scipy/scipy/pull/24076
+    logical function test_derivative_order_guard() result(success)
+
+       integer(FP_SIZE), parameter :: m = 21, k = 3
+       real(FP_REAL),    parameter :: POISON = -12345.0_FP_REAL
+
+       type(fitpack_curve) :: curve
+       integer(FP_SIZE)    :: nu
+       integer(FP_FLAG)    :: ierr
+       real(FP_REAL)       :: x(m),y(m),xe(3),ye(3),wrk(m+k+1)
+
+       success = .false.
+
+       x  = linspace(zero,two*pi,m)
+       y  = sin(x)
+       xe = [0.5_FP_REAL,three,5.5_FP_REAL]
+
+       ierr = curve%new_fit(x,y,order=k)
+       if (.not.FITPACK_SUCCESS(ierr)) then
+          print *, '[test_derivative_order_guard] fit failed: ',FITPACK_MESSAGE(ierr)
+          return
+       end if
+
+       ! nu = k is still the (piecewise constant) k-th derivative
+       ye = POISON
+       call splder(curve%t,curve%knots,curve%c,k,k,xe,ye,size(xe,kind=FP_SIZE),OUTSIDE_EXTRAPOLATE,wrk,ierr)
+       if (.not.FITPACK_SUCCESS(ierr) .or. any(equal(ye,POISON))) then
+          print *, '[test_derivative_order_guard] nu=k failed, ierr=',ierr
+          return
+       end if
+
+       ! nu > k: identically zero, reported as a normal return
+       do nu = k+1,k+4
+          ye = POISON
+          call splder(curve%t,curve%knots,curve%c,k,nu,xe,ye,size(xe,kind=FP_SIZE),OUTSIDE_EXTRAPOLATE,wrk,ierr)
+          if (.not.FITPACK_SUCCESS(ierr)) then
+             print *, '[test_derivative_order_guard] nu=',nu,' returned ',FITPACK_MESSAGE(ierr)
+             return
+          end if
+          if (.not.all(equal(ye,zero))) then
+             print *, '[test_derivative_order_guard] nu=',nu,' did not return zeros: ',ye
+             return
+          end if
+       end do
+
+       ! a negative order remains an input error
+       ye = POISON
+       call splder(curve%t,curve%knots,curve%c,k,-1_FP_SIZE,xe,ye,size(xe,kind=FP_SIZE),OUTSIDE_EXTRAPOLATE,wrk,ierr)
+       if (ierr/=FITPACK_INPUT_ERROR) then
+          print *, '[test_derivative_order_guard] nu<0 not rejected, ierr=',ierr
+          return
+       end if
+
+       ! same through the object interface
+       ye = curve%dfdx(xe,order=k+2,ierr=ierr)
+       if (.not.FITPACK_SUCCESS(ierr) .or. .not.all(equal(ye,zero))) then
+          print *, '[test_derivative_order_guard] curve%dfdx(order=k+2) ierr=',ierr,' y=',ye
+          return
+       end if
+
+       success = .true.
+
+    end function test_derivative_order_guard
+
+    ! w=0 is the documented way to exclude a data point, so `m>k` is not a sufficient data check:
+    ! the fit must have at least k+1 strictly positive weights or the normal equations are singular.
+    ! Regression test for https://github.com/scipy/scipy/issues/23542
+    logical function test_fit_weight_guard() result(success)
+
+       integer(FP_SIZE), parameter :: m = 12, k = 3, nest = m+k+1
+
+       real(FP_REAL)    :: x(m),y(m),w(m),t(nest),c(nest),fp
+       real(FP_REAL)    :: wrk(m*(k+1)+nest*(7+3*k))
+       integer(FP_SIZE) :: iwrk(nest),n,i
+       integer(FP_FLAG) :: ier
+
+       success = .false.
+
+       x = linspace(zero,one,m)
+       y = exp(x)
+
+       ! (a) all weights zero: rejected up front instead of returning NaN coefficients
+       w = zero
+       call reset()
+       call curfit(IOPT_NEW_SMOOTHING,m,x,y,w,x(1),x(m),k,one,nest,n,t,c,fp,wrk,size(wrk,kind=FP_SIZE),iwrk,ier)
+       if (ier/=FITPACK_INPUT_ERROR) then
+          print *, '[test_fit_weight_guard] all-zero weights not rejected, ier=',ier
+          return
+       end if
+
+       ! (b) exactly k positive weights: still one short of a determined system
+       w = zero
+       w(1:k) = one
+       call reset()
+       call curfit(IOPT_NEW_SMOOTHING,m,x,y,w,x(1),x(m),k,one,nest,n,t,c,fp,wrk,size(wrk,kind=FP_SIZE),iwrk,ier)
+       if (ier/=FITPACK_INPUT_ERROR) then
+          print *, '[test_fit_weight_guard] k positive weights not rejected, ier=',ier
+          return
+       end if
+
+       ! (c) k+1 positive weights: accepted, and the coefficients must be finite
+       w = zero
+       w(1:k+1) = one
+       call reset()
+       call curfit(IOPT_NEW_SMOOTHING,m,x,y,w,x(1),x(m),k,1.0e6_FP_REAL,nest,n,t,c,fp,wrk, &
+                   size(wrk,kind=FP_SIZE),iwrk,ier)
+       if (.not.FITPACK_SUCCESS(ier)) then
+          print *, '[test_fit_weight_guard] k+1 positive weights rejected, ier=',ier
+          return
+       end if
+       if (.not.all(c(1:n-k-1)==c(1:n-k-1))) then
+          print *, '[test_fit_weight_guard] NaN coefficients with k+1 positive weights'
+          return
+       end if
+
+       success = .true.
+
+       contains
+
+          subroutine reset()
+             n = 0; t = zero; c = zero; fp = zero; wrk = zero; iwrk = 0
+          end subroutine reset
+
+    end function test_fit_weight_guard
+
+    ! Degrees below 1 must be rejected coherently by every fitting front end (scipy#25381 hit an
+    ! internal error for k=0), and a high-variance data set must not derail the knot-count estimate
+    ! (scipy#25726: the real-to-integer conversion of that estimate can overflow).
+    logical function test_fit_degree_guard() result(success)
+
+       integer(FP_SIZE), parameter :: m = 12, kmax = 5, nest = m+kmax+1
+       integer(FP_DIM),  parameter :: dims = 2
+       integer(FP_SIZE), parameter :: mg = 6
+
+       real(FP_REAL)    :: x(m),y(m),w(m),t(nest),c(nest),fp
+       real(FP_REAL)    :: wrk(m*(kmax+1)+nest*(8+5*kmax))
+       integer(FP_SIZE) :: iwrk(nest),n,i,j,k
+       integer(FP_FLAG) :: ier
+       type(fitpack_curve) :: curve
+
+       ! gridded fit: per-axis degrees
+       integer(FP_SIZE) :: mgrid(dims),kgrid(dims),nestg(dims),ngrid(dims)
+       real(FP_REAL)    :: xg(mg,dims),lo(dims),hi(dims),tg(mg+kmax+1,dims)
+       real(FP_REAL)    :: zg(mg*mg),cg((mg+kmax+1)**2),fpg,wrkg(20000)
+       integer(FP_SIZE) :: iwrkg(2000)
+
+       success = .false.
+
+       x = linspace(zero,one,m)
+       y = exp(x)
+       w = one
+
+       ! (a) k<1 and k>5 are input errors for the scalar fitters
+       do k = 0,6,6
+          n = 0; t = zero; c = zero; fp = zero; wrk = zero; iwrk = 0
+          call curfit(IOPT_NEW_SMOOTHING,m,x,y,w,x(1),x(m),k,one,nest,n,t,c,fp,wrk, &
+                      size(wrk,kind=FP_SIZE),iwrk,ier)
+          if (ier/=FITPACK_INPUT_ERROR) then
+             print *, '[test_fit_degree_guard] curfit accepted k=',k,' ier=',ier
+             return
+          end if
+
+          n = 0; t = zero; c = zero; fp = zero; wrk = zero; iwrk = 0
+          call percur(IOPT_NEW_SMOOTHING,m,x,y,w,k,one,nest,n,t,c,fp,wrk, &
+                      size(wrk,kind=FP_SIZE),iwrk,ier)
+          if (ier/=FITPACK_INPUT_ERROR) then
+             print *, '[test_fit_degree_guard] percur accepted k=',k,' ier=',ier
+             return
+          end if
+       end do
+
+       ! (b) same for the gridded front end, on every axis
+       mgrid = mg
+       nestg = mg+kmax+1
+       do i = 1,mg
+          xg(i,:) = real(i-1,FP_REAL)
+       end do
+       lo = xg(1,:)
+       hi = xg(mg,:)
+       do i = 1,mg
+          do j = 1,mg
+             zg((i-1)*mg+j) = xg(i,1)+xg(j,2)
+          end do
+       end do
+
+       do i = 1,dims
+          kgrid    = 3
+          kgrid(i) = 0
+          ngrid    = 0; tg = zero; cg = zero; fpg = zero
+          call regrid(IOPT_NEW_SMOOTHING,dims,mgrid,xg,zg,lo,hi,kgrid,one,nestg,ngrid,tg,cg,fpg, &
+                      wrkg,size(wrkg,kind=FP_SIZE),iwrkg,size(iwrkg,kind=FP_SIZE),ier)
+          if (ier/=FITPACK_INPUT_ERROR) then
+             print *, '[test_fit_degree_guard] regrid accepted k=0 on axis ',i,' ier=',ier
+             return
+          end if
+       end do
+
+       ! (c) the object interface reports the same input error
+       ier = curve%new_fit(x,y,order=0_FP_SIZE)
+       if (FITPACK_SUCCESS(ier)) then
+          print *, '[test_fit_degree_guard] curve%new_fit accepted order=0'
+          return
+       end if
+
+       ! (d) a data set spanning many orders of magnitude drives the knot-count estimate to
+       !     extreme values: the fit must still terminate with finite coefficients
+       y = [(ten**(2*i-m),i=1,m)]
+       n = 0; t = zero; c = zero; fp = zero; wrk = zero; iwrk = 0
+       call curfit(IOPT_NEW_SMOOTHING,m,x,y,w,x(1),x(m),3_FP_SIZE,smallnum10,nest,n,t,c,fp,wrk, &
+                   size(wrk,kind=FP_SIZE),iwrk,ier)
+       if (ier==FITPACK_INPUT_ERROR) then
+          print *, '[test_fit_degree_guard] high-variance fit rejected'
+          return
+       end if
+       if (.not.all(abs(c(1:n-4))<huge(zero))) then
+          print *, '[test_fit_degree_guard] high-variance fit returned non-finite coefficients'
+          return
+       end if
+
+       success = .true.
+
+    end function test_fit_degree_guard
 
     ! ODE-style reciprocal error weight
     elemental real(FP_REAL) function rewt(RTOL,ATOL,x)

--- a/test/test.f90
+++ b/test/test.f90
@@ -70,6 +70,9 @@ program test
         call add_test(test_derivative_spline())
         call add_test(test_grid_surface_scattered_eval())
         call add_test(test_nd_grid_equivalence())
+        call add_test(test_derivative_order_guard())
+        call add_test(test_fit_weight_guard())
+        call add_test(test_fit_degree_guard())
 
     end subroutine run_interface_tests
 


### PR DESCRIPTION
Three input/evaluation guards ported from the fixes SciPy accumulated while translating FITPACK to C. Part of the plan in #62.

### `splder`: derivative orders above the spline degree ([scipy#24076](https://github.com/scipy/scipy/pull/24076))

`s^(nu)` of a degree-`k` spline vanishes identically for `nu > k`. The routine rejected such an order with `FITPACK_INPUT_ERROR` and returned **without writing `y`**, so any caller that does not inspect the flag — including `fitpack_curve%dfdx(x, order=...)`, whose result array is the function return value — read whatever the output array happened to hold. `nu > k` now returns the zero function with a normal flag; `nu < 0` remains an input error, and `nu == k` (the piecewise-constant top derivative) is unchanged.

The tensor-product derivative path was checked and needs no change: `pardtc`, `parder` and `pardeu` validate `nu` **per axis** (`any(nu<0) .or. any(nu>=k)`) before touching memory, so the de Boor recursion is never entered out of range there.

**Test:** `test_derivative_order_guard` — orders `k+1 … k+4` return exact zeros with a success flag from both `splder` and `curve%dfdx`, order `k` still returns the constant derivative, order `-1` is still an input error. Fails before (`nu=4` returns `Invalid input` and leaves the poisoned output array untouched).

### `curfit`: `w = 0` is point exclusion, so `m > k` is not the real precondition ([scipy#23755](https://github.com/scipy/scipy/pull/23755) / [scipy#23542](https://github.com/scipy/scipy/issues/23542))

`curfit` documented `w_i > 0` but never enforced it, and its data-sufficiency check was `m > k`. An all-zero weight vector therefore passed validation and came back as `FITPACK_LEASTSQUARES_OK` with **NaN coefficients** — a silent wrong answer. The precondition is now `count(w > 0) > k`.

`percur`, `parcur`, `clocur` and `concur` were checked: all four already reject `w <= 0` outright (`any(w<=zero) return`), so for them `count(w>0) == m` and `m > k` is already equivalent. No change needed.

**Test:** `test_fit_weight_guard` — all-zero weights and exactly `k` positive weights are rejected with `FITPACK_INPUT_ERROR`; `k+1` positive weights fit successfully with finite coefficients. Fails before (`ier = -2` with NaN coefficients).

### Knot-count estimate and degree validation ([scipy#25726](https://github.com/scipy/scipy/pull/25726), [scipy#25381](https://github.com/scipy/scipy/pull/25381))

The number of knots to add on the next iteration is `int(rn*fpms/reduc)`. On large, high-variance data that ratio can exceed `huge(0_FP_SIZE)`, where the real-to-integer conversion is undefined (UBSan flags it upstream). The twelve conversion sites — `fpclos`, `fpcons`, `fpcurf`, `fppara`, `fppasu` (×2), `fpperi`, `fppogr` (×2), `fpregr`, `fpspgr` (×2) — now go through the new `fp_knots_to_add`, which saturates at `huge(0_FP_SIZE)` (and absorbs a NaN ratio) instead.

This is hardening, not a visible behaviour change: on x86-64 an out-of-range `int()` yields `INT_MIN`, which the surrounding `max(npl1, nplus/2, 1)` already absorbed. There is no input that makes the old and new code disagree observably from the public API, so the accompanying check is a pin rather than a fail-before test.

`k < 1` was audited rather than fixed: `curfit`, `percur`, `parcur`, `clocur`, `concur`, `surfit` and `regrid` all reject `k <= 0` (and `k > 5`) up front, and the object interfaces inherit that, so the `k = 0` internal error SciPy hit does not exist here. `test_fit_degree_guard` pins that coherence across `curfit`, `percur`, `regrid` (per axis) and `fitpack_curve%new_fit`, plus a high-variance fit that exercises the clamped estimate.

### Verification

- `fpm test`: 60 → 63 tests, all passing (gfortran 16.1.0, fpm 0.13.0).
- `fpm test --flag "-finit-real=inf"`: 63/63.
- Each of the two behavioural tests was confirmed to fail on the unmodified sources.

Two pre-existing conditions on this toolchain, unrelated to this PR and reproduced on a pristine `main`: `-fcheck=bounds` SIGSEGVs (gfortran 16.1.x bounds-check bug), and `--profile release` fails `test_polar_fit` and `test_comm_roundtrips` with `Invalid input`.
