### PR TITLE
regrid: configurable iteration cap and gridded regression gates

### DIFF
--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -118,6 +118,10 @@ module fitpack_core
     integer(FP_FLAG), parameter,  public :: KNOT_DIM_1    =  1  ! Last knot added on 1st dim (x or u)
     integer(FP_FLAG), parameter,  public :: KNOT_DIM_2    =  2  ! Last knot added on 2nd dim (y or v)
 
+    ! Default cap on the smoothing-parameter iterations of the gridded fit. Large grids can need
+    ! more; regrid takes an optional maxit that overrides it.
+    integer(FP_SIZE), parameter, public :: REGRID_MAXIT = 20
+
     ! Spline degrees
     integer(FP_SIZE), parameter, public :: MAX_ORDER = 19    ! Max spline order (for array allocation)
     integer(FP_SIZE), parameter, public :: DEGREE_3  =  3
@@ -322,7 +326,7 @@ module fitpack_core
             case (FITPACK_LEASTSQUARES_OK); msg = 'Success! (least-squares)'
             case (FITPACK_INSUFFICIENT_STORAGE); msg = 'Insufficient Storage'
             case (FITPACK_S_TOO_SMALL); msg = 'Smoothing parameter is too small'
-            case (FITPACK_MAXIT); msg = 'Infinite loop detected'
+            case (FITPACK_MAXIT); msg = 'Iteration limit reached before f(p)=s'
             case (FITPACK_TOO_MANY_KNOTS); msg = 'More knots than data points'
             case (FITPACK_OVERLAPPING_KNOTS); msg = 'Overlapping knots found'
             case (FITPACK_INVALID_RANGE); msg = 'Invalid variable range'
@@ -16728,8 +16732,12 @@ module fitpack_core
       !!   mq = 2*max_{i=1..dims-1} [ product(nk1max(1:i)) * product(m(i+1:dims)) ]
       !!   mm = max(nestmax, mmax, product(m(2:dims)), product(nk1max(1:dims-1)))
       !!
+      !! @param[in] maxit  Optional cap on the smoothing-parameter iterations (default
+      !!                   `REGRID_MAXIT`). Large grids may need more than the default before
+      !!                   `f(p)=s` is met; `FITPACK_MAXIT` reports that the cap was reached.
+      !!
       !! @see regrid, fpregr; Dierckx, SIAM J.Numer.Anal. 19 (1982) 1286-1304; Ch.5 §5.4.
-      pure subroutine regrid(iopt,dims,m,xg,z,lo,hi,k,s,nest,n,t,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+      pure subroutine regrid(iopt,dims,m,xg,z,lo,hi,k,s,nest,n,t,c,fp,wrk,lwrk,iwrk,kwrk,ier,maxit)
 
       !  ..scalar arguments..
       integer(FP_SIZE), intent(in)    :: iopt
@@ -16738,6 +16746,7 @@ module fitpack_core
       real(FP_REAL),    intent(out)   :: fp
       integer(FP_SIZE), intent(in)    :: lwrk,kwrk
       integer(FP_FLAG), intent(out)   :: ier
+      integer(FP_SIZE), intent(in), optional :: maxit
       !  ..array arguments..
       integer(FP_SIZE), intent(in)    :: m(dims),k(dims),nest(dims)
       real(FP_REAL),    intent(in)    :: lo(dims),hi(dims)
@@ -16750,11 +16759,10 @@ module fitpack_core
       integer(FP_SIZE), intent(inout), target     :: iwrk(kwrk)
 
       !  ..parameters..
-      integer(FP_SIZE), parameter :: maxit = 20
       real(FP_REAL),    parameter :: tol = smallnum03
       !  ..local scalars..
       integer(FP_DIM)  :: d
-      integer(FP_SIZE) :: nc,lwest,kwest,maxm,maxnest,maxk1,maxk2,mm,mynx,offr,offi,i,bufmax
+      integer(FP_SIZE) :: nit,nc,lwest,kwest,maxm,maxnest,maxk1,maxk2,mm,mynx,offr,offi,i,bufmax
       !  ..per-axis arrays..
       integer(FP_SIZE) :: k1(dims),k2(dims),nmin(dims),nk1max(MAX_IDIM)
       !  ..workspace views (carved from wrk/iwrk; contiguous by construction)..
@@ -16763,6 +16771,9 @@ module fitpack_core
 
       !  before starting computations a data check is made.
       ier = FITPACK_INPUT_ERROR
+
+      nit  = REGRID_MAXIT
+      if (present(maxit)) nit = max(IONE,maxit)
 
       k1   = k+1
       k2   = k+2
@@ -16831,7 +16842,7 @@ module fitpack_core
       pnr(1:maxm,1:dims)             => iwrk(offi+1:offi+maxm*dims);            offi = offi+maxm*dims
       pnrdat(1:maxnest,1:dims)       => iwrk(offi+1:offi+maxnest*dims)
 
-      call fpregr(iopt,dims,xg,m,z,lo,hi,k,s,nest,tol,maxit,nc, &
+      call fpregr(iopt,dims,xg,m,z,lo,hi,k,s,nest,tol,nit,nc, &
                      n,t,c,fp,wrk(1),wrk(2),wrk(3:2+dims),iwrk(1),iwrk(2:1+dims), &
                      pfpint,pnr,pnrdat,psp,pright,pq,pa,pb,ier)
       return

--- a/test/fitpack_grid_nd_tests.f90
+++ b/test/fitpack_grid_nd_tests.f90
@@ -27,6 +27,7 @@ module fitpack_grid_nd_tests
     private
 
     public :: test_nd_grid_equivalence
+    public :: test_nd_grid_regressions
 
     !> regrid workspace sizing (generous; mirrors legacy mnregr which uses nxest=nyest=17)
     integer(FP_SIZE), parameter :: NXEST = 17, NYEST = 17
@@ -1620,5 +1621,312 @@ module fitpack_grid_nd_tests
         9100 format('[gate M] class ',a,' /= direct core call')
         9200 format('[gate M] class ',a,' functional check failed  (max |diff| = ',1pe12.3,')')
     end function gate_gridded_spline_peripherals
+
+    !> @brief Regression gates for the gridded defects SciPy reported against FITPACK.
+    !!
+    !! N. Per-axis validation of the derivative orders in pardtc/parder (scipy#24084)
+    !! O. Knot saturation at the interpolating maximum leaves a usable fit (scipy#22433, scipy#17787)
+    !! P. The smoothing-parameter iteration cap is honoured and configurable (scipy#22433)
+    logical function test_nd_grid_regressions(iunit) result(success)
+        integer, optional, intent(in) :: iunit
+        integer :: useUnit
+
+        useUnit = output_unit
+        if (present(iunit)) useUnit = iunit
+
+        success = .true.
+
+        if (success) success = gate_pardtc_axis_orders(useUnit)
+        if (success) success = gate_regrid_saturated_knots(useUnit)
+        if (success) success = gate_regrid_maxit(useUnit)
+
+        if (success) write(useUnit,'(a)') '[test_nd_grid_regressions] all gridded regression gates OK'
+
+    end function test_nd_grid_regressions
+
+    !> @brief Gate N — each derivative order is validated against its own axis degree.
+    !!
+    !! With kx=3 and ky=2, the order (2,0) is legal in x and must be accepted; comparing it against
+    !! the y degree (the scipy#24084 defect) would reject it. The result is checked against the
+    !! analytic derivative of an in-space separable polynomial, and orders that really do reach the
+    !! per-axis degree must still be refused. Repeated at dims=3 with three distinct degrees.
+    logical function gate_pardtc_axis_orders(useUnit) result(ok)
+        integer, intent(in) :: useUnit
+
+        integer(FP_SIZE), parameter :: kx = 3, ky = 2, mg = 8, nk1 = 6
+        integer(FP_SIZE), parameter :: nkk = nk1+kx+1, nc2 = nk1*nk1
+        real(FP_REAL),    parameter :: cpx(4) = [1.0_FP_REAL,0.5_FP_REAL,-0.3_FP_REAL,0.2_FP_REAL]
+        real(FP_REAL),    parameter :: cpy(3) = [0.8_FP_REAL,-0.4_FP_REAL,0.6_FP_REAL]
+        real(FP_REAL),    parameter :: DTOL = 1.0e-8_FP_REAL
+
+        integer(FP_SIZE) :: n2(2),k2(2),m2(2),nest2(2),nu2(2)
+        real(FP_REAL)    :: t2(nkk,2),xg2(mg,2),c2(nc2),z2(mg*mg),lo(2),hi(2),fp
+        real(FP_REAL)    :: zd(mg*mg),wrk(8000)
+        integer(FP_SIZE) :: iwrk(800)
+        integer(FP_FLAG) :: ier
+        integer(FP_SIZE) :: i,j,iout
+        real(FP_REAL)    :: maxdiff,x,y
+
+        ! dims=3 leg: degrees 3/2/4, orders legal on one axis but not on another
+        integer(FP_SIZE), parameter :: kz = 4, nk1z = 7
+        integer(FP_SIZE) :: n3(3),k3(3),nu3(3)
+        real(FP_REAL)    :: t3(nk1z+kz+1,3),c3(nk1*nk1*nk1z),newc3(nk1*nk1*nk1z)
+        real(FP_REAL)    :: ca(nk1),cb(nk1),cd(nk1z)
+
+        ok = .true.
+
+        ! in-space separable polynomial: degree kx in x, degree ky in y
+        t2 = zero; xg2 = zero
+        call clamped_unit_knots(kx,nk1,t2(:,1),n2(1))
+        call clamped_unit_knots(ky,nk1,t2(:,2),n2(2))
+        nest2 = n2
+        k2    = [kx,ky]
+        m2    = mg
+        lo    = zero
+        hi    = one
+        do i=1,mg; xg2(i,1) = real(i-1,FP_REAL)/real(mg-1,FP_REAL); end do
+        xg2(:,2) = xg2(:,1)
+        do i=1,mg
+           do j=1,mg
+              z2((i-1)*mg+j) = poly_deriv(cpx,0_FP_SIZE,xg2(i,1))*poly_deriv(cpy,0_FP_SIZE,xg2(j,2))
+           end do
+        end do
+
+        wrk = zero; iwrk = 0
+        call regrid(-1_FP_FLAG,2_FP_DIM,m2,xg2,z2,lo,hi,k2,zero,nest2,n2,t2,c2,fp, &
+                    wrk,size(wrk,kind=FP_SIZE),iwrk,size(iwrk,kind=FP_SIZE),ier)
+        if (.not.FITPACK_SUCCESS(ier) .or. fp>1.0e-9_FP_REAL) then
+            ok = .false.; write(useUnit,4000) 'least-squares fit',ier; return
+        end if
+
+        ! (a) nu=(2,0): 2 >= ky but 2 < kx, so it is a legal x-derivative
+        nu2 = [2_FP_SIZE,0_FP_SIZE]
+        call parder(2_FP_DIM,t2,n2,c2,k2,nu2,xg2,m2,zd, &
+                    wrk,size(wrk,kind=FP_SIZE),iwrk,size(iwrk,kind=FP_SIZE),ier)
+        if (.not.FITPACK_SUCCESS(ier)) then
+            ok = .false.; write(useUnit,4100) nu2(1),nu2(2),kx,ky,ier; return
+        end if
+        maxdiff = zero
+        do i=1,mg
+           x = xg2(i,1)
+           do j=1,mg
+              y = xg2(j,2)
+              iout = (i-1)*mg+j
+              maxdiff = max(maxdiff, abs(zd(iout) - &
+                        poly_deriv(cpx,nu2(1),x)*poly_deriv(cpy,nu2(2),y)))
+           end do
+        end do
+        if (.not.(maxdiff<=DTOL)) then
+            ok = .false.; write(useUnit,4200) maxdiff; return
+        end if
+
+        ! (b) orders that reach their own axis degree stay rejected
+        nu2 = [0_FP_SIZE,ky]
+        call pardtc(2_FP_DIM,t2,n2,c2,k2,nu2,zd,ier)
+        if (ier/=FITPACK_INPUT_ERROR) then
+            ok = .false.; write(useUnit,4300) nu2(1),nu2(2),ier; return
+        end if
+        nu2 = [kx,0_FP_SIZE]
+        call pardtc(2_FP_DIM,t2,n2,c2,k2,nu2,zd,ier)
+        if (ier/=FITPACK_INPUT_ERROR) then
+            ok = .false.; write(useUnit,4300) nu2(1),nu2(2),ier; return
+        end if
+
+        ! (c) dims=3, three distinct degrees: (2,1,3) is legal on every axis, (0,2,0) is not
+        call build_separable_3d(kx,ky,kz,nk1,nk1,nk1z,t3,n3,k3,c3,ca,cb,cd)
+        nu3 = [2_FP_SIZE,1_FP_SIZE,3_FP_SIZE]
+        call pardtc(3_FP_DIM,t3,n3,c3,k3,nu3,newc3,ier)
+        if (.not.FITPACK_SUCCESS(ier)) then
+            ok = .false.; write(useUnit,4400) nu3,ier; return
+        end if
+        nu3 = [0_FP_SIZE,ky,0_FP_SIZE]
+        call pardtc(3_FP_DIM,t3,n3,c3,k3,nu3,newc3,ier)
+        if (ier/=FITPACK_INPUT_ERROR) then
+            ok = .false.; write(useUnit,4400) nu3,ier; return
+        end if
+
+        write(useUnit,'(a)') '[gate N] pardtc/parder validate each derivative order against its own axis degree'
+
+        4000 format('[gate N] ',a,' failed, ier=',i0)
+        4100 format('[gate N] order (',i0,',',i0,') rejected with kx=',i0,', ky=',i0,': ier=',i0)
+        4200 format('[gate N] d2/dx2 /= analytic derivative  (max |diff| = ',1pe12.3,')')
+        4300 format('[gate N] order (',i0,',',i0,') should be an input error, got ier=',i0)
+        4400 format('[gate N] dims=3 order (',i0,',',i0,',',i0,') gave ier=',i0)
+    end function gate_pardtc_axis_orders
+
+    !> @brief Gate O — a fit whose knot count saturates at the interpolating maximum stays usable.
+    !!
+    !! Aliased (noise-like) data on a modest grid drives fpknot until one or both axes reach
+    !! nmax = m+k+1. Upstream that produced NaN coefficients without any error flag (scipy#17787);
+    !! here fpknot refuses to split a knot interval that holds no interior data point, so the
+    !! Schoenberg-Whitney condition survives saturation. The gate pins that: saturation must
+    !! actually happen, and the fit must come back successful, finite and within tolerance of s.
+    logical function gate_regrid_saturated_knots(useUnit) result(ok)
+        integer, intent(in) :: useUnit
+
+        integer(FP_SIZE), parameter :: mx = 9, my = 25, kk = 3
+        integer(FP_SIZE), parameter :: NXS = mx+kk+1, NYS = my+kk+1, NCS = (NXS-kk-1)*(NYS-kk-1)
+        real(FP_REAL),    parameter :: RTOL = 2.0e-3_FP_REAL
+
+        integer(FP_SIZE) :: m2(2),k2(2),nest2(2),n2(2)
+        real(FP_REAL)    :: xg(max(mx,my),2),lo(2),hi(2),t2(max(NXS,NYS),2)
+        real(FP_REAL)    :: z(mx*my),c(NCS),zev(mx*my),fp,s
+        real(FP_REAL)    :: wrk(20000),ewrk(4000)
+        integer(FP_SIZE) :: iwrk(2000),eiwrk(400)
+        integer(FP_FLAG) :: ier
+        integer(FP_SIZE) :: i,j,is,nc
+        logical          :: saturated
+
+        ok = .true.
+        saturated = .false.
+
+        m2    = [mx,my]
+        k2    = kk
+        nest2 = [NXS,NYS]
+        xg    = zero
+        do i=1,mx; xg(i,1) = real(i-1,FP_REAL); end do
+        do j=1,my; xg(j,2) = real(j-1,FP_REAL); end do
+        lo = [xg(1,1),xg(1,2)]
+        hi = [xg(mx,1),xg(my,2)]
+        do i=1,mx
+           do j=1,my
+              z((i-1)*my+j) = aliased_sample(i,j)
+           end do
+        end do
+
+        do is=1,10
+           s  = 0.05_FP_REAL*is
+           n2 = 0; t2 = zero; c = zero; fp = zero; wrk = zero; iwrk = 0
+           call regrid(IOPT_NEW_SMOOTHING,2_FP_DIM,m2,xg,z,lo,hi,k2,s,nest2,n2,t2,c,fp, &
+                       wrk,size(wrk,kind=FP_SIZE),iwrk,size(iwrk,kind=FP_SIZE),ier)
+           if (.not.FITPACK_SUCCESS(ier)) then
+               ok = .false.; write(useUnit,5000) s,ier; return
+           end if
+
+           nc = product(n2-k2-1)
+           if (.not.all(c(1:nc)==c(1:nc)) .or. .not.(abs(fp)<huge(zero))) then
+               ok = .false.; write(useUnit,5100) s; return
+           end if
+           if (.not.(abs(fp-s)<=RTOL*s)) then
+               ok = .false.; write(useUnit,5200) s,fp; return
+           end if
+           saturated = saturated .or. any(n2==m2+k2+1)
+
+           ! the fitted spline must evaluate to finite values on the data grid
+           call ndspev(2_FP_DIM,t2,n2,c(1:nc),k2,xg,m2,zev, &
+                       ewrk,size(ewrk,kind=FP_SIZE),eiwrk,size(eiwrk,kind=FP_SIZE),ier)
+           if (.not.FITPACK_SUCCESS(ier) .or. .not.all(abs(zev)<huge(zero))) then
+               ok = .false.; write(useUnit,5300) s; return
+           end if
+        end do
+
+        if (.not.saturated) then
+            ok = .false.
+            write(useUnit,'(a)') '[gate O] no axis ever reached its interpolating knot count: gate is vacuous'
+            return
+        end if
+
+        write(useUnit,'(a)') '[gate O] regrid stays finite and on-tolerance when a knot count saturates at nmax'
+
+        5000 format('[gate O] fit failed at s=',1pe10.3,', ier=',i0)
+        5100 format('[gate O] non-finite coefficients or residual at s=',1pe10.3)
+        5200 format('[gate O] residual off tolerance at s=',1pe10.3,': fp=',1pe12.5)
+        5300 format('[gate O] evaluation of the saturated fit failed at s=',1pe10.3)
+    end function gate_regrid_saturated_knots
+
+    !> @brief Gate P — the smoothing-parameter iteration cap is honoured and overridable.
+    !!
+    !! Large grids can need more than the historical hard-coded 20 iterations of the f(p)=s root
+    !! search (scipy#22433). The cap is now a named default that regrid takes as an optional
+    !! argument: a cap of one iteration must report FITPACK_MAXIT, omitting the argument must be
+    !! identical to passing REGRID_MAXIT, and a raised cap must never do worse than the default.
+    logical function gate_regrid_maxit(useUnit) result(ok)
+        integer, intent(in) :: useUnit
+
+        integer(FP_SIZE), parameter :: mx = 20, my = 30, kk = 1
+        integer(FP_SIZE), parameter :: NXS = mx+kk+1, NYS = my+kk+1, NCS = (NXS-kk-1)*(NYS-kk-1)
+
+        integer(FP_SIZE) :: m2(2),k2(2),nest2(2),n2(2),ndef(2)
+        real(FP_REAL)    :: xg(max(mx,my),2),lo(2),hi(2),t2(max(NXS,NYS),2)
+        real(FP_REAL)    :: z(mx*my),c(NCS),cdef(NCS),fp,fpdef,s
+        real(FP_REAL)    :: wrk(40000)
+        integer(FP_SIZE) :: iwrk(4000)
+        integer(FP_FLAG) :: ier,ierdef
+        integer(FP_SIZE) :: i,j
+
+        ok = .true.
+
+        m2    = [mx,my]
+        k2    = kk
+        nest2 = [NXS,NYS]
+        xg    = zero
+        do i=1,mx; xg(i,1) = real(i-1,FP_REAL); end do
+        do j=1,my; xg(j,2) = real(j-1,FP_REAL); end do
+        lo = [xg(1,1),xg(1,2)]
+        hi = [xg(mx,1),xg(my,2)]
+        do i=1,mx
+           do j=1,my
+              z((i-1)*my+j) = aliased_sample(i,j)
+           end do
+        end do
+        s = 0.01_FP_REAL*mx*my
+
+        ! (a) a single iteration cannot reach f(p)=s: the cap must be reported, not ignored
+        call fit(1_FP_SIZE,n2,c,fp,ier)
+        if (ier/=FITPACK_MAXIT) then
+            ok = .false.; write(useUnit,7000) ier; return
+        end if
+
+        ! (b) omitting maxit must be identical to passing the documented default
+        n2 = 0; t2 = zero; cdef = zero; fpdef = zero; wrk = zero; iwrk = 0
+        call regrid(IOPT_NEW_SMOOTHING,2_FP_DIM,m2,xg,z,lo,hi,k2,s,nest2,n2,t2,cdef,fpdef, &
+                    wrk,size(wrk,kind=FP_SIZE),iwrk,size(iwrk,kind=FP_SIZE),ierdef)
+        ndef = n2
+        call fit(REGRID_MAXIT,n2,c,fp,ier)
+        if (ier/=ierdef .or. any(n2/=ndef) .or. .not.(fp==fpdef) .or. .not.all(c==cdef)) then
+            ok = .false.
+            write(useUnit,'(a)') '[gate P] explicit maxit=REGRID_MAXIT differs from the default'
+            return
+        end if
+
+        ! (c) a raised cap must never do worse than the default
+        call fit(10*REGRID_MAXIT,n2,c,fp,ier)
+        if (.not.FITPACK_SUCCESS(ier) .and. FITPACK_SUCCESS(ierdef)) then
+            ok = .false.; write(useUnit,7100) ier,ierdef; return
+        end if
+        if (ierdef==FITPACK_MAXIT .and. ier==FITPACK_MAXIT) then
+            ok = .false.
+            write(useUnit,'(a)') '[gate P] raising the iteration cap did not help convergence'
+            return
+        end if
+
+        write(useUnit,'(a)') '[gate P] regrid honours its iteration cap and the optional maxit override'
+
+        7000 format('[gate P] maxit=1 returned ier=',i0,' instead of FITPACK_MAXIT')
+        7100 format('[gate P] raised cap regressed: ier=',i0,' vs default ier=',i0)
+
+        contains
+
+           subroutine fit(mit,nout,cout,fpout,ierout)
+              integer(FP_SIZE), intent(in)  :: mit
+              integer(FP_SIZE), intent(out) :: nout(2)
+              real(FP_REAL),    intent(out) :: cout(NCS),fpout
+              integer(FP_FLAG), intent(out) :: ierout
+              nout = 0; t2 = zero; cout = zero; fpout = zero; wrk = zero; iwrk = 0
+              call regrid(IOPT_NEW_SMOOTHING,2_FP_DIM,m2,xg,z,lo,hi,k2,s,nest2,nout,t2,cout,fpout, &
+                          wrk,size(wrk,kind=FP_SIZE),iwrk,size(iwrk,kind=FP_SIZE),ierout,maxit=mit)
+           end subroutine fit
+
+    end function gate_regrid_maxit
+
+    !> @brief Deterministic aliased sample: smooth in the continuum, noise-like on an integer grid.
+    !!        Reproducible across platforms, unlike a pseudo-random generator.
+    pure real(FP_REAL) function aliased_sample(i,j) result(v)
+        integer(FP_SIZE), intent(in) :: i,j
+        real(FP_REAL) :: ri,rj
+        ri = real(i,FP_REAL)
+        rj = real(j,FP_REAL)
+        v  = sin(3.1_FP_REAL*ri)*cos(2.7_FP_REAL*rj) + half*sin(11.3_FP_REAL*ri+5.9_FP_REAL*rj)
+    end function aliased_sample
 
 end module fitpack_grid_nd_tests

--- a/test/test.f90
+++ b/test/test.f90
@@ -70,6 +70,7 @@ program test
         call add_test(test_derivative_spline())
         call add_test(test_grid_surface_scattered_eval())
         call add_test(test_nd_grid_equivalence())
+        call add_test(test_nd_grid_regressions())
 
     end subroutine run_interface_tests
 


### PR DESCRIPTION
The gridded/surface half of the SciPy port. Two of the four items turned out not to apply to this code base; those are documented with the path that was checked and pinned with a regression gate rather than "fixed". Part of the plan in #62.

### `regrid`: the iteration cap is now configurable ([scipy#22433](https://github.com/scipy/scipy/pull/22433), part 2)

The root search for `f(p) = s` was capped at a hard-coded `maxit = 20`. Large grids routinely need more, and there was no way to say so. The cap is now the named `REGRID_MAXIT` (still 20) and `regrid` takes an **optional** trailing `maxit`. Nothing else moves: `fpregr` already received the cap as a dummy, and no object-level API changes.

The non-convergence message was also misleading — `FITPACK_MAXIT` printed *"Infinite loop detected"*, which names neither the cause nor the remedy. It now reads *"Iteration limit reached before f(p)=s"*.

**Test:** gate P — `maxit=1` must report `FITPACK_MAXIT` (proving the cap is honoured), omitting the argument must be bit-identical to passing `REGRID_MAXIT` (proving the default is preserved), and a raised cap must never do worse than the default. On the gate's data the default converges in ~11 iterations; the assertions are written so the gate stays meaningful on toolchains where it does not.

### `pardtc` / `parder`: per-axis derivative-order validation — already correct ([scipy#24084](https://github.com/scipy/scipy/issues/24084))

Upstream compared the x-derivative order `nux` against `ky`, so with `kx=3, ky=2` a request for `(2,0)` was rejected even though it is a perfectly legal x-derivative. **This defect does not exist here.** The N-D rewrite validates the whole order vector element-wise against the whole degree vector:

```fortran
ier = FITPACK_INPUT_ERROR
if (any(nu<0) .or. any(nu>=k)) return
```

so axis *d* is only ever compared with `k(d)`. `parder` and `pardeu` use the same guard before allocating or reading anything, and delegate to `pardtc`.

**Test (pin):** gate N — an in-space separable polynomial is fitted at `kx=3, ky=2`; the exact upstream repro `(2,0)` must be accepted and must match `d²/dx²` of that polynomial analytically. Orders that really do reach their own axis degree — `(0,2)` and `(3,0)` — must still be input errors. Repeated at `dims=3` with degrees `3/2/4`, where an order legal on one axis but not another cannot pass by accident.

### `regrid` / `fpregr`: the saturated-knot NaN — not reproducible here ([scipy#22433](https://github.com/scipy/scipy/pull/22433) part 1, [scipy#17787](https://github.com/scipy/scipy/issues/17787))

Upstream, when a knot count reached its interpolating maximum `nmax = m+k+1` in one direction, `fpknot` kept placing knots by the incremental rule; the resulting knot set could violate the Schoenberg–Whitney condition, the system went singular, and the fit came back **all NaN with no error flag**. SciPy's fix re-derives that axis's interior knots by the interpolation rule on saturation.

That failure mode is already closed here, by this repository's own `fpknot` fix (#57): `fpknot` only ever splits an interval that holds at least one interior data point, and places the new knot **at** such a point —

```fortran
if (jpoint/=0 .and. (number==0 .or. fpint(j)>fpmax)) then ...
!  no interval carries an interior data point: there is nothing to refine
if (number==0) return
```

— so knots stay strictly increasing and every span keeps a data point, saturated or not. `regrid` additionally rejects non-increasing grid coordinates up front, so `x(nrx)` can never coincide with an existing knot.

This was checked empirically as well as by inspection: a sweep over `k = 1..3`, grids up to 80×70, both uniform-smooth and noise-like data, and smoothing factors from `0.5·m` to `1000·m` produced saturation in one or both axes in most configurations and **no NaN in any of them** — only the honest `FITPACK_MAXIT` returns that motivated the maxit change above.

Porting the knot re-derivation anyway would change the knot placement (and therefore the numbers) of every saturated fit for no defect, so it is deliberately **not** ported.

**Test (pin):** gate O — aliased data on a 9×25 grid across ten smoothing factors; the gate asserts that saturation at `nmax` actually happens (otherwise it declares itself vacuous and fails), that the coefficients and residual are finite, that `|fp − s| ≤ 2·10⁻³·s`, and that the fitted spline evaluates finitely on the data grid.

### `fpsurf`: uninitialized `acc` — does not apply ([scipy#24270](https://github.com/scipy/scipy/pull/24270))

SciPy's C translation could reach a use of `acc` before assigning it. Here `acc = tol*s` is assigned unconditionally near the top of the body (before the `iopt` branch), and the only reads are far below it, so there is no path that reads it uninitialized. The sibling locals were audited too: `fpms` is seeded to `huge(zero)`, and `p2`/`f2` — the classic set-inside-a-conditional pair — are written on entry to `root_finding_iterate` (`p2 = p; f2 = fpms`) before any read. No change.

The existing `surfit` legacy cases already cover this under `-finit-real=inf`: an uninitialized `acc` would come back as `+inf`, making `abs(fpms) <= acc` true on the first pass and returning a visibly wrong fit.

### Verification

- `fpm test`: 60 → 61 tests, all passing (gfortran 16.1.0, fpm 0.13.0).
- `fpm test --flag "-finit-real=inf"`: 61/61.
- Gate P cannot compile against the previous sources (no `maxit` argument); gates N and O are pins for behaviour that is already correct, as described above.

Same two pre-existing toolchain conditions noted in #63: `-fcheck=bounds` SIGSEGVs (gfortran 16.1.x), and `--profile release` fails `test_polar_fit` and `test_comm_roundtrips` on a pristine `main`.
