### PR TITLE
fpback: guard zero pivots on rank-deficient systems

### DIFF
--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -1796,11 +1796,18 @@ module fitpack_core
       !! \f$ R_1 \f$ is stored as `a(nest, k)` where `a(i,1)` holds the diagonal
       !! element \f$ r_{i,i} \f$ and `a(i,j)` for \f$ j > 1 \f$ holds \f$ r_{i,i+j-1} \f$.
       !!
-      !! @param[in] a     Upper triangular band matrix \f$ R_1 \f$, stored as `a(nest, k)`
-      !! @param[in] z     Right-hand side vector \f$ z_1 \f$ of length \f$ n \f$
-      !! @param[in] n     Number of equations (= number of B-spline coefficients)
-      !! @param[in] k     Bandwidth of \f$ R_1 \f$ (= spline order \f$ k+1 \f$)
-      !! @param[in] nest  Leading dimension of array `a`
+      !! ### Rank deficiency
+      !!
+      !! A row of \f$ R_1 \f$ reduces to exactly zero when the observation matrix is rank
+      !! deficient — duplicated abscissae, or a knot span whose data all carry zero weight. The
+      !! corresponding coefficient is then unconstrained: it is set to zero (the minimum-norm
+      !! choice) instead of being divided out into a NaN that silently poisons the whole fit.
+      !!
+      !! @param[in]  a     Upper triangular band matrix \f$ R_1 \f$, stored as `a(nest, k)`
+      !! @param[in]  z     Right-hand side vector \f$ z_1 \f$ of length \f$ n \f$
+      !! @param[in]  n     Number of equations (= number of B-spline coefficients)
+      !! @param[in]  k     Bandwidth of \f$ R_1 \f$ (= spline order \f$ k+1 \f$)
+      !! @param[in]  nest  Leading dimension of array `a`
       !!
       !! @return Solution vector \f$ c \f$ of length \f$ n \f$
       !!
@@ -1816,26 +1823,55 @@ module fitpack_core
       real(FP_REAL) :: store
       integer(FP_SIZE) :: i,i1,j,k1,l,m,jm1
       !  ..
-      k1   = k-1
-      c(n) = z(n)/a(n,1)
-      i    = n-1
-      if (i==0) return
+      k1 = k-1
 
-      jm1 = 1
-      rows: do j=2,n
-        store = z(i)
-        i1 = merge(jm1,k1,j<=k1)
-        m = i
-        do l=1,i1
-          m = m+1
-          store = store-c(m)*a(i,l+1)
-        end do
-        c(i) = store/a(i,1)
-        i = i-1
-        jm1 = j
-      end do rows
+      if (equal(a(n,1),zero)) then
+         c(n) = zero
+      else
+         c(n) = z(n)/a(n,1)
+      end if
+
+      i = n-1
+      if (i>0) then
+
+         jm1 = 1
+         rows: do j=2,n
+           store = z(i)
+           i1 = merge(jm1,k1,j<=k1)
+           m = i
+           do l=1,i1
+             m = m+1
+             store = store-c(m)*a(i,l+1)
+           end do
+           if (equal(a(i,1),zero)) then
+              c(i) = zero
+           else
+              c(i) = store/a(i,1)
+           end if
+           i = i-1
+           jm1 = j
+         end do rows
+
+      end if
 
       end function fpback
+
+      !> @brief Is the triangular factor of the Givens reduction rank deficient?
+      !!
+      !! fpback and fpbacp divide by the diagonal `a(i,1)`. An exactly zero diagonal - duplicated
+      !! abscissae, or a knot span whose data all carry zero weight - leaves the corresponding
+      !! B-spline coefficient unconstrained, so the fit is not determined. Callers that report a
+      !! status test the factor they have just built before solving with it.
+      !!
+      !! @param[in] a     Triangular factor in band storage; `a(i,1)` is the diagonal
+      !! @param[in] n     Number of equations
+      !! @param[in] nest  Leading dimension of `a`
+      !! @return    `.true.` if any diagonal element is exactly zero
+      pure logical(FP_BOOL) function fp_rank_deficient(a,n,nest) result(singular)
+         integer(FP_SIZE), intent(in) :: n,nest
+         real(FP_REAL),    intent(in) :: a(nest,*)
+         singular = any(equal(a(1:n,1),zero))
+      end function fp_rank_deficient
 
       !> @brief Solve a bordered upper triangular system by back-substitution.
       !!
@@ -1855,13 +1891,18 @@ module fitpack_core
       !! \f$ \tilde{N}_{i,k+1} \f$ wrap around the domain, coupling the first
       !! and last \f$ k \f$ coefficients.
       !!
-      !! @param[in] a     Upper triangular band matrix \f$ A \f$, stored as `a(nest, k1)`
-      !! @param[in] b     Dense coupling matrix \f$ B \f$, stored as `b(nest, k)`
-      !! @param[in] z     Right-hand side vector of length \f$ n \f$
-      !! @param[in] n     Number of equations
-      !! @param[in] k     Number of periodic coupling columns
-      !! @param[in] k1    Bandwidth of the triangular part \f$ A \f$
-      !! @param[in] nest  Leading dimension of arrays `a` and `b`
+      !! ### Rank deficiency
+      !!
+      !! As in fpback, a zero pivot leaves its coefficient unconstrained; it is set to zero
+      !! instead of being divided out into a NaN.
+      !!
+      !! @param[in]  a     Upper triangular band matrix \f$ A \f$, stored as `a(nest, k1)`
+      !! @param[in]  b     Dense coupling matrix \f$ B \f$, stored as `b(nest, k)`
+      !! @param[in]  z     Right-hand side vector of length \f$ n \f$
+      !! @param[in]  n     Number of equations
+      !! @param[in]  k     Number of periodic coupling columns
+      !! @param[in]  k1    Bandwidth of the triangular part \f$ A \f$
+      !! @param[in]  nest  Leading dimension of arrays `a` and `b`
       !!
       !! @return Solution vector \f$ c \f$ of length \f$ n \f$
       !!
@@ -1879,7 +1920,7 @@ module fitpack_core
       !  ..
       n2 = n-k
       l  = n
-      do i=1,k
+      wrapped_rows: do i=1,k
          store = z(l)
          j = k+2-i
          if (i/=1) then
@@ -1889,35 +1930,55 @@ module fitpack_core
                store = store-c(l0)*b(l,l1)
              end do
          endif
-         c(l) = store/b(l,j-1)
+         if (equal(b(l,j-1),zero)) then
+            c(l) = zero
+         else
+            c(l) = store/b(l,j-1)
+         end if
          l = l-1
-         if (l==0) return
-      end do
-      do i=1,n2
-         store = z(i)
-         l = n2
-         do j=1,k
-           l = l+1
-           store = store-c(l)*b(i,j)
+         if (l==0) exit wrapped_rows
+      end do wrapped_rows
+
+      banded_rows: if (l>0) then
+
+         do i=1,n2
+            store = z(i)
+            l = n2
+            do j=1,k
+              l = l+1
+              store = store-c(l)*b(i,j)
+            end do
+            c(i) = store
          end do
-         c(i) = store
-      end do
-      i = n2
-      c(i) = c(i)/a(i,1)
-      if (i==1) return
-      do j=2,n2
-         i = i-1
-         store = c(i)
-         i1 = k
-         if (j<=k) i1=j-1
-         l = i
-         do l0=1,i1
-           l = l+1
-           store = store-c(l)*a(i,l0+1)
-         end do
-         c(i) = store/a(i,1)
-      end do
-      return
+
+         i = n2
+         if (equal(a(i,1),zero)) then
+            c(i) = zero
+         else
+            c(i) = c(i)/a(i,1)
+         end if
+
+         if (i>1) then
+            do j=2,n2
+               i = i-1
+               store = c(i)
+               i1 = k
+               if (j<=k) i1=j-1
+               l = i
+               do l0=1,i1
+                 l = l+1
+                 store = store-c(l)*a(i,l0+1)
+               end do
+               if (equal(a(i,1),zero)) then
+                  c(i) = zero
+               else
+                  c(i) = store/a(i,1)
+               end if
+            end do
+         end if
+
+      end if banded_rows
+
       end function fpbacp
 
 
@@ -4899,6 +4960,12 @@ module fitpack_core
         fpint(n-1:n) = [fpold,fp0]
         nrdata(n) = nplus
 
+        ! a rank-deficient triangle leaves coefficients unconstrained: the fit is not determined.
+        if (fp_rank_deficient(a,nk1,nest)) then
+            ier = FITPACK_S_TOO_SMALL
+            return
+        end if
+
         ! backward substitution to obtain the b-spline coefficients.
         c(:nk1) = fpback(a,z,nk1,k1,nest)
 
@@ -5053,6 +5120,11 @@ module fitpack_core
               yi = zero
               call fp_rotate_shifted(h, k2, g, nest, yi, c, it, nk1)
           end do b_rows
+
+          if (fp_rank_deficient(g,nk1,nest)) then
+              ier = FITPACK_S_TOO_SMALL
+              return
+          end if
 
           ! backward substitution to obtain the b-spline coefficients.
           c(:nk1) = fpback(g,c,nk1,k2,nest)

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -1864,10 +1864,11 @@ module fitpack_core
 
       !> @brief Is the triangular factor of the Givens reduction rank deficient?
       !!
-      !! fpback and fpbacp divide by the diagonal `a(i,1)`. An exactly zero diagonal - duplicated
-      !! abscissae, or a knot span whose data all carry zero weight - leaves the corresponding
-      !! B-spline coefficient unconstrained, so the fit is not determined. Callers that report a
-      !! status test the factor they have just built before solving with it.
+      !! fpback and fpbacp keep the fit finite whatever the factor looks like: a zero diagonal
+      !! element leaves its coefficient at zero instead of dividing. This predicate is how a caller
+      !! turns that silent repair into a reported status, so it runs **once per fit**, on the factor
+      !! that produced the accepted coefficients - never inside the knot or smoothing iterations,
+      !! where the inline guards already do the work.
       !!
       !! @param[in] a     Triangular factor in band storage; `a(i,1)` is the diagonal
       !! @param[in] n     Number of equations
@@ -1876,7 +1877,12 @@ module fitpack_core
       pure logical(FP_BOOL) function fp_rank_deficient(a,n,nest) result(singular)
          integer(FP_SIZE), intent(in) :: n,nest
          real(FP_REAL),    intent(in) :: a(nest,*)
-         singular = any(equal(a(1:n,1),zero))
+         integer(FP_SIZE) :: i
+         singular = FP_TRUE
+         do i=1,n
+            if (equal(a(i,1),zero)) return
+         end do
+         singular = FP_FALSE
       end function fp_rank_deficient
 
       !> @brief Solve a bordered upper triangular system by back-substitution.
@@ -4823,8 +4829,9 @@ module fitpack_core
       integer(FP_SIZE) :: i,it,iter,j,k3,l,l0,mk1,nk1,nmax,nmin,nplus,npl1,nrint,n8
       !  ..local arrays..
       real(FP_REAL) :: h(MAX_ORDER+1)
-      logical(FP_BOOL) :: new,check1,check3,success
+      logical(FP_BOOL) :: new,check1,check3,success,accepted
 
+      accepted = FP_FALSE
       fpold = zero
       fp0   = zero
       nplus = 0
@@ -4966,27 +4973,30 @@ module fitpack_core
         fpint(n-1:n) = [fpold,fp0]
         nrdata(n) = nplus
 
-        ! a rank-deficient triangle leaves coefficients unconstrained: the fit is not determined.
-        if (fp_rank_deficient(a,nk1,nest)) then
-            ier = FITPACK_S_TOO_SMALL
-            return
-        end if
-
         ! backward substitution to obtain the b-spline coefficients.
         c(:nk1) = fpback(a,z,nk1,k1,nest)
 
-        ! test whether the approximation sinf(x) is an acceptable solution.
-        if (iopt<0) return
+        ! test whether the approximation sinf(x) is an acceptable solution. the three acceptance
+        ! exits leave through the epilogue below, which screens the accepted factor once.
+        if (iopt<0) then
+            accepted = FP_TRUE
+            exit main_loop
+        end if
 
-        fpms = fp-s; if(abs(fpms)<acc) return
+        fpms = fp-s
+        if (abs(fpms)<acc) then
+            accepted = FP_TRUE
+            exit main_loop
+        end if
 
-        ! if f(p=inf) < s accept the choice of knots.
+        ! if f(p=inf) < s accept the choice of knots and go on to the smoothing spline.
         if (fpms<zero) exit main_loop
 
         ! if n = nmax, sinf(x) is an interpolating spline.
         if (n==nmax) then
-            ier = FITPACK_INTERPOLATING_OK
-            return
+            ier      = FITPACK_INTERPOLATING_OK
+            accepted = FP_TRUE
+            exit main_loop
         end if
 
         ! increase the number of knots.
@@ -5070,9 +5080,14 @@ module fitpack_core
       !  restart the computations with the new set of knots.
       end do main_loop
 
-      !  test whether the least-squares kth degree polynomial is a solution
-      !  of our approximation problem.
-      if (ier==FITPACK_LEASTSQUARES_OK) return
+      !  sinf(x) is the answer whenever the knot pass accepted it, and also when the least-squares
+      !  kth degree polynomial already solves our approximation problem. screen the factor that
+      !  produced those coefficients: a zero diagonal means the back substitution had to leave a
+      !  coefficient unconstrained, so the fit is not determined.
+      if (accepted .or. ier==FITPACK_LEASTSQUARES_OK) then
+          if (fp_rank_deficient(a,nk1,nest)) ier = FITPACK_S_TOO_SMALL
+          return
+      end if
 
       ! *****
       !  part 2: determination of the smoothing spline sp(x).
@@ -5127,11 +5142,6 @@ module fitpack_core
               call fp_rotate_shifted(h, k2, g, nest, yi, c, it, nk1)
           end do b_rows
 
-          if (fp_rank_deficient(g,nk1,nest)) then
-              ier = FITPACK_S_TOO_SMALL
-              return
-          end if
-
           ! backward substitution to obtain the b-spline coefficients.
           c(:nk1) = fpback(g,c,nk1,k2,nest)
 
@@ -5146,8 +5156,12 @@ module fitpack_core
               fp   = fp+(w(it)*(term-y(it)))**2
           end do get_fp
 
-          ! SUCCESS! the approximation sp(x) is an acceptable solution.
-          fpms = fp-s; if (abs(fpms)<acc) return
+          ! SUCCESS! the approximation sp(x) is an acceptable solution: screen its factor once.
+          fpms = fp-s
+          if (abs(fpms)<acc) then
+              if (fp_rank_deficient(g,nk1,nest)) ier = FITPACK_S_TOO_SMALL
+              return
+          end if
 
           ! find the new value of p and carry out one more step.
           call root_finding_iterate(p1,f1,p2,f2,p3,f3,p,fpms,acc,check1,check3,success)

--- a/test/fitpack_curve_tests.f90
+++ b/test/fitpack_curve_tests.f90
@@ -53,6 +53,7 @@ module fitpack_curve_tests
     public :: test_cross_section
     public :: test_derivative_spline
     public :: test_grid_surface_scattered_eval
+    public :: test_rank_deficient_fit
 
 
     contains
@@ -2536,6 +2537,76 @@ module fitpack_curve_tests
         success = .true.
 
     end function test_grid_surface_scattered_eval
+
+    ! A duplicated abscissa empties a knot span, so the reduced triangle carries a zero diagonal and
+    ! the back substitution divided by it: the coefficients came back NaN behind a success flag.
+    ! Regression test for https://github.com/scipy/scipy/issues/22704
+    logical function test_rank_deficient_fit() result(success)
+
+       integer(FP_SIZE), parameter :: m = 18, kmax = 2, nest = m+kmax+1
+       real(FP_REAL),    parameter :: SMOOTHING = 12.0_FP_REAL
+
+       ! the data set from the report: x = 310.10 appears twice
+       real(FP_REAL), parameter :: x(m) = [ &
+             20.00_FP_REAL,153.81_FP_REAL,175.57_FP_REAL,202.47_FP_REAL,237.11_FP_REAL, &
+            253.61_FP_REAL,258.56_FP_REAL,273.40_FP_REAL,284.54_FP_REAL,293.61_FP_REAL, &
+            298.56_FP_REAL,301.86_FP_REAL,305.57_FP_REAL,307.22_FP_REAL,308.45_FP_REAL, &
+            310.10_FP_REAL,310.10_FP_REAL,310.50_FP_REAL]
+       real(FP_REAL), parameter :: y(m) = [ &
+            53.00_FP_REAL,49.50_FP_REAL,48.60_FP_REAL,46.80_FP_REAL,43.20_FP_REAL, &
+            40.32_FP_REAL,39.60_FP_REAL,36.00_FP_REAL,32.40_FP_REAL,28.80_FP_REAL, &
+            25.20_FP_REAL,21.60_FP_REAL,18.00_FP_REAL,14.40_FP_REAL,10.80_FP_REAL, &
+             7.20_FP_REAL, 3.60_FP_REAL, 0.00_FP_REAL]
+
+       real(FP_REAL)    :: w(m),xs(m),t(nest),c(nest),fp
+       real(FP_REAL)    :: wrk(m*(kmax+1)+nest*(7+3*kmax))
+       integer(FP_SIZE) :: iwrk(nest),n,k,nc
+       integer(FP_FLAG) :: ier
+
+       success = .false.
+       w = 1.38723_FP_REAL
+
+       do k = 1,kmax
+
+          n = 0; t = zero; c = zero; fp = zero; wrk = zero; iwrk = 0
+          call curfit(IOPT_NEW_SMOOTHING,m,x,y,w,x(1),x(m),k,SMOOTHING,nest,n,t,c,fp,wrk, &
+                      size(wrk,kind=FP_SIZE),iwrk,ier)
+
+          ! the singular system must be reported, not returned as a successful fit
+          if (ier/=FITPACK_S_TOO_SMALL) then
+             print *, '[test_rank_deficient_fit] k=',k,' returned ',FITPACK_MESSAGE(ier), &
+                      ' instead of a rank-deficiency error'
+             return
+          end if
+
+          nc = max(n-k-1,1_FP_SIZE)
+          if (.not.all(c(1:nc)==c(1:nc))) then
+             print *, '[test_rank_deficient_fit] k=',k,' returned NaN coefficients'
+             return
+          end if
+          if (.not.all(abs(c(1:nc))<=1000*maxval(abs(y)))) then
+             print *, '[test_rank_deficient_fit] k=',k,' coefficients blew up: ',maxval(abs(c(1:nc)))
+             return
+          end if
+
+       end do
+
+       ! control: the same data with the duplicate nudged apart fits normally
+       xs = x
+       xs(17:18) = xs(17:18)+one
+       do k = 1,kmax
+          n = 0; t = zero; c = zero; fp = zero; wrk = zero; iwrk = 0
+          call curfit(IOPT_NEW_SMOOTHING,m,xs,y,w,xs(1),xs(m),k,SMOOTHING,nest,n,t,c,fp,wrk, &
+                      size(wrk,kind=FP_SIZE),iwrk,ier)
+          if (.not.FITPACK_SUCCESS(ier)) then
+             print *, '[test_rank_deficient_fit] control fit k=',k,' failed: ',FITPACK_MESSAGE(ier)
+             return
+          end if
+       end do
+
+       success = .true.
+
+    end function test_rank_deficient_fit
 
     ! ODE-style reciprocal error weight
     elemental real(FP_REAL) function rewt(RTOL,ATOL,x)

--- a/test/test.f90
+++ b/test/test.f90
@@ -70,6 +70,7 @@ program test
         call add_test(test_derivative_spline())
         call add_test(test_grid_surface_scattered_eval())
         call add_test(test_nd_grid_equivalence())
+        call add_test(test_rank_deficient_fit())
 
     end subroutine run_interface_tests
 


### PR DESCRIPTION
Part of the plan in #62.

### The bug ([scipy#22704](https://github.com/scipy/scipy/issues/22704) — still open upstream, and present in the F77 original)

`fpback` and `fpbacp` end in a back substitution that divides by the diagonal of the reduced triangle:

```fortran
c(i) = store/a(i,1)
```

with no guard. A duplicated abscissa puts two coincident knots in the knot vector, so the B-spline over that zero-width span is identically zero, its column of the observation matrix stays exactly zero through the Givens reduction, and `a(i,1)` comes out **exactly** `0.0` — it is initialised to zero and never touched. The division then yields NaN, and the NaN propagates into every coefficient below it.

Reproduced with the 18-point data set from the report (`x = 310.10` twice, `w = 1.38723`) on unmodified `main`:

| k | s | ier | NaN coefficients? |
|---|---|-----|-------------------|
| 1 | 12 | `-1` (interpolating, *success*) | **yes** |
| 2 | 12 | `-1` (interpolating, *success*) | **yes** |

The `k=2, s=12` row is exactly the configuration in the report. A caller checking `FITPACK_SUCCESS(ier)` is told the fit worked and hands out NaN.

### The mechanism

**1. Inline guards in the back substitution — the primary fix.** `fpback` and `fpbacp` now leave a zero-pivot coefficient at zero, the minimum-norm choice for a row that constrains nothing, and the same resolution `fprank` already applies to the rank-deficient scattered-surface systems. This is free: the division loop already touches every diagonal element. No NaN can escape into any of the ~30 call sites, whether or not the caller reports a status.

**2. One status check per fit, on the accepted factor.** The pivot of `fpback` *is* the diagonal of the triangular factor, so a caller can report the rank deficiency without a signature change (a `pure function` cannot carry an `intent(out)` argument):

```fortran
pure logical(FP_BOOL) function fp_rank_deficient(a,n,nest) result(singular)
   singular = FP_TRUE
   do i=1,n
      if (equal(a(i,1),zero)) return
   end do
   singular = FP_FALSE
end function
```

It runs **once per fit, never per iteration**. In `fpcurf` the three acceptance exits of the knot pass (`iopt<0`, `|fp−s|<acc`, `n==nmax`) now funnel through a single epilogue that screens `a`, and the converged exit of the p-iteration screens `g`. The error exits — `nest` exhausted, non-monotone iteration, `maxit` — already carry an error code, so they need no screening. `curfit` propagates the result.

The flag is `FITPACK_S_TOO_SMALL`, FITPACK's documented code for *"a theoretically impossible result was found during the iteration process; probable cause: s too small"* — already listed in `curfit`'s own error table, and already what this data set returns at `k >= 3`, so the behaviour is now consistent across degrees on the same input. No new positive code was invented.

After the fix:

| k | s | ier | NaN? | max abs. coefficient (max&#124;y&#124; = 53) |
|---|---|-----|------|------------------------------|
| 1 | 0 … 12 | `2` (`FITPACK_S_TOO_SMALL`) | no | 53.0 |
| 2 | 0 … 12 | `2` (`FITPACK_S_TOO_SMALL`) | no | 53.0 |
| 1, 2 | 50, 200 | `0` | no | 53–66 (well-determined, unchanged) |

### Why not an entry-level duplicate-`x` check

It was considered and rejected. Duplicated abscissae are legal weighted-smoothing input — `curfit` deliberately admits them (it only rejects strictly decreasing `x`), and for a large enough `s` the fit is perfectly well determined, as the `s = 50` and `s = 200` rows above show. Rejecting them up front would break working code. Rank deficiency also has a second source that a duplicate check cannot see: a knot span whose data all carry zero weight. The factor diagonal is the right signal because it is the *complete* one — it detects the actual singularity, whatever produced it.

### Behaviour note

Because the check moved to the exit paths, a singular knot pass no longer bails on its first iteration: it runs to knot exhaustion and reports at the exit. Verified on the reported data across degrees 1–5 and smoothing factors 0 → 200 — no hang, no oscillation, the whole 30-case sweep in 150 ms, coefficients finite throughout (the inline guards see to that), and the reported cases still return `FITPACK_S_TOO_SMALL`.

One consequence worth stating: at `k >= 3` the coefficients returned *alongside* the error flag can be large (the system is near-singular there, not exactly singular). The earlier in-loop check happened to truncate that growth as a side effect; the exit-path check does not. Coefficients returned with a positive error flag are not meant to be consumed, and no NaN appears in either case.

### Scope

The periodic and parametric back substitutions (`fpperi`/`percur`, `fpclos`/`clocur`, `fppara`/`parcur`, `fpcons`/`concur`) keep the inline guard but not the status reporting. All four reject non-positive weights at their entry points, and no exactly-singular case was found for them; `fpbacp`'s pivots are split across the band matrix diagonal and an anti-diagonal of the coupling matrix, so a status test there would duplicate its indexing rather than read a diagonal. Adding it without a failing case to justify it would be speculative — worth revisiting if one turns up.

**Known limitation, unchanged:** with `s = 0` and `k >= 3` the same data produces a *near*-singular (not exactly singular) system — condition number ~1e16 — which no exact-zero guard can catch. That is ill-conditioning, not a defect; SciPy behaves the same way.

### Test

`test_rank_deficient_fit` — the report's data at `k = 1` and `k = 2`: the fit must report `FITPACK_S_TOO_SMALL`, the coefficients must be free of NaN and bounded, and a control run with the duplicate nudged apart must still fit cleanly. Fails on the unmodified sources (`k=1 returned Success! (interpolation) instead of a rank-deficiency error`).

### Verification

- `fpm test`: 64 → **65** tests, all passing (gfortran 16.1.0, fpm 0.13.0).
- `fpm test --flag "-finit-real=inf"`: 65/65.
- `fpm test --profile release`: 65/65, now that #66 has landed on `main` (this branch is merged up to it).
- The zero-fill change touches every `fpback`/`fpbacp` caller — surface, polar, sphere, gridded, parametric, convex — and the full legacy battery is unchanged.

One pre-existing toolchain condition remains, unrelated to this PR and unchanged by #66: `-fcheck=bounds` SIGSEGVs on gfortran 16.1.x, on a pristine `main` as well.
