### PR TITLE
Fix undefined ier in fpcurf, fpspgr and fpsphe (optimized-build failures)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10 
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -16,7 +16,9 @@ jobs:
           - {compiler: gcc, version: 12}
           - {compiler: gcc, version: 13}
           - {compiler: gcc, version: 14}
-          # - {compiler: gcc, version: 15}  # Not yet available on ubuntu-latest
+          - {compiler: gcc, version: 15}
+          # gcc 16 not yet installable: setup-fortran tops out at gcc 15, and there is
+          # no homebrew gcc@16 formula for its linux fallback. Add it once either lands.
           - {compiler: intel, version: '2023.2'}
           - {compiler: intel, version: '2024.0'}
           - {compiler: intel, version: '2025.0'}          
@@ -25,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup fortran
-        uses: fortran-lang/setup-fortran@v1.6.3
+        uses: fortran-lang/setup-fortran@v1.10.0
         with:
           compiler: ${{ matrix.toolchain.compiler }}
           version: ${{ matrix.toolchain.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 10
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -4758,8 +4758,6 @@ module fitpack_core
       real(FP_REAL) :: h(MAX_ORDER+1)
       logical(FP_BOOL) :: new,check1,check3,success
 
-      ! ier must be defined here: the acceptable-solution exits below fall through without
-      ! setting it, and the knot-addition logic tests it before it is otherwise assigned.
       ier   = FITPACK_OK
       fpold = zero
       fp0   = zero
@@ -12714,8 +12712,6 @@ module fitpack_core
       real(FP_REAL), parameter :: period = pi2
 
       !   initialization
-      ! ier must be defined here: with iopt(1)<0 the least-squares exit below falls through
-      ! without setting it, and fp0 is updated on a test of its value.
       ier   = FITPACK_OK
       ifsu  = 0
       ifsv  = 0
@@ -13239,8 +13235,6 @@ module fitpack_core
       acc = tol*s
 
       ! Initializations
-      ! ier must be defined here: the acceptable-solution exits below only overwrite it in the
-      ! rank-deficient case (ier=-rank), and fall through with the success flag otherwise.
       ier    = FITPACK_OK
       lwest  = 0
       ntt    = 0

--- a/src/fitpack_core.F90
+++ b/src/fitpack_core.F90
@@ -4758,6 +4758,9 @@ module fitpack_core
       real(FP_REAL) :: h(MAX_ORDER+1)
       logical(FP_BOOL) :: new,check1,check3,success
 
+      ! ier must be defined here: the acceptable-solution exits below fall through without
+      ! setting it, and the knot-addition logic tests it before it is otherwise assigned.
+      ier   = FITPACK_OK
       fpold = zero
       fp0   = zero
       nplus = 0
@@ -12711,6 +12714,9 @@ module fitpack_core
       real(FP_REAL), parameter :: period = pi2
 
       !   initialization
+      ! ier must be defined here: with iopt(1)<0 the least-squares exit below falls through
+      ! without setting it, and fp0 is updated on a test of its value.
+      ier   = FITPACK_OK
       ifsu  = 0
       ifsv  = 0
       ifbu  = 0
@@ -13233,6 +13239,9 @@ module fitpack_core
       acc = tol*s
 
       ! Initializations
+      ! ier must be defined here: the acceptable-solution exits below only overwrite it in the
+      ! rank-deficient case (ier=-rank), and fall through with the success flag otherwise.
+      ier    = FITPACK_OK
       lwest  = 0
       ntt    = 0
       iband1 = 0


### PR DESCRIPTION
## What

Initialize `ier = FITPACK_OK` at entry to `fpcurf`, `fpspgr` and `fpsphe` in `src/fitpack_core.F90`. Nine lines, one file.

## Why

Two interface tests passed in the debug profile but failed in any optimized build:

```
[test_polar_fit] polar test 2 failed: Invalid input
[test_comm_roundtrips] sphere fit failed: Invalid input
[fitpack] there are 24 passed, 2 failed interface tests.
```

Neither failure was in `polar` — the format string in `test_sphere_fit` says "polar test", but both are the scattered `sphere` fit. And the input checks in `sphere` were never the cause: they all passed, and `fpsphe` ran to completion and produced knots before returning `FITPACK_INPUT_ERROR` (10).

The real cause is an `intent(out)` dummy that the code uses as `intent(inout)`:

- `sphere` writes `ier = FITPACK_INPUT_ERROR` at entry, clears it to `FITPACK_OK` after the data checks, then calls `fpsphe`.
- `fpsphe` declares `integer(FP_FLAG), intent(out) :: ier`, so on entry `ier` is undefined by the standard. The compiler may delete the driver's `ier = FITPACK_OK` store as dead, and gfortran does: at `-O1` the only immediate store into that slot in `sphere` is `movl $10, (%rax)`.
- Both of `fpsphe`'s *success* exits — the acceptable least-squares spline and the acceptable smoothing spline — assign `ier` only in the rank-deficient case (`if (ncof/=rank) ier = -rank`) and fall through otherwise. So the stale `10` propagated back to the caller.

This is the F77 original's convention (`ier` had no intent and inherited the driver's `ier = 0`) that did not survive the port. `fppola` is declared `intent(inout)`, which is why the polar path was never affected.

`fpcurf` and `fpspgr` were not failing but have the same defect and are worse: both *read* `ier` before it is definitely assigned (`if (ier==FITPACK_LEASTSQUARES_OK) fp0 = fp`, and `fpcurf`'s knot-count logic branches on `ier==FITPACK_OK`), and both return without assigning it on their `iopt<0` and `abs(fpms)<acc` exits. They work today only by luck of register/stack allocation.

The initialization reproduces exactly what `curfit`, `spgrid` and `sphere` already guarantee, so behaviour on the paths that already worked is unchanged — and the routines no longer depend on their caller for a defined `ier`.

## Notes for reviewers

- **Not a compiler issue.** It breaks from `-O1` upward, not just `-O3`. No floating-point comparison is involved; `-ffp-contract=off` makes no difference. It is a latent undefined-value read that optimization exposes.
- I swept every routine in `fitpack_core` declaring `intent(out) :: ier` for exits that leave it unassigned. The other hits — `fourco`, `sproot`, `fpcosp`, `insert_inplace` — check out: they assign on every path or delegate to a routine that does.
- The `fp*` workers that already use `intent(inout)` (`fppola`, `fppogr`, `fpsurf`, `fpgrpa`, `fpgrdi`, `fpgrsp`, `fpcoco`) are correct as-is; their callers define `ier` before the call.
- Reproduced against a pristine checkout of `main` at c0ea483, so this was pre-existing and not introduced by a recent branch.
- The gfortran 16.1.0 SIGSEGV under `-fcheck=bounds` is a separate, untouched issue.

## Test plan

Toolchain: gfortran 16.1.0 (MSYS2 mingw64), fpm 0.13.0.

| Build | Before | After |
|---|---|---|
| `fpm test` (debug) | pass | 60 passed, 0 failed |
| `fpm test --flag "-O1"` | fail | 60 passed, 0 failed |
| `fpm test --profile release` | 24 passed, **2 failed** | 60 passed, 0 failed |

A standalone driver exercising just the scattered sphere fit confirmed failure at `-O1`/`-O2`/`-O3` and success at `-O0` before the change, and success at all four levels after.


---

## Also in this PR: CI matrix

Added `gcc 15` to the ubuntu build matrix, which required bumping `fortran-lang/setup-fortran` from `v1.6.3` to `v1.10.0`. v1.6.3 installs gcc on linux only from `ppa:ubuntu-toolchain-r/test`; v1.10.0 falls back to Homebrew when a version is absent from apt, and its compatibility table lists gcc 15 as supported on both `ubuntu-22.04` and `ubuntu-24.04`. The action's inputs are unchanged apart from a new optional one, so the existing gcc 10–14 and intel entries are unaffected.

**gcc 16 was not added — it is not installable yet.** `setup-fortran`'s version table caps gcc at 15 on every runner (`LATEST_gcc_ubuntu_24_04="15"`), and its linux fallback would need a Homebrew `gcc@16` formula, which does not exist (homebrew-core has `gcc@9` through `gcc@15`). A comment in the matrix records this so it can be switched on once either lands.

The gcc 15 job is the slowest in the matrix at 214s (Homebrew fallback rather than apt), still comfortably inside the existing 10 minute job timeout, which is left alone.
